### PR TITLE
fix: always-on itch card with affiliate onboarding funnel

### DIFF
--- a/app.css
+++ b/app.css
@@ -6110,15 +6110,6 @@ html[data-init-view="wishlist"] .steal-list-footer-passive { display: none; }
   border: 1px solid color-mix(in srgb, var(--brand-itch, #fa5c5c) 55%, transparent);
   box-shadow: 0 0 0 1px color-mix(in srgb, var(--brand-itch, #fa5c5c) 18%, transparent);
 }
-/* Not connected yet: dim the card to read as inactive, but keep the pink border. */
-.dash-card-itch--inactive {
-  opacity: 0.72;
-  filter: saturate(0.9);
-}
-.dash-card-itch--inactive:hover {
-  opacity: 1;
-  filter: none;
-}
 .dash-itch-recap { color: #cbd5e1; line-height: 1.5; display: flex; flex-direction: column; gap: 0.65rem; flex: 1; min-height: 0; padding: 0 18px 16px; }
 .itch-card-rail {
   height: 4px;
@@ -6167,7 +6158,27 @@ html[data-init-view="wishlist"] .steal-list-footer-passive { display: none; }
   line-height: 1.45;
 }
 .itch-onboard-affiliate { color: #fca5a5; }
-.itch-onboard-cta { align-self: flex-start; margin-top: 0.15rem; }
+.itch-onboard-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.4rem;
+  margin-top: 0.15rem;
+}
+.itch-onboard-cta { align-self: flex-start; }
+.itch-onboard-cta--primary {
+  background: color-mix(in srgb, var(--brand-itch, #fa5c5c) 22%, var(--bg-elev));
+  border-color: color-mix(in srgb, var(--brand-itch, #fa5c5c) 55%, var(--border-subtle));
+  color: #fecaca;
+  text-decoration: none;
+}
+.itch-onboard-cta--primary:hover {
+  background: color-mix(in srgb, var(--brand-itch, #fa5c5c) 32%, var(--bg-elev));
+  color: #fff;
+}
+.itch-onboard-cta--secondary {
+  opacity: 0.92;
+}
 .itch-value-block { display: flex; flex-direction: column; gap: 0.35rem; }
 .itch-value-grid {
   display: grid;

--- a/js/dashboard-cards.js
+++ b/js/dashboard-cards.js
@@ -4,7 +4,7 @@
 import { state, STATUS_CHIP_DEFS } from './state.js';
 import { escapeAttr, escapeHtml, formatNum } from './dom-util.js';
 import { gameKey, normalizeGame, hltbMain, ratingValue, hasEnoughReviews, coverFallbackFor, libraryCoverFor, sanitizeCoverUrl, itchIsGame, chipStatusKey, combinedPlaytime, storeBadgeHtml, formatDollar } from './game-core.js';
-import { hasLiveAffiliates } from './affiliate.js';
+import { affiliateUrl, hasLiveAffiliates } from './affiliate.js';
 import { freeItchCount, paidItchCount, itchSpendTotal } from './sabermetrics.js';
 import { gameGenresCanonical } from './genres.js';
 import { getPersonal } from './personal-storage.js';
@@ -26,8 +26,6 @@ import { DASH_STORE_LABELS, DASH_STORE_COLORS } from './dashboard-shared.js';
 import { dashDrillItchGenre } from './dashboard-drilldown.js';
 import { dashboardCharts } from './dashboard-charts.js';
 import { computeRecentAdditions } from './dashboard-spotlight.js';
-import { isItchTabAvailable, connectedProviderCount } from './connections-status.js';
-
 const ITCH_HERO_MIN_RATING = 80;
 const ITCH_HERO_MAX = 30;
 
@@ -216,22 +214,10 @@ export function renderDashboardCoopSpotlight(games) {
   `;
 }
 
-/**
- * itch recap card visibility + affiliate dimming.
- * - Hidden only on a truly-empty new profile (no data, nothing connected) so a
- *   brand-new dashboard isn't cluttered by an affiliate promo.
- * - Dimmed (inactive) when itch itself isn't set up yet — the onboarding state —
- *   while keeping the permanent pink affiliate border.
- */
+/** itch recap card is always visible on the picks row (onboarding when library is empty). */
 export function applyItchVisibility() {
   document.getElementById("dashboardPicksRow")?.classList.remove("no-itch");
-  const card = document.getElementById("dashItchCard");
-  if (!card) return;
-  const itchActive = isItchTabAvailable();
-  const hasAnyData = (state.games || []).length > 0 || (state.itchGames || []).length > 0;
-  const trulyEmpty = !itchActive && !hasAnyData && connectedProviderCount() === 0;
-  card.classList.toggle("hidden", trulyEmpty);
-  card.classList.toggle("dash-card-itch--inactive", !itchActive);
+  document.getElementById("dashItchCard")?.classList.remove("hidden");
 }
 
 export function renderDashboardSponsoredPick() {
@@ -495,11 +481,15 @@ function itchOnboardingHtml() {
   const affiliateNote = hasLiveAffiliates()
     ? `<p class="itch-onboard-affiliate">BAKLOG is an itch.io affiliate - your purchases help keep the app free.</p>`
     : "";
+  const browseUrl = affiliateUrl('https://itch.io/games/free');
   return `<div class="itch-onboarding">
-    <div class="itch-onboard-lead">Start earning free games today</div>
-    <p class="itch-onboard-copy">Connect itch.io on Connections and run the itch fetcher to sync your library, ratings, and indie picks here.</p>
+    <div class="itch-onboard-lead">Start collecting free games on itch.io</div>
+    <p class="itch-onboard-copy">Create a free itch.io account, claim indie games, and build a library. Connect here when you are ready to sync your collection into BAKLOG.</p>
     ${affiliateNote}
-    <button type="button" class="summary-jump-chip itch-onboard-cta" data-jump-view="connections" title="Open Connections to add your itch.io key">Connect itch.io →</button>
+    <div class="itch-onboard-actions">
+      <a class="summary-jump-chip itch-onboard-cta itch-onboard-cta--primary" href="${escapeAttr(browseUrl)}" target="_blank" rel="noopener noreferrer" title="Browse free games on itch.io">Browse free games on itch.io →</a>
+      <button type="button" class="summary-jump-chip itch-onboard-cta itch-onboard-cta--secondary" data-jump-view="connections" title="Open Connections to add your itch.io key">Already have itch? Connect it →</button>
+    </div>
   </div>`;
 }
 

--- a/tests/dashboard-picks-row.test.js
+++ b/tests/dashboard-picks-row.test.js
@@ -66,27 +66,28 @@ describe('dashboard picks row', () => {
     expect(itchTab).toMatch(/\bhidden\b/);
   });
 
-  it('hides the itch card on a truly-empty new profile', async () => {
+  it('shows the itch card on a truly-empty new profile', async () => {
     const { setAuthStatusSnapshot } = await import('../js/connections-status.js');
     setAuthStatusSnapshot([]);
     state.itchGames = [];
     state.games = [];
     applyItchVisibility();
     const itch = document.getElementById('dashItchCard');
-    expect(itch.classList.contains('hidden')).toBe(true);
+    expect(itch.classList.contains('hidden')).toBe(false);
+    expect(itch.classList.contains('dash-card-itch--inactive')).toBe(false);
   });
 
-  it('shows the itch card dimmed when something else is connected but itch is not', async () => {
+  it('shows the itch card full-strength when something else is connected but itch is not', async () => {
     const { setAuthStatusSnapshot } = await import('../js/connections-status.js');
     setAuthStatusSnapshot([{ key: 'steam', status: 'connected' }]);
     state.itchGames = [];
     applyItchVisibility();
     const itch = document.getElementById('dashItchCard');
     expect(itch.classList.contains('hidden')).toBe(false);
-    expect(itch.classList.contains('dash-card-itch--inactive')).toBe(true);
+    expect(itch.classList.contains('dash-card-itch--inactive')).toBe(false);
   });
 
-  it('shows the itch card active (not dimmed) when itch data exists', async () => {
+  it('shows the itch card when itch data exists', async () => {
     const { setAuthStatusSnapshot } = await import('../js/connections-status.js');
     setAuthStatusSnapshot([]);
     state.itchGames = [{ store: 'itch', id: 'a', name: 'Demo' }];
@@ -103,10 +104,11 @@ describe('dashboard picks row', () => {
     document.getElementById('dashItchRecap').innerHTML = '';
     renderDashboardItchRecap();
     const recap = document.getElementById('dashItchRecap');
-    expect(recap.textContent).toContain('Start earning free games today');
-    expect(recap.textContent).toContain('Connect itch.io');
+    expect(recap.textContent).toContain('Start collecting free games on itch.io');
+    expect(recap.textContent).toContain('Already have itch?');
     expect(recap.querySelector('.itch-card-rail')).toBeTruthy();
     expect(recap.querySelector('[data-jump-view="connections"]')).toBeTruthy();
+    expect(recap.querySelector('.itch-onboard-cta--primary')?.getAttribute('href')).toContain('itch.io/games/free');
   });
 
   it('renders library value block when itch videogames exist', async () => {


### PR DESCRIPTION
## Summary
- Reverts the PR #11 behavior that hid the dashboard itch card on a truly-empty new profile.
- Drops the dimmed `dash-card-itch--inactive` state; card stays full-strength with the pink affiliate border.
- Empty-state onboarding is now an affiliate funnel: primary external "Browse free games on itch.io" link (`affiliateUrl`) plus secondary in-app "Already have itch? Connect it" chip.

## Test plan
- [x] `npx vitest run tests/dashboard-picks-row.test.js` (8 passed)
- [x] `npx vitest run` full suite (114 files, 1196 passed)
