### PR TITLE
Tag all itch.io outbound links through affiliateUrl

### DIFF
--- a/js/affiliate.js
+++ b/js/affiliate.js
@@ -5,6 +5,10 @@
  * they already carry ITAD's affiliate tag and the API ToS forbids altering
  * them. High-commission marketplaces that only appear as ITAD deal shops
  * (Fanatical, GMG, etc.) are monetized via the Sponsored feed instead.
+ *
+ * Call sites: storeUrlForGame (game-core.js), free-claim outbound links
+ * (claim-card.js, claimable.js), and wishlist fallback deal URLs (deals.js).
+ * Help/settings links (itch.io/login, API keys page) are intentionally raw.
  */
 
 /* ============================================================================

--- a/js/claim-card.js
+++ b/js/claim-card.js
@@ -21,6 +21,7 @@
 import { escapeHtml, escapeAttr, isSafeHttpUrl } from './dom-util.js';
 import { normalizeNameForDedup } from './game-core.js';
 import { storeLogoHtml, storeDisplayName } from './store-logos.js';
+import { affiliateUrl } from './affiliate.js';
 
 /** Strip giveaway/store boilerplate from auto-sourced claim titles before ownership match. */
 export function stripClaimTitleDecorations(title) {
@@ -309,10 +310,11 @@ export function claimDetailPanelHtml(claim, {
     ? `<span class="claim-detail-ends">Ends ${escapeHtml(ends)}</span>`
     : '';
   const claimable = !owned && isSafeHttpUrl(claim.claim_url);
+  const claimHref = claimable ? affiliateUrl(claim.claim_url) : '';
   const claimBtn = owned
     ? `<p class="claim-detail-owned">Already in your library.</p>`
     : (claimable
-      ? `<a href="${escapeAttr(claim.claim_url)}" target="_blank" rel="noopener noreferrer" class="claim-detail-claim-btn">Claim free →</a>`
+      ? `<a href="${escapeAttr(claimHref)}" target="_blank" rel="noopener noreferrer" class="claim-detail-claim-btn">Claim free →</a>`
       : `<p class="claim-detail-owned">Claim link unavailable.</p>`);
   return `<form method="dialog" class="claim-detail-panel">
       <div class="claim-detail-header">

--- a/js/claimable.js
+++ b/js/claimable.js
@@ -9,6 +9,7 @@ import { dataFetch } from './api-client.js';
 import { syncCoverFits } from './covers.js';
 import { getAdsForLocation, sponsoredClaimCardHtml } from './sponsored-deals.js';
 import { isPro } from './auth-gate.js';
+import { affiliateUrl } from './affiliate.js';
 import {
   stripClaimTitleDecorations,
   dedupeClaims,
@@ -616,7 +617,7 @@ export function handleClaimableClick(e) {
     const id = goBtn.dataset.claimGo;
     const claim = (state.claimableFeed?.items || []).find(c => c.id === id)
       || state.claimableNow.find(c => c.id === id);
-    if (isSafeHttpUrl(claim?.claim_url)) window.open(claim.claim_url, '_blank', 'noopener,noreferrer');
+    if (isSafeHttpUrl(claim?.claim_url)) window.open(affiliateUrl(claim.claim_url), '_blank', 'noopener,noreferrer');
     return true;
   }
   const card = e.target.closest('[data-claim-id]');

--- a/js/deals.js
+++ b/js/deals.js
@@ -19,6 +19,7 @@ import {
 import { isPlatformToken } from './genres.js';
 import { savePrefs } from './prefs.js';
 import { refreshFilterUI, switchView } from './filters-ui.js';
+import { affiliateUrl } from './affiliate.js';
 
 /** Cut-depth modifier class — emerald default, big-gradient for 50%+,
  *  amber→red→pink gradient for 75%+. Matches the pre-CSS-extract project. */
@@ -477,7 +478,7 @@ export function getDealInfo(g) {
       cut,
       isHistoricalLow: false,
       shop: "Steam",
-      url: g.store_url || null,
+      url: g.store_url ? affiliateUrl(g.store_url) : null,
     };
   }
   return null;

--- a/tests/affiliate.test.js
+++ b/tests/affiliate.test.js
@@ -92,6 +92,15 @@ describe('affiliateUrl', () => {
     expect(affiliateUrl(creator)).toBe(creator);
   });
 
+  it('tags itch free-claim and fetcher store_url shapes', () => {
+    AFFILIATE_CREDENTIALS.itch = 'eob7ZQcpthHDp';
+    const claim = affiliateUrl('https://s-xavier-uy.itch.io/another-world-adventures');
+    expect(new URL(claim).searchParams.get('ac')).toBe('eob7ZQcpthHDp');
+
+    const local = affiliateUrl('https://dev.itch.io/local-game');
+    expect(new URL(local).searchParams.get('ac')).toBe('eob7ZQcpthHDp');
+  });
+
   it('wraps URL in deeplink template when a {url} template is pasted in', () => {
     AFFILIATE_CREDENTIALS.gog = 'https://track.example.com/?dest={url}';
     const url = 'https://www.gog.com/en/game/bar';

--- a/tests/claim-card.test.js
+++ b/tests/claim-card.test.js
@@ -11,10 +11,12 @@ import { describe, expect, it, beforeAll } from 'vitest';
 import {
   claimableModuleMarkup,
   claimCardHtml,
+  claimDetailPanelHtml,
   dedupeClaims,
   sortClaims,
   sanitizeBlurb,
 } from '../js/claim-card.js';
+import { AFFILIATE_CREDENTIALS } from '../js/affiliate.js';
 
 beforeAll(() => {
   // covers.js (not imported here) normally installs these globals; the markup
@@ -78,6 +80,40 @@ describe('claimableModuleMarkup', () => {
     const html = claimableModuleMarkup(items, { visibleCount: 5 });
     expect(html).toContain('data-claim-show-more');
     expect(html).toContain('+2 more');
+  });
+});
+
+describe('claimDetailPanelHtml affiliate tagging', () => {
+  const itchClaim = {
+    id: 'itch-demo',
+    store: 'itch',
+    title: 'Another World Adventures',
+    claim_url: 'https://s-xavier-uy.itch.io/another-world-adventures',
+    source: 'itad',
+  };
+
+  it('tags itch.io claim links when the affiliate program is live', () => {
+    const prev = AFFILIATE_CREDENTIALS.itch;
+    AFFILIATE_CREDENTIALS.itch = 'eob7ZQcpthHDp';
+    try {
+      const html = claimDetailPanelHtml(itchClaim);
+      expect(html).toContain('ac=eob7ZQcpthHDp');
+      expect(html).not.toContain(`href="${itchClaim.claim_url}"`);
+    } finally {
+      AFFILIATE_CREDENTIALS.itch = prev;
+    }
+  });
+
+  it('leaves claim links raw when the affiliate program is off', () => {
+    const prev = AFFILIATE_CREDENTIALS.itch;
+    AFFILIATE_CREDENTIALS.itch = '';
+    try {
+      const html = claimDetailPanelHtml(itchClaim);
+      expect(html).toContain(`href="${itchClaim.claim_url}"`);
+      expect(html).not.toContain('ac=');
+    } finally {
+      AFFILIATE_CREDENTIALS.itch = prev;
+    }
   });
 });
 

--- a/tests/deals.test.js
+++ b/tests/deals.test.js
@@ -4,6 +4,7 @@
 
 import { describe, expect, it, beforeEach } from 'vitest';
 import { state } from '../js/state.js';
+import { AFFILIATE_CREDENTIALS } from '../js/affiliate.js';
 import {
   parsePriceLike,
   getDealInfo,
@@ -116,6 +117,23 @@ describe('getDealInfo', () => {
 
   it('returns null when no pricing', () => {
     expect(getDealInfo({ ...baseGame, price: null, discount_percent: 0 })).toBeNull();
+  });
+
+  it('tags itch.io fallback store_url when affiliate is live', () => {
+    const prev = AFFILIATE_CREDENTIALS.itch;
+    AFFILIATE_CREDENTIALS.itch = 'eob7ZQcpthHDp';
+    try {
+      const g = {
+        ...baseGame,
+        price: '$4.99',
+        discount_percent: 20,
+        store_url: 'https://dev.itch.io/sale-game',
+      };
+      const d = getDealInfo(g);
+      expect(d?.url).toContain('ac=eob7ZQcpthHDp');
+    } finally {
+      AFFILIATE_CREDENTIALS.itch = prev;
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Audit confirmed store buttons via storeUrlForGame were already tagged; fixed three gaps where itch links bypassed affiliateUrl.
- Free-claim detail panel and Claim free button now route claim_url through affiliateUrl (sets itch ?ac= cookie when enrolled).
- Wishlist fallback deal URLs from store_url in getDealInfo are tagged the same way.
- ITAD redirects, help/settings copy, and marketing links intentionally left raw.

## Test plan
- [x] npm test tests/affiliate.test.js tests/claim-card.test.js tests/deals.test.js (56 passed)
- [ ] CI green on PR
- [ ] Locally paste itch credential in AFFILIATE_CREDENTIALS.itch and spot-check: library store link, free claim, wishlist deal card open with ?ac= on itch URLs

Made with [Cursor](https://cursor.com)