### PR TITLE
fix: row ad shows on drill and rotates

### DIFF
--- a/js/sponsored-deals.js
+++ b/js/sponsored-deals.js
@@ -178,6 +178,18 @@ function sessionStartForLocation(locationKey, eligibleLen) {
   return sessionLocationPicks.get(locationKey).start;
 }
 
+/**
+ * Drop the cached session pick for a location so the next getAdsForLocation()
+ * advances the round-robin cursor to the next eligible creative. Used by the
+ * table so each drill-in / filter shows a fresh row ad instead of pinning the
+ * same one for the whole session.
+ * @param {string} locationKey
+ */
+export function rotateLocationAd(locationKey) {
+  const key = String(locationKey || '').toLowerCase();
+  if (key) sessionLocationPicks.delete(key);
+}
+
 export function pickLocationForView(view, kind = 'pick') {
   const v = String(view || 'library').toLowerCase();
   if (kind === 'row') {

--- a/js/table-ui.js
+++ b/js/table-ui.js
@@ -56,7 +56,7 @@ import {
 } from './deals.js';
 import { isPlatformToken } from './genres.js';
 import { syncCoverFits } from './covers.js';
-import { getAdsForLocation, pickLocationForView, sponsoredTableRowHtml } from './sponsored-deals.js';
+import { getAdsForLocation, pickLocationForView, rotateLocationAd, sponsoredTableRowHtml } from './sponsored-deals.js';
 import {
   getPersonal,
   setPersonal,
@@ -1143,11 +1143,16 @@ function appendChunk(list, start, end, ctx) {
   const t0 = run ? performance.now() : 0;
   const out = [];
   const rowLoc = resolveTableRowLocation();
-  const tableAd = SPONSORED_TABLE_SLOT >= start && SPONSORED_TABLE_SLOT < end
+  // Anchor the ad to the fixed slot, but on short (drilled) lists fall back to
+  // the last row so the row ad still appears instead of being dropped because
+  // index 5 was never rendered.
+  const total = list.length;
+  const slot = total > SPONSORED_TABLE_SLOT ? SPONSORED_TABLE_SLOT : Math.max(0, total - 1);
+  const tableAd = total > 0 && slot >= start && slot < end
     ? getAdsForLocation(rowLoc)[0]
     : null;
   for (let i = start; i < end; i++) {
-    if (tableAd && i === SPONSORED_TABLE_SLOT) out.push(sponsoredTableRowHtml(tableAd, { ...ctx, locationKey: rowLoc }));
+    if (tableAd && i === slot) out.push(sponsoredTableRowHtml(tableAd, { ...ctx, locationKey: rowLoc }));
     out.push(tableRowHtml(list[i], i, ctx));
   }
   const html = out.join("");
@@ -1454,6 +1459,10 @@ export async function renderTable(opts) {
     return;
   }
   noteTableRender();
+  // Rotate the row ad on each real (re)render — drill-ins, filters, sorts — so
+  // it isn't pinned to one creative all session. Scroll re-renders go through
+  // the virtual-window path (not renderTable), so this never flickers mid-scroll.
+  rotateLocationAd(resolveTableRowLocation());
   const loaderToken = drillIn ? 0 : beginRowLoader();
   try {
   // drillIn uses the view overlay; in-tab filter/sort uses the row pill only

--- a/tests/sponsored-deals.test.js
+++ b/tests/sponsored-deals.test.js
@@ -12,6 +12,7 @@ import {
   getEligibleSponsoredDeal,
   getEligibleSponsors,
   getAdsForLocation,
+  rotateLocationAd,
   getSpotlightHouseAds,
   setSpotlightHouseAdsForTest,
   itemPlacements,
@@ -224,6 +225,20 @@ describe('getAdsForLocation round-robin', () => {
     ));
     localStorage.setItem('baklog-ad-cursors', JSON.stringify({ 'lib-pick': 1 }));
     expect(getAdsForLocation('lib-pick')[0].id).toBe('b');
+  });
+
+  it('rotateLocationAd advances to the next ad within a session', () => {
+    __setSponsorsForTest(v2Doc(
+      { a: sponsor({ id: 'a', title: 'A' }), b: sponsor({ id: 'b', title: 'B' }) },
+      { 'lib-row': ['a', 'b'] },
+    ));
+    expect(getAdsForLocation('lib-row')[0].id).toBe('a');
+    // Without a rotate, the session pick stays pinned to 'a'.
+    expect(getAdsForLocation('lib-row')[0].id).toBe('a');
+    rotateLocationAd('lib-row');
+    expect(getAdsForLocation('lib-row')[0].id).toBe('b');
+    rotateLocationAd('lib-row');
+    expect(getAdsForLocation('lib-row')[0].id).toBe('a');
   });
 
   it('returns up to three claim-cards', () => {


### PR DESCRIPTION
Anchors the table ad to the last row on small drilldowns so it no longer vanishes, and rotates the row ad per render instead of pinning one creative all session.

Made with [Cursor](https://cursor.com)