### PR TITLE
feat: itch dashboard card affiliate polish

### DIFF
--- a/app.css
+++ b/app.css
@@ -6088,6 +6088,19 @@ html[data-init-view="wishlist"] .steal-list-footer-passive { display: none; }
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  /* Permanent affiliate accent: itch is our affiliate, so the card always wears
+     a pink border whether or not the user has connected it. */
+  border: 1px solid color-mix(in srgb, var(--brand-itch, #fa5c5c) 55%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--brand-itch, #fa5c5c) 18%, transparent);
+}
+/* Not connected yet: dim the card to read as inactive, but keep the pink border. */
+.dash-card-itch--inactive {
+  opacity: 0.72;
+  filter: saturate(0.9);
+}
+.dash-card-itch--inactive:hover {
+  opacity: 1;
+  filter: none;
 }
 .dash-itch-recap { color: #cbd5e1; line-height: 1.5; display: flex; flex-direction: column; gap: 0.65rem; flex: 1; min-height: 0; padding: 0 18px 16px; }
 .itch-card-rail {

--- a/js/dashboard-cards.js
+++ b/js/dashboard-cards.js
@@ -26,6 +26,7 @@ import { DASH_STORE_LABELS, DASH_STORE_COLORS } from './dashboard-shared.js';
 import { dashDrillItchGenre } from './dashboard-drilldown.js';
 import { dashboardCharts } from './dashboard-charts.js';
 import { computeRecentAdditions } from './dashboard-spotlight.js';
+import { isItchTabAvailable, connectedProviderCount } from './connections-status.js';
 
 const ITCH_HERO_MIN_RATING = 80;
 const ITCH_HERO_MAX = 30;
@@ -215,10 +216,22 @@ export function renderDashboardCoopSpotlight(games) {
   `;
 }
 
-/** itch recap card is always visible on the picks row (onboarding when library is empty). */
+/**
+ * itch recap card visibility + affiliate dimming.
+ * - Hidden only on a truly-empty new profile (no data, nothing connected) so a
+ *   brand-new dashboard isn't cluttered by an affiliate promo.
+ * - Dimmed (inactive) when itch itself isn't set up yet — the onboarding state —
+ *   while keeping the permanent pink affiliate border.
+ */
 export function applyItchVisibility() {
   document.getElementById("dashboardPicksRow")?.classList.remove("no-itch");
-  document.getElementById("dashItchCard")?.classList.remove("hidden");
+  const card = document.getElementById("dashItchCard");
+  if (!card) return;
+  const itchActive = isItchTabAvailable();
+  const hasAnyData = (state.games || []).length > 0 || (state.itchGames || []).length > 0;
+  const trulyEmpty = !itchActive && !hasAnyData && connectedProviderCount() === 0;
+  card.classList.toggle("hidden", trulyEmpty);
+  card.classList.toggle("dash-card-itch--inactive", !itchActive);
 }
 
 export function renderDashboardSponsoredPick() {

--- a/tests/dashboard-picks-row.test.js
+++ b/tests/dashboard-picks-row.test.js
@@ -66,23 +66,36 @@ describe('dashboard picks row', () => {
     expect(itchTab).toMatch(/\bhidden\b/);
   });
 
-  it('keeps itch card visible when itch library is empty', () => {
+  it('hides the itch card on a truly-empty new profile', async () => {
+    const { setAuthStatusSnapshot } = await import('../js/connections-status.js');
+    setAuthStatusSnapshot([]);
+    state.itchGames = [];
+    state.games = [];
     applyItchVisibility();
-    const row = document.getElementById('dashboardPicksRow');
     const itch = document.getElementById('dashItchCard');
-    const recent = document.getElementById('dashRecentCard');
-    expect(row.classList.contains('no-itch')).toBe(false);
-    expect(itch.classList.contains('hidden')).toBe(false);
-    expect(recent.classList.contains('hidden')).toBe(false);
+    expect(itch.classList.contains('hidden')).toBe(true);
   });
 
-  it('still keeps itch card visible when itch data exists', () => {
+  it('shows the itch card dimmed when something else is connected but itch is not', async () => {
+    const { setAuthStatusSnapshot } = await import('../js/connections-status.js');
+    setAuthStatusSnapshot([{ key: 'steam', status: 'connected' }]);
+    state.itchGames = [];
+    applyItchVisibility();
+    const itch = document.getElementById('dashItchCard');
+    expect(itch.classList.contains('hidden')).toBe(false);
+    expect(itch.classList.contains('dash-card-itch--inactive')).toBe(true);
+  });
+
+  it('shows the itch card active (not dimmed) when itch data exists', async () => {
+    const { setAuthStatusSnapshot } = await import('../js/connections-status.js');
+    setAuthStatusSnapshot([]);
     state.itchGames = [{ store: 'itch', id: 'a', name: 'Demo' }];
     applyItchVisibility();
     const row = document.getElementById('dashboardPicksRow');
     const itch = document.getElementById('dashItchCard');
     expect(row.classList.contains('no-itch')).toBe(false);
     expect(itch.classList.contains('hidden')).toBe(false);
+    expect(itch.classList.contains('dash-card-itch--inactive')).toBe(false);
   });
 
   it('renders onboarding copy when itch library is empty', async () => {


### PR DESCRIPTION
Hide itch card on truly-empty profiles, dim when itch not connected, permanent pink affiliate border.

Made with [Cursor](https://cursor.com)