### PR TITLE
fix: clear stale Supabase refresh tokens on boot

### DIFF
--- a/js/auth-gate.js
+++ b/js/auth-gate.js
@@ -187,6 +187,24 @@ function applySession(session) {
   }
 }
 
+/** Supabase refresh failures that mean local storage is stale — clear and re-prompt. */
+function isStaleRefreshTokenError(error) {
+  const msg = String(error?.message || error || '').toLowerCase();
+  return msg.includes('refresh token') || msg.includes('invalid refresh');
+}
+
+/** Drop a dead Supabase session from localStorage so auto-refresh stops retrying. */
+async function clearStaleAuthSession() {
+  if (!_supabase) return;
+  try {
+    await _supabase.auth.signOut();
+  } catch {
+    /* best-effort */
+  }
+  _accessToken = null;
+  _accountProfileId = '';
+}
+
 /** Verify the current bearer is accepted by server.py before boot continues. */
 async function probeServerToken() {
   if (!_accessToken) return false;
@@ -327,15 +345,14 @@ export async function initAuthGate() {
 
   bindSignInForm();
 
-  const { data: { session } } = await _supabase.auth.getSession();
-  if (session && (await ensureServerReadySession(session))) {
+  const { data: { session }, error: sessionError } = await _supabase.auth.getSession();
+  if (sessionError && isStaleRefreshTokenError(sessionError)) {
+    await clearStaleAuthSession();
+  } else if (session && (await ensureServerReadySession(session))) {
     markAuthReady();
     return;
-  }
-  if (session) {
-    await _supabase.auth.signOut();
-    _accessToken = null;
-    _accountProfileId = '';
+  } else if (session) {
+    await clearStaleAuthSession();
   }
 
   _authedPromise = new Promise((resolve) => { _resolveAuthed = resolve; });
@@ -373,7 +390,12 @@ export async function refreshAccessToken() {
   _refreshInFlight = (async () => {
     try {
       const { data, error } = await _supabase.auth.refreshSession();
-      if (error || !data.session) return null;
+      if (error) {
+        if (isStaleRefreshTokenError(error)) await clearStaleAuthSession();
+        applySession(null);
+        return null;
+      }
+      if (!data.session) return null;
       applySession(data.session);
       if (!(await probeServerToken())) {
         applySession(null);

--- a/tests/auth-gate.test.js
+++ b/tests/auth-gate.test.js
@@ -3,25 +3,32 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 const supabaseMock = vi.hoisted(() => {
   let session = null;
   let authListener = null;
+  let getSessionResult = null;
+  const signOut = vi.fn(async () => { session = null; });
+  const client = {
+    auth: {
+      getSession: vi.fn(async () => getSessionResult ?? { data: { session }, error: null }),
+      signInWithPassword: vi.fn(async () => ({ data: { session }, error: null })),
+      signOut,
+      refreshSession: vi.fn(async () => ({ data: { session }, error: null })),
+      onAuthStateChange: vi.fn((cb) => {
+        authListener = cb;
+        return { data: { subscription: { unsubscribe: vi.fn() } } };
+      }),
+    },
+  };
   return {
-    createClient: vi.fn(() => ({
-      auth: {
-        getSession: vi.fn(async () => ({ data: { session } })),
-        signInWithPassword: vi.fn(async () => ({ data: { session }, error: null })),
-        signOut: vi.fn(async () => { session = null; }),
-        refreshSession: vi.fn(async () => ({ data: { session }, error: null })),
-        onAuthStateChange: vi.fn((cb) => {
-          authListener = cb;
-          return { data: { subscription: { unsubscribe: vi.fn() } } };
-        }),
-      },
-    })),
-    setSession(s) { session = s; },
+    createClient: vi.fn(() => client),
+    client,
+    setSession(s) { session = s; getSessionResult = null; },
+    setGetSessionResult(r) { getSessionResult = r; },
     getSession() { return session; },
     fireAuthChange(next) { authListener?.('SIGNED_IN', next); },
     reset() {
       session = null;
       authListener = null;
+      getSessionResult = null;
+      signOut.mockClear();
     },
   };
 });
@@ -65,6 +72,21 @@ describe('auth-gate', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.resetModules();
+  });
+
+  it('initAuthGate clears stale refresh token and shows sign-in', async () => {
+    supabaseMock.setGetSessionResult({
+      data: { session: null },
+      error: { message: 'Invalid Refresh Token: Refresh Token Not Found' },
+    });
+    const { initAuthGate } = await import('../js/auth-gate.js');
+    const boot = initAuthGate();
+    await new Promise((r) => setTimeout(r, 50));
+    expect(supabaseMock.client.auth.signOut).toHaveBeenCalled();
+    const ov = document.getElementById('authGateOverlay');
+    expect(ov.hidden).toBe(false);
+    expect(document.documentElement.hasAttribute('data-auth-required')).toBe(true);
+    await expect(Promise.race([boot, Promise.resolve('pending')])).resolves.toBe('pending');
   });
 
   it('initAuthGate hides overlay when session is valid', async () => {


### PR DESCRIPTION
## Summary
- Fixes console `AuthApiError: Invalid Refresh Token: Refresh Token Not Found` on boot when localStorage holds a dead Supabase session.
- `initAuthGate` now reads `getSession()` errors; stale refresh failures call `signOut()` to clear storage instead of leaving auto-refresh retrying forever.
- `refreshAccessToken()` applies the same cleanup when `refreshSession()` fails with a stale token.

## Test plan
- [x] `npx vitest run tests/auth-gate.test.js` (8 passed, includes stale-refresh boot case)
