### PR TITLE
fix: exclude local launchers from auto-fetch

### DIFF
--- a/fetchers/manifest.json
+++ b/fetchers/manifest.json
@@ -22,7 +22,8 @@
       "args": ["--skip-hltb"],
       "refreshArgs": ["--refresh"],
       "metaKey": "gog",
-      "color": "#6d28d9"
+      "color": "#6d28d9",
+      "autoFetch": false
     },
     {
       "key": "psn",
@@ -46,7 +47,7 @@
       "color": "#64748b",
       "requires": [{ "env": "EPIC_AUTH_CODE", "note": "OAuth auth code — run fetch_epic.py --auth-help" }]
     },
-    { "key": "amazon", "label": "Amazon", "group": "library", "script": "fetch_amazon.py", "args": ["--skip-hltb"], "metaKey": "amazon", "color": "#c2410c" },
+    { "key": "amazon", "label": "Amazon", "group": "library", "script": "fetch_amazon.py", "args": ["--skip-hltb"], "metaKey": "amazon", "color": "#c2410c", "autoFetch": false },
     {
       "key": "xbox",
       "label": "Xbox",

--- a/fetchers/registry.py
+++ b/fetchers/registry.py
@@ -151,6 +151,20 @@ def _script_flags(script: str) -> set[str]:
     return flags
 
 
+def no_auto_fetch_keys(path: Path | None = None) -> list[str]:
+    """Fetcher keys marked autoFetch:false (local launchers — need the app open).
+
+    Launcher-backed sources (GOG Galaxy, Amazon Games) scan a locally installed
+    client, so they can't refresh unattended like web/API stores. Auto-refresh
+    (browser loop + background scheduler) skips them.
+    """
+    return sorted(
+        e["key"]
+        for e in manifest_entries(path)
+        if e.get("key") and e.get("autoFetch") is False
+    )
+
+
 def export_js_registry(out_path: Path | None = None) -> None:
     """Write js/fetcher-registry.js for the browser bundle."""
     out = out_path or bundle_root() / "js" / "fetcher-registry.js"
@@ -161,6 +175,7 @@ def export_js_registry(out_path: Path | None = None) -> None:
         "enrichFetcherKeys": sorted(ENRICH_FETCHER_KEYS),
         "enrichReloadWishlistKeys": sorted(ENRICH_RELOAD_WISHLIST_KEYS),
         "authProviderByKey": AUTH_PROVIDER_BY_KEY,
+        "noAutoFetchKeys": no_auto_fetch_keys(),
     }
     lines = [
         "// Generated from fetchers/registry.py — keep in sync with manifest maps.",
@@ -177,6 +192,8 @@ def export_js_registry(out_path: Path | None = None) -> None:
         f"export const ENRICH_RELOAD_WISHLIST_KEYS = new Set({json.dumps(payload['enrichReloadWishlistKeys'])});",
         "",
         f"export const FETCHER_AUTH_PROVIDER = {json.dumps(payload['authProviderByKey'], indent=2)};",
+        "",
+        f"export const NO_AUTO_FETCH_KEYS = new Set({json.dumps(payload['noAutoFetchKeys'])});",
         "",
     ]
     out.write_text("\n".join(lines), encoding="utf-8")

--- a/js/fetcher-auto-refresh.js
+++ b/js/fetcher-auto-refresh.js
@@ -2,7 +2,7 @@
  * Auto-refresh scheduling: ITAD, claims, stale-24h, connect, enrich.
  */
 import { markClaimsPendingAutoRun } from './claimable.js';
