### PR TITLE
feat: add favorite developer insight

### DIFF
--- a/js/dashboard-insights.js
+++ b/js/dashboard-insights.js
@@ -317,6 +317,16 @@ export function buildInsightPool(games, snapIn, ctxIn) {
     add(`Most played: <strong>${escapeHtml(byPlay[0].name)}</strong> · ${escapeHtml(formatNum(hrs))}h`);
   }
 
+  const devCounts = {};
+  for (const g of games) {
+    const ng = normalizeGame(g);
+    (ng.developers || g.developers || []).forEach(d => { if (d) devCounts[d] = (devCounts[d] || 0) + 1; });
+  }
+  const favDev = Object.entries(devCounts).sort((a, b) => b[1] - a[1])[0];
+  if (favDev && favDev[1] > 1) {
+    add(`Favorite developer: <strong>${escapeHtml(favDev[0])}</strong> · ${escapeHtml(formatNum(favDev[1]))} games`, METRIC_WEIGHT.moderate);
+  }
+
   const hltbVals = ctxIn ? ctxIn.hltbVals : backlog.map(g => hltbMain(g)).filter(h => h != null && h > 0);
   if (hltbVals.length) {
     const avg = Math.round(hltbVals.reduce((s, h) => s + h, 0) / hltbVals.length);

--- a/js/metric-tips.js
+++ b/js/metric-tips.js
@@ -237,6 +237,7 @@ export const METRIC_TIPS = {
   // Insight-only concepts (leading text before colon)
   'Biggest backlog': 'Genre with the most backlog HLTB hours stacked up.',
   'Most played': 'Game with the highest combined playtime.',
+  'Favorite developer': 'The developer with the most games in your library.',
   'Avg HLTB main': 'Average main-story HLTB hours across backlog games.',
   'Longest unplayed': 'Longest HLTB backlog game you have never played.',
   'Top deal': 'Wishlist item with the best deal score right now.',

--- a/js/stat-families.js
+++ b/js/stat-families.js
@@ -109,7 +109,7 @@ export function familyForLabel(label) {
   }
 
   if (matchesAny(l, [
-    'top genre', 'top decade', 'top developer', 'top publisher', 'top store',
+    'top genre', 'top decade', 'top developer', 'favorite developer', 'top publisher', 'top store',
     'biggest store', 'oldest in library', 'newest release', 'oldest unplayed',
     'newest add', 'missing a', 'missing a–z', 'taste era', 'finished vs backlog era',
     'one-hit dev', 'monogamy', 'playtime in', 'diagnosis', 'a-z', 'top tag',


### PR DESCRIPTION
Surfaces the developer with the most games in the library as a dashboard insight (with tip + IDENTITY family).

Made with [Cursor](https://cursor.com)