### PR TITLE
Align library-count 1UP roll timing with landing mega-hero demo

### DIFF
--- a/js/library-count-animation.js
+++ b/js/library-count-animation.js
@@ -13,8 +13,10 @@
 
 import { state } from './state.js';
 import { prefersReducedMotion } from './motion.js';
-import { countUpDurationForDelta, easeInOutCubic } from './dashboard-shared.js';
+import { easeInOutCubic } from './dashboard-shared.js';
 
+// Match landing mega-hero demo (`landing/demo.js` COUNT_ROLL_MS).
+const COUNT_ROLL_MS = 1000;
 const POPUP_SPAWN_INTERVAL_MS = 70;
 const POPUP_LIFETIME_MS = 700;
 const POPUP_CAP = 10;
@@ -156,8 +158,7 @@ export function flashCountUp(node, from, to, format = fmtCommas, opts = {}) {
     return;
   }
 
-  const delta = Math.abs(safeTo - safeFrom);
-  const durationMs = opts.durationMs ? Math.max(120, opts.durationMs) : countUpDurationForDelta(delta);
+  const durationMs = Math.max(120, opts.durationMs || COUNT_ROLL_MS);
   const wantPopups = opts.popups !== false && safeTo > safeFrom;
   const host = wantPopups ? ensureHost(node) : null;
 


### PR DESCRIPTION
## Summary
- Reset stale `feat/library-count-1up` onto current `main` (old branch was 129 commits behind and would have reverted shipped work).
- Align fetch-driven library-count roll duration to the landing mega-hero demo: fixed **1000ms** (`COUNT_ROLL_MS` in `landing/demo.js`) instead of delta-scaled `countUpDurationForDelta`.
- Keeps existing 1UP popup behavior, post-boot arming, and Vitest coverage.

## Context
The original feature branch predated most of the library-count integration already on `main`. This PR preserves the one meaningful delta (demo timing) without replaying obsolete history.

## Test plan
- [x] `npx vitest run tests/library-count-animation.test.js` (13/13)
- [x] `npm run build`
- [ ] Manual: run a fetch that adds games; hero/chip count rolls over ~1s with green +N popups
- [ ] Manual: `?demo=count` still works after boot arms animations