### PR TITLE
chore: git worktree helper scripts for parallel agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,10 +65,13 @@ When multiple Cursor agents work at once, **one agent = one git worktree = one s
 **Worktrees** — give each concurrent agent its own folder:
 
 ```powershell
-git worktree add ..\baklog-pro feat/pro
-git worktree add ..\baklog-spotlight feat/spotlight-discovery
-git worktree list   # dashboard of who is where
+.\scripts\new-worktree.ps1 feat/pro                 # -> ..\baklog-pro on feat/pro
+.\scripts\new-worktree.ps1 feat/spotlight-discovery # rejects bare names; feat/|fix/|chore/ only
+git worktree list                                   # dashboard of who is where
+.\scripts\close-worktree.ps1 feat/pro               # after squash-merge: remove + delete local/remote + prune
 ```
+
+The helpers enforce the branch-naming scheme and junction `.venv` + `node_modules` into the new folder so it is usable immediately. Raw equivalent: `git worktree add ..\baklog-pro feat/pro`.
 
 **Merge hygiene** — squash-merge PRs to `main`, then delete the local branch and `git push origin --delete <branch>`. Run `git fetch --prune` after cleanup. Tag or bundle before destructive branch deletes (`git tag backup/<branch>-YYYY-MM-DD <branch>`; `git bundle create ..\baklog-backups\pre-reset.bundle --all`).
 