-import { FETCHER_AUTH_PROVIDER } from './fetcher-registry.js';
+import { FETCHER_AUTH_PROVIDER, NO_AUTO_FETCH_KEYS } from './fetcher-registry.js';
 import { fetcherRunner, fetcherSources } from './fetcher-health-shared.js';
 import {
   LS_AUTO_STALE_LAST_RUN,
@@ -170,6 +170,9 @@ export function maybeAutoFetchStale24h(deps = {}) {
 
   const candidates = sources.filter((src) => {
     if (src.key === 'itad') return false;
+    // Local launchers (GOG Galaxy, Amazon) can't refresh unattended — only
+    // web/API stores auto-fetch. See fetchers/manifest.json autoFetch:false.
+    if (NO_AUTO_FETCH_KEYS.has(src.key)) return false;
     if (!FETCHER_AUTH_PROVIDER[src.key]) return false;
     const { ageMs } = freshnessFn(src);
     if (ageMs < AUTO_STALE_AGE_MS) return false;

--- a/js/fetcher-registry.js
+++ b/js/fetcher-registry.js
@@ -65,3 +65,5 @@ export const FETCHER_AUTH_PROVIDER = {
   "wishlistHumble": "humble",
   "itad": "itad"
 };
+
+export const NO_AUTO_FETCH_KEYS = new Set(["amazon", "gog"]);

--- a/scheduler.py
+++ b/scheduler.py
@@ -159,6 +159,8 @@ class BackgroundScheduler:
         for key, spec in self._fetchers.items():
             if spec.get("group") != "library":
                 continue
+            if spec.get("autoFetch") is False:
+                continue  # local launcher (GOG Galaxy, Amazon) — needs the app open
             if not platform_supported(spec.get("platforms")):
                 continue
             if self._missing_requirements(spec.get("requires") or []):

--- a/tests/auto-fetch.test.js
+++ b/tests/auto-fetch.test.js
@@ -259,9 +259,11 @@ describe('maybeAutoFetchStale24h', () => {
     expect(runFn).not.toHaveBeenCalled();
   });
 
-  it('picks the stalest eligible store fetcher', () => {
+  it('picks the stalest eligible store fetcher, skipping local launchers', () => {
     const runFn = vi.fn();
     const setLastRun = vi.fn();
+    // gog is the stalest but is a local launcher (autoFetch:false), so the next
+    // stalest web store (steam) wins instead.
     const freshness = (src) => ({
       ageMs: src.key === 'gog' ? AUTO_STALE_AGE_MS + 50_000 : AUTO_STALE_AGE_MS + 10_000,
     });
@@ -281,8 +283,31 @@ describe('maybeAutoFetchStale24h', () => {
       runFn,
     });
     expect(ok).toBe(true);
-    expect(runFn).toHaveBeenCalledWith('gog', { auto: true });
+    expect(runFn).toHaveBeenCalledWith('steam', { auto: true });
     expect(setLastRun).toHaveBeenCalled();
+  });
+
+  it('does not auto-fetch a local launcher even when it is the only stale store', () => {
+    const runFn = vi.fn();
+    const ok = maybeAutoFetchStale24h({
+      isApiAvailable: () => true,
+      inFlightCount: () => 0,
+      now: Date.now(),
+      getLastRun: () => 0,
+      setLastRun: vi.fn(),
+      sources: [
+        { key: 'gog', label: 'GOG', group: 'library', metaKey: 'gog', missingRequirements: [] },
+      ],
+      fetcherFreshness: () => ({ ageMs: AUTO_STALE_AGE_MS + 99_999 }),
+      fetcherCredentialsSatisfied: () => true,
+      stateFor: () => null,
+      authCooldownRemainingMs: () => 0,
+      isFetcherDisconnected: () => false,
+      isFetcherReconnectRequired: () => false,
+      runFn,
+    });
+    expect(ok).toBe(false);
+    expect(runFn).not.toHaveBeenCalled();
   });
 
   it('still runs while the page is hidden (minimized/unfocused window)', () => {

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -174,6 +174,38 @@ def test_skips_fetcher_on_auth_cooldown(monkeypatch):
     assert mgr.submitted == []
 
 
+def test_skips_auto_fetch_disabled_launcher(monkeypatch):
+    # A local launcher (autoFetch:false) is the stalest store but must never be
+    # enqueued by the background scheduler; the fresh web store is not stale.
+    monkeypatch.setattr(
+        sched,
+        "_catalog_age_sec",
+        lambda mk, pid, now: {
+            "amazon": sched.DEFAULT_STALE_AGE_SEC + 9999,
+            "steam": 10,
+        }.get(mk, 10),
+    )
+    fetchers = {
+        "steam": {"group": "library", "metaKey": "steam", "requires": [], "platforms": []},
+        "amazon": {
+            "group": "library",
+            "metaKey": "amazon",
+            "requires": [],
+            "platforms": [],
+            "autoFetch": False,
+        },
+    }
+    mgr = FakeManager()
+    s = sched.BackgroundScheduler(
+        manager=mgr,
+        fetchers=fetchers,
+        missing_requirements=lambda reqs: list(reqs),
+        is_pro_fn=lambda: True,
+    )
+    assert s.tick(now=time.time()) is None
+    assert mgr.submitted == []
+
+
 def test_enrichers_and_prices_never_eligible(monkeypatch):
     _set_ages(
         monkeypatch,


### PR DESCRIPTION
GOG Galaxy and Amazon (local launchers) no longer auto-refresh in the browser loop or background scheduler; only web/API stores do.

Made with [Cursor](https://cursor.com)