### PR TITLE
fix: fetch real Epic playtime

### DIFF
--- a/epic_client.py
+++ b/epic_client.py
@@ -38,6 +38,10 @@ def default_epic_cache_dir() -> Path:
 
 OAUTH_URL = "https://account-public-service-prod.ol.epicgames.com/account/api/oauth/token"
 LIBRARY_URL = "https://library-service.live.use1a.on.epicgames.com/library/api/public/items"
+PLAYTIME_ALL_URL = (
+    "https://library-service.live.use1a.on.epicgames.com"
+    "/library/api/public/playtime/account/{account_id}/all"
+)
 CATALOG_HOST = "catalog-public-service-prod06.ol.epicgames.com"
 LOGIN_URL = (
     "https://www.epicgames.com/id/api/redirect"
@@ -250,6 +254,40 @@ class EpicClient:
             if not cursor:
                 break
         return records
+
+    def get_playtime(self) -> dict[str, int]:
+        """Total tracked playtime per artifact (appName), in seconds.
+
+        Epic's library service tracks playtime keyed by ``artifactId`` which
+        matches the entitlement ``appName``. Returns {} on any failure so a
+        missing/empty playtime feed never breaks the library fetch.
+        """
+        if not self._account_id:
+            return {}
+        self._throttle()
+        try:
+            resp = self.session.get(
+                PLAYTIME_ALL_URL.format(account_id=self._account_id),
+                headers=self._auth_headers(),
+                timeout=30,
+            )
+            if resp.status_code == 401:
+                raise EpicAuthError("Playtime 401: access token expired")
+            resp.raise_for_status()
+            data = resp.json()
+        except EpicAuthError:
+            raise
+        except Exception:
+            return {}
+        out: dict[str, int] = {}
+        for row in data if isinstance(data, list) else []:
+            if not isinstance(row, dict):
+                continue
+            artifact = row.get("artifactId")
+            total = row.get("totalTime")
+            if artifact and isinstance(total, (int, float)) and total > 0:
+                out[str(artifact)] = int(total)
+        return out
 
     def get_catalog_item(
         self, namespace: str, catalog_id: str, country: str = "US", locale: str = "en-US"

--- a/fetch_epic.py
+++ b/fetch_epic.py
@@ -439,6 +439,17 @@ def main() -> int:
         flush=True,
     )
 
+    # Epic tracks playtime per artifact (== entitlement appName), separate from
+    # the library/catalog feed. Pull it once; non-fatal if the feed is empty or
+    # unavailable so a playtime hiccup never blocks the library refresh.
+    playtime_by_artifact: dict[str, int] = {}
+    try:
+        playtime_by_artifact = client.get_playtime()
+    except EpicAuthError as e:
+        stats.warn(f"playtime: {e}")
+    if playtime_by_artifact:
+        print(f"  playtime tracked for {len(playtime_by_artifact)} titles", flush=True)
+
     empty_exit = refuse_empty_result(
         apps,
         label="Epic library",
@@ -494,6 +505,25 @@ def main() -> int:
         print(f"  catalog hits: {len(catalog)}/{len(apps_needing_catalog)}")
     elif catalog_skipped:
         print(f"  catalog: all {catalog_skipped} entitlements reused from cache (no API calls)", flush=True)
+
+    # Sum playtime seconds per (namespace, title) so editions/DLC entitlements
+    # that collapse into one library row (e.g. cross-edition Fortnite) report
+    # their combined time — mirrors the PSN cross-gen playtime fix.
+    playtime_sec_by_key: dict[tuple[str, str], int] = {}
+    if playtime_by_artifact:
+        for rec in apps:
+            secs = playtime_by_artifact.get(str(rec.get("appName")))
+            if not secs:
+                continue
+            ns = str(rec.get("namespace"))
+            item = catalog.get((ns, str(rec.get("catalogItemId"))))
+            nm = (
+                (item or {}).get("title")
+                or rec.get("sandboxName")
+                or rec.get("appName")
+                or str(rec.get("catalogItemId"))
+            ).strip().lower()
+            playtime_sec_by_key[(ns, nm)] = playtime_sec_by_key.get((ns, nm), 0) + int(secs)
 
     hltb_client = HltbClient()
     games_out: list[dict] = []
@@ -597,6 +627,16 @@ def main() -> int:
         key_fn=row_key_by_id,
         no_carry=args.no_carry,
     )
+
+    if playtime_sec_by_key:
+        playtime_applied = 0
+        for g in games_out:
+            key = (str(g.get("epic_namespace")), (g.get("name") or "").strip().lower())
+            secs = playtime_sec_by_key.get(key)
+            if secs:
+                g["playtime_minutes"] = int(round(secs / 60))
+                playtime_applied += 1
+        print(f"  applied playtime to {playtime_applied} games", flush=True)
 
     payload = {
         "fetched_at": datetime.now(UTC).isoformat(),

--- a/tests/test_fetch_epic.py
+++ b/tests/test_fetch_epic.py
@@ -141,3 +141,48 @@ def test_needs_catalog_fetch_for_non_game_cached_row() -> None:
         }
     }
     assert _needs_catalog_fetch(rec, existing, _args())
+
+
+class _PlaytimeResp:
+    status_code = 200
+
+    def __init__(self, payload: object) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> object:
+        return self._payload
+
+
+def _playtime_client(payload: object, account_id: str | None = "acc"):
+    from epic_client import EpicClient
+
+    client = object.__new__(EpicClient)
+    client._account_id = account_id
+    client._access_token = "tok"
+    client._throttle = lambda: None  # type: ignore[method-assign]
+
+    class _Sess:
+        def get(self, *a, **k):
+            return _PlaytimeResp(payload)
+
+    client.session = _Sess()
+    return client
+
+
+def test_get_playtime_parses_and_filters_zero_and_junk() -> None:
+    client = _playtime_client([
+        {"artifactId": "a", "totalTime": 3600},
+        {"artifactId": "b", "totalTime": 0},
+        {"artifactId": "c"},
+        {"noId": True},
+        "junk",
+    ])
+    assert client.get_playtime() == {"a": 3600}
+
+
+def test_get_playtime_without_account_returns_empty() -> None:
+    client = _playtime_client([{"artifactId": "a", "totalTime": 99}], account_id=None)
+    assert client.get_playtime() == {}


### PR DESCRIPTION
Epic hardcoded playtime to 0; now pulls the per-artifact playtime feed and sums across collapsed entitlements.

Made with [Cursor](https://cursor.com)