### PR TITLE
fix: keep dashboard marquee stable with sparse/empty data

### DIFF
--- a/app.css
+++ b/app.css
@@ -5074,16 +5074,33 @@ html[data-theme="dark"] .dash-spotlight.has-portrait-art .dash-spotlight-art-bg 
 .dash-marquee-track {
   --marquee-duration: 180s;
   display: inline-flex;
-  gap: 28px;
+  gap: 0;
   white-space: nowrap;
   animation: dashMarquee var(--marquee-duration) linear infinite;
   will-change: transform;
+}
+/* Each copy carries the chip spacing plus a trailing gap so the loop seam
+   (copy1 -> copy2) is spaced identically to the internal chip gaps. */
+.dash-marquee-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 28px;
+  padding-right: 28px;
 }
 .dash-marquee:hover .dash-marquee-track { animation-play-state: paused; }
 @keyframes dashMarquee {
   from { transform: translateX(0); }
   to { transform: translateX(-50%); }
 }
+/* Too few chips to fill the bar (sparse/empty data): center them and stop the
+   scroll so the seamless loop never leaves a visible gap or jump. */
+.dash-marquee--static .dash-marquee-track {
+  animation: none;
+  width: 100%;
+  justify-content: center;
+}
+.dash-marquee--static .dash-marquee-copy { padding-right: 0; }
+.dash-marquee--static .dash-marquee-copy[aria-hidden="true"] { display: none; }
 .dash-marquee-item {
   display: inline-flex;
   align-items: center;

--- a/js/dashboard-insights.js
+++ b/js/dashboard-insights.js
@@ -1215,7 +1215,9 @@ export function renderMarqueeTrackInner(items) {
       <span class="dash-marquee-label">${escapeHtml(it.label)}</span>
     </span>`;
   }).join('');
-  return `${itemHtml}${itemHtml}`;
+  // Two identical copies so the -50% scroll loops seamlessly. Wrapping each copy
+  // lets the static (too-few-chips) path hide the duplicate and center the rest.
+  return `<span class="dash-marquee-copy">${itemHtml}</span><span class="dash-marquee-copy" aria-hidden="true">${itemHtml}</span>`;
 }
 
 export function renderMarqueeHtml(items) {

--- a/js/marquee-speed.js
+++ b/js/marquee-speed.js
@@ -14,10 +14,23 @@ function scopeEl(rootEl) {
 
 /** Set --marquee-duration from measured track width for constant px/s. */
 export function applyMarqueeSpeed(rootEl = document) {
-  const track = scopeEl(rootEl).querySelector('.dash-marquee-track');
+  const scope = scopeEl(rootEl);
+  const track = scope.querySelector('.dash-marquee-track');
   if (!track) return;
-  const copyWidth = track.scrollWidth / 2;
+  const firstCopy = track.querySelector('.dash-marquee-copy');
+  const copyWidth = firstCopy ? firstCopy.scrollWidth : track.scrollWidth / 2;
   if (!copyWidth) return;
+  // One copy must fill the bar for the -50% loop to be seamless. When the chips
+  // don't fill it (sparse/empty data), animating leaves a visible gap/jump — so
+  // mark the marquee static (centered, no scroll) instead.
+  const marquee = scope.querySelector('.dash-marquee');
+  const containerWidth = marquee ? marquee.clientWidth : 0;
+  const fits = containerWidth > 0 && copyWidth <= containerWidth;
+  if (marquee) marquee.classList.toggle('dash-marquee--static', fits);
+  if (fits) {
+    track.style.removeProperty('--marquee-duration');
+    return;
+  }
   track.style.setProperty('--marquee-duration', `${copyWidth / pxPerSec()}s`);
 }
 

--- a/landing/marquee-speed.js
+++ b/landing/marquee-speed.js
@@ -13,10 +13,23 @@
   }
 
   function applyMarqueeSpeed(rootEl) {
-    const track = scopeEl(rootEl).querySelector(".dash-marquee-track");
+    const scope = scopeEl(rootEl);
+    const track = scope.querySelector(".dash-marquee-track");
     if (!track) return;
-    const copyWidth = track.scrollWidth / 2;
+    const firstCopy = track.querySelector(".dash-marquee-copy");
+    const copyWidth = firstCopy ? firstCopy.scrollWidth : track.scrollWidth / 2;
     if (!copyWidth) return;
+    // One copy must fill the bar for the -50% loop to be seamless. When the
+    // chips don't fill it, animating leaves a visible gap/jump — mark the
+    // marquee static (centered, no scroll) instead.
+    const marquee = scope.querySelector(".dash-marquee");
+    const containerWidth = marquee ? marquee.clientWidth : 0;
+    const fits = containerWidth > 0 && copyWidth <= containerWidth;
+    if (marquee) marquee.classList.toggle("dash-marquee--static", fits);
+    if (fits) {
+      track.style.removeProperty("--marquee-duration");
+      return;
+    }
     track.style.setProperty("--marquee-duration", `${copyWidth / pxPerSec()}s`);
   }
 

--- a/tests/dashboard-marquee.test.js
+++ b/tests/dashboard-marquee.test.js
@@ -127,4 +127,43 @@ describe('applyMarqueeSpeed', () => {
 
     expect(track.style.getPropertyValue('--marquee-duration')).toBe('');
   });
+
+  it('marks the marquee static when one copy does not fill the bar', () => {
+    const root = document.createElement('div');
+    root.innerHTML = `
+      <div class="dash-marquee">
+        <div class="dash-marquee-track"><span class="dash-marquee-copy">a</span><span class="dash-marquee-copy" aria-hidden="true">a</span></div>
+      </div>`;
+    const marquee = root.querySelector('.dash-marquee');
+    const copy = root.querySelector('.dash-marquee-copy');
+    Object.defineProperty(copy, 'scrollWidth', { value: 200, configurable: true });
+    Object.defineProperty(marquee, 'clientWidth', { value: 800, configurable: true });
+
+    applyMarqueeSpeed(root);
+
+    expect(marquee.classList.contains('dash-marquee--static')).toBe(true);
+    expect(root.querySelector('.dash-marquee-track').style.getPropertyValue('--marquee-duration')).toBe('');
+  });
+
+  it('animates (not static) when the chips overflow the bar', () => {
+    document.documentElement.style.setProperty('--marquee-px-per-sec', String(MARQUEE_PX_PER_SEC));
+    const root = document.createElement('div');
+    root.innerHTML = `
+      <div class="dash-marquee">
+        <div class="dash-marquee-track"><span class="dash-marquee-copy">a</span><span class="dash-marquee-copy" aria-hidden="true">a</span></div>
+      </div>`;
+    const marquee = root.querySelector('.dash-marquee');
+    const copy = root.querySelector('.dash-marquee-copy');
+    Object.defineProperty(copy, 'scrollWidth', { value: 1000, configurable: true });
+    Object.defineProperty(marquee, 'clientWidth', { value: 800, configurable: true });
+
+    applyMarqueeSpeed(root);
+
+    expect(marquee.classList.contains('dash-marquee--static')).toBe(false);
+    expect(root.querySelector('.dash-marquee-track').style.getPropertyValue('--marquee-duration')).toBe(`${1000 / MARQUEE_PX_PER_SEC}s`);
+  });
+
+  it('renderMarqueeHtml returns empty string for no items (no broken marquee)', () => {
+    expect(renderMarqueeHtml([])).toBe('');
+  });
 });


### PR DESCRIPTION
## Summary
- Fixes the dashboard marquee "breaks with no data" bug: a sparse/empty set of chips no longer leaves a visible gap or jump in the scroll loop.
- Each loop copy is wrapped in `.dash-marquee-copy`, and the seam gap moves onto the copy (`padding-right`) so the `-50%` translate stays perfectly seamless.
- When one copy can't fill the bar, `applyMarqueeSpeed` marks the marquee `.dash-marquee--static` (centered, no animation) instead of animating a partial loop. Mirrored in `landing/marquee-speed.js`.
- `renderMarqueeHtml([])` still returns `''` (no broken marquee element).

## Test plan
- [x] `npx vitest run tests/dashboard-marquee.test.js` (9 passed) — added static/overflow/empty cases
- [x] `npx vitest run` full suite (108 files, 1092 passed, 7 skipped)
