### PR TITLE
Redesign dashboard itch card: always on, pink rail, value block

### DIFF
--- a/app.css
+++ b/app.css
@@ -3613,9 +3613,6 @@ html[data-theme="ember"] .brand-logo-pills { fill: url(#brandMarkGrad); }
 .dash-picks-row:has(.dash-sponsored-pick-slot:not(.hidden)) {
   grid-template-columns: repeat(4, minmax(0, 1fr));
 }
-.dash-picks-row.no-itch:has(.dash-sponsored-pick-slot:not(.hidden)) .dash-picks-versus {
-  grid-column: span 2;
-}
 .dash-card.hidden { display: none; }
 /* Dashboard card headings follow the active theme (override Tailwind text-slate-*) */
 .dash-card > h3,
@@ -6081,7 +6078,87 @@ html[data-init-view="wishlist"] .steal-list-footer-passive { display: none; }
   user-select: none;
 }
 .has-notes-dot:hover { background: color-mix(in srgb, var(--accent) 18%, transparent); color: var(--text-bright, #f0f9ff); }
-.dash-itch-recap { color: #cbd5e1; line-height: 1.5; display: flex; flex-direction: column; gap: 0.65rem; flex: 1; min-height: 0; }
+.dash-card-itch {
+  padding: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.dash-itch-recap { color: #cbd5e1; line-height: 1.5; display: flex; flex-direction: column; gap: 0.65rem; flex: 1; min-height: 0; padding: 0 18px 16px; }
+.itch-card-rail {
+  height: 4px;
+  background: var(--brand-itch, #fa5c5c);
+  flex-shrink: 0;
+}
+.itch-card-rail--affiliate {
+  height: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.4rem 18px;
+  background: color-mix(in srgb, var(--brand-itch, #fa5c5c) 22%, var(--bg-elev));
+  border-bottom: 1px solid color-mix(in srgb, var(--brand-itch, #fa5c5c) 45%, transparent);
+}
+.itch-card-rail-brand {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #fecaca;
+}
+.itch-card-rail-copy {
+  font-size: 0.62rem;
+  color: #fca5a5;
+  text-align: right;
+}
+.itch-card-title { margin: 0.75rem 0 0; }
+.itch-onboarding {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.35rem 0 0.25rem;
+}
+.itch-onboard-lead {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+.itch-onboard-copy,
+.itch-onboard-affiliate {
+  margin: 0;
+  font-size: 0.75rem;
+  color: #94a3b8;
+  line-height: 1.45;
+}
+.itch-onboard-affiliate { color: #fca5a5; }
+.itch-onboard-cta { align-self: flex-start; margin-top: 0.15rem; }
+.itch-value-block { display: flex; flex-direction: column; gap: 0.35rem; }
+.itch-value-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+.itch-value-stat {
+  background: color-mix(in srgb, var(--brand-itch, #fa5c5c) 8%, var(--bg-elev));
+  border: 1px solid color-mix(in srgb, var(--brand-itch, #fa5c5c) 25%, var(--border-subtle));
+  border-radius: 6px;
+  padding: 0.4rem 0.5rem;
+}
+.itch-value-label {
+  font-size: 0.58rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #94a3b8;
+}
+.itch-value-num {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #f8fafc;
+  font-variant-numeric: tabular-nums;
+}
+.itch-value-spend { color: #fecaca; }
+.itch-stat-strip { margin-top: 0.1rem; }
 .dash-itch-recap strong { color: #ffffff; font-weight: 600; }
 .dash-itch-recap .dash-itch-muted { color: #94a3b8; font-size: 0.75rem; margin-top: 0.35rem; }
 .itch-distribution { display: flex; flex-direction: column; gap: 0.3rem; flex: 0 0 auto; }
@@ -6192,33 +6269,20 @@ html[data-init-view="wishlist"] .steal-list-footer-passive { display: none; }
 .dash-picks-row .dash-picks-versus,
 .dash-picks-row .dash-card-itch,
 .dash-picks-row .dash-recent-card { grid-column: span 1; }
-.dash-picks-row.no-itch .dash-picks-versus { grid-column: span 2; }
-.dash-picks-row.no-itch .dash-recent-card { grid-column: span 1; }
-/* itch present: order columns Versus | Recently added | itch (itch on the right) */
-.dash-picks-row:not(.no-itch) .dash-picks-versus { order: 1; }
-.dash-picks-row:not(.no-itch) .dash-recent-card { order: 2; }
-.dash-picks-row:not(.no-itch) .dash-card-itch { order: 3; }
-/* itch present: stack Best rated over Fastest in the versus card */
-.dash-picks-row:not(.no-itch) .dash-versus-grid {
+/* Versus | Recently added | itch (itch on the right) */
+.dash-picks-row .dash-picks-versus { order: 1; }
+.dash-picks-row .dash-recent-card { order: 2; }
+.dash-picks-row .dash-card-itch { order: 3; }
+/* Stack Best rated over Fastest in the versus card */
+.dash-picks-row .dash-versus-grid {
   grid-template-columns: 1fr;
   grid-template-rows: 1fr auto 1fr;
   gap: 12px;
 }
-.dash-picks-row:not(.no-itch) .dash-versus-divider {
+.dash-picks-row .dash-versus-divider {
   width: 100%;
   height: 1px;
   min-height: 1px;
-}
-/* itch absent: side-by-side rated | fastest inside the 2/3 versus card */
-.dash-picks-row.no-itch .dash-versus-grid {
-  grid-template-columns: 1fr 1px 1fr;
-  grid-template-rows: minmax(0, 1fr);
-  gap: 16px;
-}
-.dash-picks-row.no-itch .dash-versus-divider {
-  width: auto;
-  height: auto;
-  min-height: 0;
 }
 #dashRecentCard {
   display: flex;
@@ -6238,8 +6302,7 @@ html[data-init-view="wishlist"] .steal-list-footer-passive { display: none; }
 }
 .dash-recent-age { flex-shrink: 0; font-size: 12px; }
 @media (max-width: 900px) {
-  .dash-picks-row,
-  .dash-picks-row.no-itch { grid-template-columns: 1fr; }
+  .dash-picks-row { grid-template-columns: 1fr; }
   .dash-picks-row .dash-picks-versus,
   .dash-picks-row .dash-card-itch,
   .dash-picks-row .dash-recent-card { grid-column: auto; }

--- a/index.html
+++ b/index.html
@@ -560,7 +560,7 @@
         <div id="dashboardCoopSpotlight" class="dash-card"></div>
         <div id="dashboardWishlistStats" class="dash-wishlist-stats-target grid grid-cols-1 sm:grid-cols-3 gap-4"></div>
         <div id="dashboardHouseSlot" class="dash-house-slot hidden mb-4"></div>
-        <div id="dashboardPicksRow" class="dash-picks-row no-itch">
+        <div id="dashboardPicksRow" class="dash-picks-row">
           <div id="dashboardSponsoredPick" class="dash-sponsored-pick-slot hidden"></div>
           <div class="dash-card dash-picks-versus" id="dashPicksVersusCard">
             <div class="dash-versus-head">
@@ -579,9 +579,8 @@
               </div>
             </div>
           </div>
-          <div class="dash-card dash-card-itch hidden" id="dashItchCard">
-            <h3 class="text-sm font-semibold text-slate-200 mb-2">itch.io library</h3>
-            <div id="dashItchRecap" class="dash-itch-recap text-sm"></div>
+          <div class="dash-card dash-card-itch" id="dashItchCard">
+            <div id="dashItchRecap" class="dash-itch-recap text-sm" role="region" aria-label="itch.io library"></div>
           </div>
           <div class="dash-card dash-recent-card" id="dashRecentCard">
             <h3 class="text-sm font-semibold text-slate-200 mb-2">Recently added</h3>

--- a/js/dashboard-cards.js
+++ b/js/dashboard-cards.js
@@ -3,7 +3,9 @@
 
 import { state, STATUS_CHIP_DEFS } from './state.js';
 import { escapeAttr, escapeHtml, formatNum } from './dom-util.js';
-import { gameKey, normalizeGame, hltbMain, ratingValue, hasEnoughReviews, coverFallbackFor, libraryCoverFor, sanitizeCoverUrl, itchIsGame, chipStatusKey, combinedPlaytime, storeBadgeHtml } from './game-core.js';
+import { gameKey, normalizeGame, hltbMain, ratingValue, hasEnoughReviews, coverFallbackFor, libraryCoverFor, sanitizeCoverUrl, itchIsGame, chipStatusKey, combinedPlaytime, storeBadgeHtml, formatDollar } from './game-core.js';
+import { hasLiveAffiliates } from './affiliate.js';
+import { freeItchCount, paidItchCount, itchSpendTotal } from './sabermetrics.js';
 import { gameGenresCanonical } from './genres.js';
 import { getPersonal } from './personal-storage.js';
 import { wishlistGamesWithDeals, dealHeroCardHtml, dealHeroEmptyHtml, dealSaleScoreboardCardHtml, dealStealsCardHtml, getDealInfo, dealScore, isStealDeal } from './deals.js';
@@ -18,7 +20,7 @@ import {
   renderHouseLocationSlot,
 } from './sponsored-deals.js';
 import { focusGame } from './table-ui.js';
-import { DASH_STORE_LABELS, DASH_STORE_COLORS, ITCH_CLASS_LABELS } from './dashboard-shared.js';
+import { DASH_STORE_LABELS, DASH_STORE_COLORS } from './dashboard-shared.js';
 // Itch click routing uses dashDrillItchGenre from the drilldown module.
 // dashboard-drilldown does NOT import this module; the cycle stays one-way.
 import { dashDrillItchGenre } from './dashboard-drilldown.js';
@@ -213,12 +215,10 @@ export function renderDashboardCoopSpotlight(games) {
   `;
 }
 
+/** itch recap card is always visible on the picks row (onboarding when library is empty). */
 export function applyItchVisibility() {
-  const row = document.getElementById("dashboardPicksRow");
-  const card = document.getElementById("dashItchCard");
-  const has = (state.itchGames || []).length > 0;
-  row?.classList.toggle("no-itch", !has);
-  card?.classList.toggle("hidden", !has);
+  document.getElementById("dashboardPicksRow")?.classList.remove("no-itch");
+  document.getElementById("dashItchCard")?.classList.remove("hidden");
 }
 
 export function renderDashboardSponsoredPick() {
@@ -271,8 +271,7 @@ export function renderDashboardPicksVersus(games) {
       return ratingValue(b) - ratingValue(a);
     });
 
-  const hasItch = (state.itchGames || []).length > 0;
-  const maxPicks = hasItch ? 5 : 10;
+  const maxPicks = 5;
   const balanced = Math.min(ratedAll.length, fastAll.length, maxPicks);
   const sliceCount = balanced > 0 ? balanced : Math.min(Math.max(ratedAll.length, fastAll.length), maxPicks);
   // Ad displaces the last slot: sliceCount-1 real games + ad = sliceCount rows; dismiss
@@ -469,6 +468,69 @@ export function renderDashboardWishlistStats() {
   renderDashboardHouseSlot();
 }
 
+function itchBrandRailHtml() {
+  if (hasLiveAffiliates()) {
+    return `<div class="itch-card-rail itch-card-rail--affiliate" role="note">
+      <span class="itch-card-rail-brand">itch.io</span>
+      <span class="itch-card-rail-copy">Affiliate · purchases help support BAKLOG</span>
+    </div>`;
+  }
+  return `<div class="itch-card-rail" aria-hidden="true"></div>`;
+}
+
+function itchOnboardingHtml() {
+  const affiliateNote = hasLiveAffiliates()
+    ? `<p class="itch-onboard-affiliate">BAKLOG is an itch.io affiliate — your purchases help keep the app free.</p>`
+    : "";
+  return `<div class="itch-onboarding">
+    <div class="itch-onboard-lead">Start earning free games today</div>
+    <p class="itch-onboard-copy">Connect itch.io on Connections and run the itch fetcher to sync your library, ratings, and indie picks here.</p>
+    ${affiliateNote}
+    <button type="button" class="summary-jump-chip itch-onboard-cta" data-jump-view="connections" title="Open Connections to add your itch.io key">Connect itch.io →</button>
+  </div>`;
+}
+
+function itchValueBlockHtml(gamesOnly) {
+  const free = freeItchCount(gamesOnly) ?? 0;
+  const paid = paidItchCount(gamesOnly) ?? 0;
+  const spend = itchSpendTotal(gamesOnly);
+  const spendLabel = spend != null ? formatDollar(spend) : "—";
+  return `<div class="itch-value-block" title="Free vs paid itch.io videogames by minimum list price">
+    <div class="itch-distribution-label">Library value</div>
+    <div class="itch-value-grid">
+      <div class="itch-value-stat" title="itch.io videogames with zero minimum price">
+        <div class="itch-value-label">Free</div>
+        <div class="itch-value-num">${formatNum(free)}</div>
+      </div>
+      <div class="itch-value-stat" title="itch.io videogames you paid for">
+        <div class="itch-value-label">Paid</div>
+        <div class="itch-value-num">${formatNum(paid)}</div>
+      </div>
+      <div class="itch-value-stat" title="Sum of minimum prices for paid itch.io videogames">
+        <div class="itch-value-label">Spend</div>
+        <div class="itch-value-num itch-value-spend">${escapeHtml(spendLabel)}</div>
+      </div>
+    </div>
+  </div>`;
+}
+
+function itchStatStripHtml({ videogames, total, backlogged, rated }) {
+  return `<div class="sale-scoreboard itch-stat-strip">
+    <div class="sale-stat" title="itch.io items classified as videogames">
+      <div class="sale-stat-label">Videogames</div>
+      <div class="sale-stat-value">${formatNum(videogames)}<span class="sale-stat-suffix"> / ${formatNum(total)}</span></div>
+    </div>
+    <div class="sale-stat" title="itch.io videogames marked backlog">
+      <div class="sale-stat-label">Backlog</div>
+      <div class="sale-stat-value ${backlogged ? "" : "sale-stat-muted"}">${backlogged ? formatNum(backlogged) : " - "}</div>
+    </div>
+    <div class="sale-stat" title="itch.io videogames with a community rating">
+      <div class="sale-stat-label">Rated</div>
+      <div class="sale-stat-value ${rated ? "" : "sale-stat-muted"}">${rated ? formatNum(rated) : " - "}</div>
+    </div>
+  </div>`;
+}
+
 function itchBreakdownRows(entries, fillClass, action) {
   const max = Math.max(...entries.map(([, n]) => n), 1);
   return entries.map(([value, count, label]) => {
@@ -563,10 +625,12 @@ export function renderDashboardItchRecap() {
     delete dashboardCharts.chartItchStatus;
   }
 
-  const total = state.itchGames.length;
   applyItchVisibility();
+  const total = state.itchGames.length;
   if (!total) {
-    el.innerHTML = `<p class="text-sm text-slate-400">No itch.io data yet - add your itch.io key on Connections and run the itch fetcher.</p>`;
+    el.innerHTML = `${itchBrandRailHtml()}
+      <h3 class="itch-card-title text-sm font-semibold text-slate-200">itch.io library</h3>
+      ${itchOnboardingHtml()}`;
     return;
   }
 
@@ -613,22 +677,6 @@ export function renderDashboardItchRecap() {
   else itchHeroIndex = 0;
   const heroHtml = videogames ? renderItchHeroHtml(heroCandidates) : "";
 
-  const classCounts = {};
-  state.itchGames.forEach(g => {
-    const cls = g.classification || "game";
-    classCounts[cls] = (classCounts[cls] || 0) + 1;
-  });
-  const classEntries = Object.entries(classCounts)
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 5)
-    .map(([cls, count]) => [cls, count, ITCH_CLASS_LABELS[cls] || cls]);
-  const classHtml = classEntries.length
-    ? `<div class="itch-breakdown">
-        <div class="itch-distribution-label" title="itch.io item types (game, tool, soundtrack, etc.)">What's in your library</div>
-        <div class="itch-breakdown-list">${itchBreakdownRows(classEntries, "itch-bar-class", null)}</div>
-      </div>`
-    : "";
-
   const genreCounts = {};
   gamesOnly.forEach(g => {
     gameGenresCanonical(g).forEach(genre => {
@@ -646,24 +694,15 @@ export function renderDashboardItchRecap() {
       </div>`
     : "";
 
+  const valueHtml = videogames ? itchValueBlockHtml(gamesOnly) : "";
+
   el.innerHTML = `
-    <div class="sale-scoreboard">
-      <div class="sale-stat" title="itch.io items classified as videogames">
-        <div class="sale-stat-label">Videogames</div>
-        <div class="sale-stat-value">${formatNum(videogames)}<span class="sale-stat-suffix"> / ${formatNum(total)}</span></div>
-      </div>
-      <div class="sale-stat" title="itch.io videogames marked backlog">
-        <div class="sale-stat-label">Backlog</div>
-        <div class="sale-stat-value ${backlogged ? "" : "sale-stat-muted"}">${backlogged ? formatNum(backlogged) : " - "}</div>
-      </div>
-      <div class="sale-stat" title="itch.io videogames with a community rating">
-        <div class="sale-stat-label">Rated</div>
-        <div class="sale-stat-value ${rated ? "" : "sale-stat-muted"}">${rated ? formatNum(rated) : " - "}</div>
-      </div>
-    </div>
-    ${segHtml}
+    ${itchBrandRailHtml()}
+    <h3 class="itch-card-title text-sm font-semibold text-slate-200">itch.io library</h3>
     ${heroHtml}
-    ${classHtml}
+    ${itchStatStripHtml({ videogames, total, backlogged, rated })}
+    ${valueHtml}
+    ${segHtml}
     ${genreHtml}
     <div class="itch-footer">
       <button type="button" class="summary-jump-chip px-2 py-1 rounded text-xs cursor-pointer" data-jump-view="itch" title="Switch to the itch.io library tab">Open itch.io tab →</button>

--- a/tests/dashboard-picks-row.test.js
+++ b/tests/dashboard-picks-row.test.js
@@ -33,7 +33,9 @@ describe('dashboard picks row', () => {
           <div id="dashVersusFast" class="dash-versus-list"></div>
           <span id="dashVersusBadge" class="hidden"></span>
         </div>
-        <div id="dashItchCard" class="dash-card-itch"></div>
+        <div id="dashItchCard" class="dash-card-itch">
+          <div id="dashItchRecap" class="dash-itch-recap"></div>
+        </div>
         <div id="dashRecentCard" class="dash-recent-card">
           <div id="dashRecentAdditions" class="dash-recent-list"></div>
         </div>
@@ -55,32 +57,57 @@ describe('dashboard picks row', () => {
     vi.restoreAllMocks();
   });
 
-  it('ships index.html with itch hidden by default until library data exists', () => {
+  it('ships index.html with itch card always visible on the picks row', () => {
     const picksRow = INDEX_HTML.match(/<div[^>]*id="dashboardPicksRow"[^>]*>/)?.[0] ?? '';
     const itchCard = INDEX_HTML.match(/<div[^>]*id="dashItchCard"[^>]*>/)?.[0] ?? '';
     const itchTab = INDEX_HTML.match(/<button[^>]*data-view="itch"[^>]*>/)?.[0] ?? '';
-    expect(picksRow).toMatch(/\bno-itch\b/);
-    expect(itchCard).toMatch(/\bhidden\b/);
+    expect(picksRow).not.toMatch(/\bno-itch\b/);
+    expect(itchCard).not.toMatch(/\bhidden\b/);
     expect(itchTab).toMatch(/\bhidden\b/);
   });
 
-  it('shows recents card and no-itch when itch library is empty', () => {
+  it('keeps itch card visible when itch library is empty', () => {
     applyItchVisibility();
     const row = document.getElementById('dashboardPicksRow');
     const itch = document.getElementById('dashItchCard');
     const recent = document.getElementById('dashRecentCard');
-    expect(row.classList.contains('no-itch')).toBe(true);
-    expect(itch.classList.contains('hidden')).toBe(true);
+    expect(row.classList.contains('no-itch')).toBe(false);
+    expect(itch.classList.contains('hidden')).toBe(false);
     expect(recent.classList.contains('hidden')).toBe(false);
   });
 
-  it('removes no-itch and shows itch card when itch data exists', () => {
+  it('still keeps itch card visible when itch data exists', () => {
     state.itchGames = [{ store: 'itch', id: 'a', name: 'Demo' }];
     applyItchVisibility();
     const row = document.getElementById('dashboardPicksRow');
     const itch = document.getElementById('dashItchCard');
     expect(row.classList.contains('no-itch')).toBe(false);
     expect(itch.classList.contains('hidden')).toBe(false);
+  });
+
+  it('renders onboarding copy when itch library is empty', async () => {
+    const { renderDashboardItchRecap } = await import('../js/dashboard-cards.js');
+    document.getElementById('dashItchRecap').innerHTML = '';
+    renderDashboardItchRecap();
+    const recap = document.getElementById('dashItchRecap');
+    expect(recap.textContent).toContain('Start earning free games today');
+    expect(recap.textContent).toContain('Connect itch.io');
+    expect(recap.querySelector('.itch-card-rail')).toBeTruthy();
+    expect(recap.querySelector('[data-jump-view="connections"]')).toBeTruthy();
+  });
+
+  it('renders library value block when itch videogames exist', async () => {
+    const { renderDashboardItchRecap } = await import('../js/dashboard-cards.js');
+    state.itchGames = [
+      { store: 'itch', id: '1', name: 'Freebie', classification: 'game', min_price: 0 },
+      { store: 'itch', id: '2', name: 'Paid', classification: 'game', min_price: 4.99 },
+    ];
+    state.personal = {};
+    document.getElementById('dashItchRecap').innerHTML = '';
+    renderDashboardItchRecap();
+    const recap = document.getElementById('dashItchRecap');
+    expect(recap.querySelector('.itch-value-block')).toBeTruthy();
+    expect(recap.textContent).toContain('Library value');
   });
 
   it('appends two distinct sponsored rows to rated and fast columns', async () => {


### PR DESCRIPTION
## Summary
- itch.io recap card is always visible on the dashboard picks row (onboarding when library is empty).
- Pink itch-brand top rail; affiliate disclosure when the itch program is live.
- New library value block: free vs paid counts + total itch spend.
- Elevated layout: hero pick first, stat strip, composition bar, top genres (dropped redundant item-type breakdown).

## Test plan
- [x] npm test tests/dashboard-picks-row.test.js tests/itch-hero-order.test.js
- [ ] CI green
- [ ] Manual QA: empty library shows onboarding + rail; with library shows hero, value block, genres; affiliate rail copy only when AFFILIATE_CREDENTIALS.itch is set locally

Made with [Cursor](https://cursor.com)