### PR TITLE
Add AGENTS.md for Cursor Cloud development setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Product overview
+
+BAKLOG is a **local-only** cross-store game backlog dashboard. One Python dev server (`server.py`) serves the static UI plus REST/SSE APIs for personal data, fetcher orchestration, and store sign-in. There is no Docker, database, or monorepo.
+
+### Required services
+
+| Service | Command | Port |
+|---------|---------|------|
+| BAKLOG dev server | `python3 server.py` | `8765` (binds `127.0.0.1`) |
+
+Optional read-only mode: `python3 -m http.server 8080` (no personal-data API or fetcher triggers).
+
+### Dependency install
+
+See `README.md` and `.github/workflows/ci.yml`. Standard path:
+
+```bash
+pip install -e ".[dev]"
+npm ci
+```
+
+Python **3.11+** is required (`pyproject.toml`). Node **20+** is used in CI for Vitest.
+
+If `pytest`, `ruff`, or `playwright` are not found after pip install, add `~/.local/bin` to `PATH` (user-site scripts on this VM).
+
+### Lint / test / run
+
+| Task | Command |
+|------|---------|
+| Python tests | `pytest -q` |
+| Python lint | `ruff check .` (advisory in CI; some existing debt) |
+| JS tests | `npm test` |
+| Dev server | `python3 server.py` → http://127.0.0.1:8765 |
+
+### Sample library data
+
+Generated `games_*.json` files are gitignored. A fresh clone has an empty dashboard until fetchers run or fixture JSON is placed at the repo root. For UI smoke tests without store credentials, a minimal `games_steam.json` with a `games` array is enough (see `fetch_games.py` output shape).
+
+### Optional: Playwright / Connections tab
+
+Store sign-in via the Connections tab needs a one-time browser install:
+
+```bash
+playwright install chromium
+```
+
+Not required for dashboard browsing, pytest, or vitest.
+
+### Gotchas
+
+- ES modules require HTTP — do not open `index.html` via `file://`; use `server.py`.
+- `data/personal.json` and `cache/` are created at runtime and gitignored.
+- Live fetchers need credentials in `.env` (copy from `.env.example`) or the Connections tab; ITAD/Steam fetch failures without credentials are expected.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud-specific instructions for setting up and running BAKLOG locally:

- Dev server startup (`python3 server.py` on port 8765)
- Dependency install commands (`pip install -e ".[dev]"`, `npm ci`)
- Lint/test commands matching CI
- Notes on sample data, Playwright, and common gotchas

This was created as part of the development environment setup for Cloud Agents.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb6c8d5f-8a36-4ae3-9e8b-fcd46ee4de4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb6c8d5f-8a36-4ae3-9e8b-fcd46ee4de4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