--- a/scripts/close-worktree.ps1
+++ b/scripts/close-worktree.ps1
@@ -1,0 +1,86 @@
+# Tear down a worktree after its branch is squash-merged.
+#
+# Removes the worktree folder, deletes the local branch, deletes the remote
+# branch, then prunes stale worktree + remote-tracking refs. This is the
+# "always delete after merge" rule as one command.
+#
+# Usage (from repo root):
+#   .\scripts\close-worktree.ps1 feat/ads-polish
+#   .\scripts\close-worktree.ps1 feat/ads-polish -KeepRemote   # leave origin branch
+#   .\scripts\close-worktree.ps1 feat/ads-polish -Force        # unmerged: force-delete
+#   .\scripts\close-worktree.ps1 feat/ads-polish -DryRun       # show what would happen
+#
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$Branch,
+    [switch]$KeepRemote,
+    [switch]$Force,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+Set-Location $RepoRoot
+
+function Step($desc, $cmd) {
+    if ($DryRun) {
+        Write-Host "[dry-run] $desc" -ForegroundColor Yellow
+        Write-Host "          $cmd" -ForegroundColor DarkGray
+    } else {
+        Write-Host "--- $desc ---" -ForegroundColor Cyan
+        Invoke-Expression $cmd
+    }
+}
+
+# --- Locate the worktree folder bound to this branch ----------------------
+$WorktreePath = $null
+$cur = $null
+foreach ($line in (git worktree list --porcelain)) {
+    if ($line -like "worktree *") { $cur = $line.Substring(9) }
+    elseif ($line -like "branch *") {
+        $ref = $line.Substring(7)   # refs/heads/<branch>
+        if ($ref -eq "refs/heads/$Branch") { $WorktreePath = $cur }
+    }
+}
+
+if ($WorktreePath -and ((Resolve-Path $WorktreePath).Path -eq $RepoRoot)) {
+    Write-Host "Refusing to remove the primary worktree (you're on '$Branch' in the main folder)." -ForegroundColor Red
+    Write-Host "Switch the main worktree to 'main' first." -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host ""
+Write-Host "BAKLOG close-worktree" -ForegroundColor Cyan
+Write-Host "  Branch:   $Branch"
+Write-Host "  Folder:   $(if ($WorktreePath) { $WorktreePath } else { '(no worktree found - branch only)' })"
+Write-Host "  Remote:   $(if ($KeepRemote) { 'keep' } else { 'delete origin/' + $Branch })"
+Write-Host ""
+
+# --- Remove the worktree --------------------------------------------------
+if ($WorktreePath) {
+    $rmFlag = if ($Force) { " --force" } else { "" }
+    Step "Removing worktree" "git worktree remove `"$WorktreePath`"$rmFlag"
+} else {
+    Write-Host "No worktree bound to '$Branch' (deleting branch only)." -ForegroundColor Yellow
+}
+
+# --- Delete local + remote branch -----------------------------------------
+$delFlag = if ($Force) { "-D" } else { "-d" }
+Step "Deleting local branch" "git branch $delFlag $Branch"
+
+if (-not $KeepRemote) {
+    Step "Deleting remote branch" "git push origin --delete $Branch"
+}
+
+# --- Prune stale refs -----------------------------------------------------
+Step "Pruning worktrees" "git worktree prune"
+Step "Pruning remote-tracking refs" "git fetch --prune"
+
+Write-Host ""
+if ($DryRun) {
+    Write-Host "Dry run complete - nothing changed." -ForegroundColor Yellow
+} else {
+    Write-Host "close-worktree complete." -ForegroundColor Green
+}
+Write-Host ""
+git worktree list

--- a/scripts/new-worktree.ps1
+++ b/scripts/new-worktree.ps1
@@ -1,0 +1,97 @@
+# Spin up an isolated git worktree for a parallel agent.
+#
+# One agent = one worktree = one single-purpose branch. Enforces the
+# feat/ | fix/ | chore/ naming scheme and wires up .venv / node_modules so the
+# new folder is immediately usable on Windows.
+#
+# Usage (from repo root):
+#   .\scripts\new-worktree.ps1 feat/ads-polish
+#   .\scripts\new-worktree.ps1 fix/itad-prices -From main
+#   .\scripts\new-worktree.ps1 feat/affiliate-v2 -FreshVenv   # clean venv instead of a junction
+#   .\scripts\new-worktree.ps1 chore/deps -NoLink             # skip .venv / node_modules linking
+#
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$Branch,
+    [string]$From = "main",
+    [switch]$FreshVenv,
+    [switch]$NoLink
+)
+
+$ErrorActionPreference = "Stop"
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$ParentDir = Split-Path -Parent $RepoRoot
+Set-Location $RepoRoot
+
+# --- Validate branch name -------------------------------------------------
+if ($Branch -notmatch '^(feat|fix|chore)/[a-z0-9][a-z0-9._-]*$') {
+    Write-Host "Rejected branch name: '$Branch'" -ForegroundColor Red
+    Write-Host "Use one concern per branch with a prefix: feat/ , fix/ , or chore/" -ForegroundColor Yellow
+    Write-Host "  e.g. feat/pro-debug-url   (not 'pro-debug-url')" -ForegroundColor Yellow
+    exit 1
+}
+
+$slug = ($Branch -replace '^(feat|fix|chore)/', '') -replace '[^a-zA-Z0-9._-]', '-'
+$WorktreePath = Join-Path $ParentDir "baklog-$slug"
+
+if (Test-Path $WorktreePath) {
+    Write-Host "Path already exists: $WorktreePath" -ForegroundColor Red
+    exit 1
+}
+
+$branchExists = (git branch --list $Branch)
+if ($branchExists) {
+    Write-Host "Branch '$Branch' already exists. Pick a fresh name or close the old worktree first." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host ""
+Write-Host "BAKLOG new-worktree" -ForegroundColor Cyan
+Write-Host "  Branch:   $Branch (from $From)"
+Write-Host "  Folder:   $WorktreePath"
+Write-Host ""
+
+# --- Refresh base + create the worktree -----------------------------------
+Write-Host "--- Fetching origin ---" -ForegroundColor Cyan
+git fetch origin --prune 2>$null
+
+Write-Host "--- Creating worktree ---" -ForegroundColor Cyan
+git worktree add -b $Branch $WorktreePath $From
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "git worktree add failed." -ForegroundColor Red
+    exit 1
+}
+
+# --- Wire up dependencies so the folder is usable -------------------------
+if (-not $NoLink) {
+    # .venv: a junction is instant and works because BAKLOG runs scripts from
+    # the worktree root (sys.path[0] wins over the editable install path).
+    $srcVenv = Join-Path $RepoRoot ".venv"
+    $dstVenv = Join-Path $WorktreePath ".venv"
+    if ($FreshVenv) {
+        Write-Host "--- Building fresh .venv ---" -ForegroundColor Cyan
+        py -3.13 -m venv $dstVenv
+        & (Join-Path $dstVenv "Scripts\python.exe") -m pip install -e "$WorktreePath[dev]"
+    } elseif (Test-Path $srcVenv) {
+        Write-Host "--- Linking .venv (junction) ---" -ForegroundColor Cyan
+        New-Item -ItemType Junction -Path $dstVenv -Value $srcVenv | Out-Null
+    } else {
+        Write-Host "No .venv to link (run: py -3.13 -m venv .venv; .\.venv\Scripts\pip install -e '.[dev]')" -ForegroundColor Yellow
+    }
+
+    # node_modules: junction the existing install so npm test works immediately.
+    $srcNode = Join-Path $RepoRoot "node_modules"
+    $dstNode = Join-Path $WorktreePath "node_modules"
+    if (Test-Path $srcNode) {
+        Write-Host "--- Linking node_modules (junction) ---" -ForegroundColor Cyan
+        New-Item -ItemType Junction -Path $dstNode -Value $srcNode | Out-Null
+    }
+}
+
+Write-Host ""
+Write-Host "Worktree ready." -ForegroundColor Green
+Write-Host "  cd `"$WorktreePath`""
+Write-Host "  Point one agent here; keep it to this single concern."
+Write-Host "  When merged:  .\scripts\close-worktree.ps1 $Branch"
+Write-Host ""
+git worktree list


### PR DESCRIPTION
Adds new-worktree.ps1 and close-worktree.ps1 plus AGENTS.md wiring for one-agent-one-worktree workflow.

Made with [Cursor](https://cursor.com)