### PR TITLE
fix: only flash library 1UP for genuinely new games

### DIFF
--- a/js/library-load.js
+++ b/js/library-load.js
@@ -291,8 +291,14 @@ export async function applyMergedLibrary(mergeKey = null) {
 
   // Fire after the render so popup hosts exist in the DOM. Wrapped in
   // try/catch — this is pure polish; never let it break a real merge.
+  // Gate the library burst on genuinely-new keys (recordLibraryFirstSeen),
+  // not the raw visible-count delta: un-hiding a game, a cross-store dedup
+  // change, or a wishlist->library move all bump libNow by 1 without adding a
+  // real acquisition, which would flash a celebratory +1 that never shows up
+  // in "Recently added".
   try {
-    if (libPrev != null && libNow > libPrev) {
+    const newlyAdded = state._lastNewlyAddedCount ?? 0;
+    if (libPrev != null && libNow > libPrev && newlyAdded > 0) {
       fireLibraryCountFlash('library', libPrev, libNow);
     }
     if (wlPrev != null && wlNow > wlPrev) {

--- a/tests/reload-after-fetcher.test.js
+++ b/tests/reload-after-fetcher.test.js
@@ -74,6 +74,21 @@ describe('reloadAfterFetcher source routing', () => {
       /reloadAfterFetcher\(key\)[\s\S]*await applyMergedLibrary\(\)/,
     );
   });
+
+  it('gates the library count flash on genuinely-new keys, not raw visible delta', () => {
+    // Regression: un-hide / dedup / wishlist->library bumps libNow by 1 without
+    // a real acquisition; the celebratory burst must not fire (nothing lands in
+    // "Recently added"). Flash requires _lastNewlyAddedCount > 0.
+    const fn = LIBRARY_LOAD_SRC.match(
+      /export async function applyMergedLibrary\([\s\S]*?\n\}/,
+    );
+    expect(fn, 'applyMergedLibrary').toBeTruthy();
+    const body = fn[0];
+    expect(body).toMatch(
+      /libNow > libPrev && newlyAdded > 0[\s\S]*fireLibraryCountFlash\('library'/,
+    );
+    expect(body).toContain('state._lastNewlyAddedCount ?? 0');
+  });
 });
 
 describe('manifest key coverage', () => {


### PR DESCRIPTION
## Summary
- Fixes "number went up by 1 but nothing in Recents."
- The hero count 1UP burst fired on any visible-count increase, while "Recently added" leads on genuinely new keys (`recordLibraryFirstSeen`). These diverge: un-hiding a game, a cross-store dedup change, or a wishlist->library move bumps the visible count by 1 without a real acquisition.
- Gates the library flash on `state._lastNewlyAddedCount > 0` so the burst only fires for genuine additions. The hero number still updates via the normal dashboard render, so the total never goes stale. Wishlist flash unchanged (no first-seen signal there).

## Test plan
- [x] `reload-after-fetcher.test.js` — new source-guard assertion for the gate (8 tests green)
- [x] `library-count-animation.test.js` — 13 tests green
- [x] Lint clean
