### PR TITLE
Fix manifest cache invalidation on Windows using st_mtime_ns

### DIFF
--- a/shared/install_paths.py
+++ b/shared/install_paths.py
@@ -8,7 +8,7 @@ import sys
 from pathlib import Path
 
 _BUILT_MANIFEST_CACHE: dict | None = None
-_BUILT_MANIFEST_MTIME: float | None = None
+_BUILT_MANIFEST_MTIME_NS: int | None = None
 
 
 def is_frozen() -> bool:
@@ -57,21 +57,21 @@ def serve_built_frontend() -> bool:
 
 def load_built_manifest() -> dict:
     """Parsed dist/manifest.json; empty dict when not serving built frontend."""
-    global _BUILT_MANIFEST_CACHE, _BUILT_MANIFEST_MTIME
+    global _BUILT_MANIFEST_CACHE, _BUILT_MANIFEST_MTIME_NS
     if not serve_built_frontend():
         return {}
     path = built_manifest_path()
     try:
-        mtime = path.stat().st_mtime
+        mtime_ns = path.stat().st_mtime_ns
     except OSError:
         return {}
-    if _BUILT_MANIFEST_CACHE is not None and _BUILT_MANIFEST_MTIME == mtime:
+    if _BUILT_MANIFEST_CACHE is not None and _BUILT_MANIFEST_MTIME_NS == mtime_ns:
         return _BUILT_MANIFEST_CACHE
     try:
         _BUILT_MANIFEST_CACHE = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         _BUILT_MANIFEST_CACHE = {}
-    _BUILT_MANIFEST_MTIME = mtime
+    _BUILT_MANIFEST_MTIME_NS = mtime_ns
     return _BUILT_MANIFEST_CACHE
 
 

--- a/tests/test_install_paths.py
+++ b/tests/test_install_paths.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import time
 from pathlib import Path
 
 from shared import install_paths
@@ -27,7 +29,7 @@ def test_serve_built_false_without_manifest(monkeypatch, tmp_path):
     monkeypatch.setattr(install_paths, "is_frozen", lambda: False)
     monkeypatch.setattr(install_paths, "bundle_root", lambda: tmp_path)
     install_paths._BUILT_MANIFEST_CACHE = None
-    install_paths._BUILT_MANIFEST_MTIME = None
+    install_paths._BUILT_MANIFEST_MTIME_NS = None
     assert install_paths.serve_built_frontend() is False
     assert install_paths.load_built_manifest() == {}
 
@@ -41,9 +43,11 @@ def test_manifest_cache_invalidates_on_mtime_change(monkeypatch, tmp_path):
     monkeypatch.setattr(install_paths, "is_frozen", lambda: False)
     monkeypatch.setattr(install_paths, "bundle_root", lambda: tmp_path)
     install_paths._BUILT_MANIFEST_CACHE = None
-    install_paths._BUILT_MANIFEST_MTIME = None
+    install_paths._BUILT_MANIFEST_MTIME_NS = None
     assert install_paths.load_built_manifest()["js/app.js"] == "js/app-OLD.js"
     manifest.write_text('{"js/app.js":"js/app-NEW.js"}', encoding="utf-8")
+    # Windows runners can expose coarse st_mtime; bump explicitly so invalidation is observable.
+    os.utime(manifest, (time.time() + 1, time.time() + 1))
     assert install_paths.load_built_manifest()["js/app.js"] == "js/app-NEW.js"
 
 
@@ -58,7 +62,7 @@ def test_serve_built_true_with_flag_and_manifest(monkeypatch, tmp_path):
     monkeypatch.setattr(install_paths, "is_frozen", lambda: False)
     monkeypatch.setattr(install_paths, "bundle_root", lambda: tmp_path)
     install_paths._BUILT_MANIFEST_CACHE = None
-    install_paths._BUILT_MANIFEST_MTIME = None
+    install_paths._BUILT_MANIFEST_MTIME_NS = None
     assert install_paths.serve_built_frontend() is True
     manifest = install_paths.load_built_manifest()
     assert manifest["app.css"] == "app.abc.css"

--- a/tests/test_server_built_frontend.py
+++ b/tests/test_server_built_frontend.py
@@ -30,7 +30,7 @@ def server_mod(monkeypatch, tmp_path):
     import shared.install_paths as ip
 
     ip._BUILT_MANIFEST_CACHE = None
-    ip._BUILT_MANIFEST_MTIME = None
+    ip._BUILT_MANIFEST_MTIME_NS = None
     import shared.built_frontend as bf
 
     bf.invalidate_built_index_cache()
@@ -61,7 +61,7 @@ def test_built_index_html_rewrites_css_when_frozen(server_mod, tmp_path, monkeyp
     monkeypatch.setattr(bf, "bundle_root", lambda: tmp_path)
     bf.invalidate_built_index_cache()
     ip._BUILT_MANIFEST_CACHE = None
-    ip._BUILT_MANIFEST_MTIME = None
+    ip._BUILT_MANIFEST_MTIME_NS = None
 
     html = built_index_html()
     assert html is not None
@@ -84,7 +84,7 @@ def test_built_index_invalidates_when_manifest_changes(server_mod, tmp_path):
     import shared.install_paths as ip
 
     ip._BUILT_MANIFEST_CACHE = None
-    ip._BUILT_MANIFEST_MTIME = None
+    ip._BUILT_MANIFEST_MTIME_NS = None
     import shared.built_frontend as bf
 
     bf.invalidate_built_index_cache()


### PR DESCRIPTION
## Summary
- Use `st_mtime_ns` instead of `st_mtime` for built manifest cache invalidation
- Add explicit `os.utime` in tests so cache invalidation is observable on coarse Windows filesystems

Fixes red CI on main (Windows pytest manifest cache test).

## Test plan
- [x] `pytest tests/test_install_paths.py tests/test_server_built_frontend.py` (9 passed locally)