### PR TITLE
fix: surface Epic privacy-policy corrective-action with retry guidance

### DIFF
--- a/auth/manager.py
+++ b/auth/manager.py
@@ -430,7 +430,12 @@ def set_form_credentials(provider: str, fields: dict[str, str]) -> dict[str, Any
                 "ITAD rejected this API key — copy the API key UUID from isthereanydeal.com/apps/my/"
             )
     if provider == "epic":
-        from epic_client import EpicAuthError, EpicClient, default_epic_cache_dir
+        from epic_client import (
+            EpicAuthError,
+            EpicClient,
+            EpicCorrectiveActionError,
+            default_epic_cache_dir,
+        )
 
         code = cleaned["EPIC_AUTH_CODE"].strip()
         if len(code) < 16 or not re.fullmatch(r"[A-Za-z0-9_\-]+", code):
@@ -441,6 +446,12 @@ def set_form_credentials(provider: str, fields: dict[str, str]) -> dict[str, Any
         try:
             client = EpicClient(auth_code=code, cache_dir=default_epic_cache_dir())
             client.login()
+        except EpicCorrectiveActionError as e:
+            raise ValueError(
+                "Epic needs you to accept its privacy policy. In the Epic sign-in "
+                "window, accept the privacy policy / complete the prompt, then refresh "
+                "the page and paste a fresh authorizationCode here."
+            ) from e
         except EpicAuthError as e:
             msg = str(e)
             if "OAuth 400" in msg or "invalid_grant" in msg or "expired" in msg.lower():

--- a/auth/runner.py
+++ b/auth/runner.py
@@ -274,6 +274,25 @@ def _epic_code_from_text(text: str) -> str:
     return m.group(1) if m else ""
 
 
+def _epic_error_from_text(text: str) -> dict[str, str] | None:
+    """Detect Epic's corrective-action gate in a redirect body (HTML-wrapped JSON safe)."""
+    from epic_client import corrective_action_in_text
+
+    return corrective_action_in_text(text or "")
+
+
+EPIC_CORRECTIVE_ACTION_HINT = (
+    "Epic needs you to accept its privacy policy. Accept the privacy policy / "
+    "complete the prompt in the sign-in window, then we'll finish connecting "
+    "automatically."
+)
+EPIC_CORRECTIVE_ACTION_ERROR = (
+    "Epic needs you to accept its privacy policy. In the Epic sign-in window, "
+    "accept the privacy policy / complete the prompt, then refresh the page and "
+    "click Connect again."
+)
+
+
 def _extract_epic_inline(page, context, session: AuthSession | None = None) -> dict[str, str]:
     """Sign in to Epic in the managed window, then auto-capture + exchange the code.
 
@@ -302,22 +321,42 @@ def _extract_epic_inline(page, context, session: AuthSession | None = None) -> d
             except Exception:
                 body = ""
             code = _epic_code_from_text(body)
+            html = ""
             if not code:
                 try:
-                    code = _epic_code_from_text(main.content())
+                    html = main.content()
                 except Exception:
-                    code = ""
+                    html = ""
+                code = _epic_code_from_text(html)
             if code:
-                from epic_client import EpicAuthError, EpicClient, default_epic_cache_dir
+                from epic_client import (
+                    EpicAuthError,
+                    EpicClient,
+                    EpicCorrectiveActionError,
+                    default_epic_cache_dir,
+                )
 
                 try:
                     EpicClient(auth_code=code, cache_dir=default_epic_cache_dir()).login()
+                except EpicCorrectiveActionError as exc:
+                    raise RuntimeError(EPIC_CORRECTIVE_ACTION_ERROR) from exc
                 except EpicAuthError as exc:
                     raise RuntimeError(
                         f"Epic rejected the captured code ({exc}). Refresh the Epic page so a new "
                         "code appears, or paste the authorizationCode into the fallback field below."
                     ) from exc
                 return {"EPIC_AUTH_CODE": code}
+
+            # No code yet: if Epic is showing its corrective-action gate (e.g.
+            # privacy-policy acceptance), guide the user to complete it and keep
+            # polling instead of silently timing out.
+            if _epic_error_from_text(body) or _epic_error_from_text(html):
+                now = time.time()
+                if session and now - last_hint > 8:
+                    last_hint = now
+                    session.emit("waiting_for_user", {"message": EPIC_CORRECTIVE_ACTION_HINT})
+                page.wait_for_timeout(int(POLL_SEC * 1000))
+                continue
 
         now = time.time()
         if session and now - last_hint > 10:

--- a/epic_client.py
+++ b/epic_client.py
@@ -18,6 +18,7 @@ tools like legendary; they grant access only when paired with a real user code.
 
 import base64
 import json
+import re
 import threading
 import time
 from pathlib import Path
@@ -84,6 +85,73 @@ REQUEST_DELAY_SEC = 0.12
 
 class EpicAuthError(Exception):
     """Authorization code missing/expired or refresh token rejected."""
+
+
+class EpicCorrectiveActionError(EpicAuthError):
+    """Epic blocked the OAuth exchange behind an in-browser gate.
+
+    Epic returns ``errors.com.epicgames.oauth.corrective_action_required`` (e.g.
+    ``correctiveAction=PRIVACY_POLICY_ACCEPTANCE``) when the account must complete
+    a prompt in the sign-in window before a code/token will be issued. We never
+    call Epic's continuation endpoint ourselves — the user finishes the gate in
+    the managed browser and retries.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        corrective_action: str | None = None,
+        continuation: str | None = None,
+        error_code: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.corrective_action = corrective_action
+        self.continuation = continuation
+        self.error_code = error_code
+
+
+def epic_error_fields(text: str) -> dict[str, str]:
+    """Best-effort parse of Epic's OAuth error body into its key fields.
+
+    Handles raw JSON and HTML-wrapped JSON (e.g. ``document.body.innerText`` from
+    the redirect page). Returns ``errorCode``/``message``/``correctiveAction``/
+    ``continuation`` with empty strings for anything absent.
+    """
+    out = {"errorCode": "", "message": "", "correctiveAction": "", "continuation": ""}
+    if not text:
+        return out
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        data = None
+    if isinstance(data, dict):
+        out["errorCode"] = str(data.get("errorCode") or "")
+        out["message"] = str(data.get("message") or "")
+        meta = data.get("metadata")
+        if isinstance(meta, dict):
+            out["correctiveAction"] = str(meta.get("correctiveAction") or "")
+            out["continuation"] = str(meta.get("continuation") or "")
+        return out
+    for field in ("errorCode", "message", "correctiveAction", "continuation"):
+        m = re.search(rf'"{field}"\s*:\s*"([^"]*)"', text)
+        if m:
+            out[field] = m.group(1)
+    return out
+
+
+def is_corrective_action(fields: dict[str, str]) -> bool:
+    """True when parsed Epic error fields indicate a corrective-action gate."""
+    return (
+        "corrective_action_required" in (fields.get("errorCode") or "")
+        or bool(fields.get("correctiveAction"))
+    )
+
+
+def corrective_action_in_text(text: str) -> dict[str, str] | None:
+    """Return corrective-action fields if ``text`` contains the gate, else None."""
+    fields = epic_error_fields(text)
+    return fields if is_corrective_action(fields) else None
 
 
 class EpicClient:
@@ -192,10 +260,18 @@ class EpicClient:
             timeout=30,
         )
         if resp.status_code >= 400:
-            try:
-                err = resp.json().get("errorCode", resp.text[:200])
-            except json.JSONDecodeError:
-                err = resp.text[:200]
+            fields = epic_error_fields(resp.text or "")
+            if is_corrective_action(fields):
+                action = fields.get("correctiveAction") or "corrective_action_required"
+                raise EpicCorrectiveActionError(
+                    f"Epic requires you to complete '{action}' before continuing. "
+                    "Accept Epic's privacy policy in the sign-in window, then refresh "
+                    "and reconnect.",
+                    corrective_action=fields.get("correctiveAction") or None,
+                    continuation=fields.get("continuation") or None,
+                    error_code=fields.get("errorCode") or None,
+                )
+            err = fields.get("errorCode") or (resp.text[:200] if resp.text else "")
             raise EpicAuthError(f"OAuth {resp.status_code}: {err}")
         return resp.json()
 

--- a/tests/test_epic_corrective_action.py
+++ b/tests/test_epic_corrective_action.py
@@ -1,0 +1,111 @@
+"""Epic's ``corrective_action_required`` gate (e.g. privacy-policy acceptance)
+must surface as a structured, retry-with-guidance error rather than a generic
+``OAuth 400`` or a silent timeout."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import auth.runner as runner
+from epic_client import (
+    EpicAuthError,
+    EpicClient,
+    EpicCorrectiveActionError,
+    corrective_action_in_text,
+    epic_error_fields,
+    is_corrective_action,
+)
+
+CORRECTIVE_PAYLOAD = {
+    "errorCode": "errors.com.epicgames.oauth.corrective_action_required",
+    "message": "Corrective action is required to continue.",
+    "metadata": {
+        "correctiveAction": "PRIVACY_POLICY_ACCEPTANCE",
+        "continuation": "continuation-token-123",
+    },
+    "correlationId": "abc-correlation",
+}
+
+INVALID_GRANT_PAYLOAD = {
+    "errorCode": "errors.com.epicgames.account.oauth.invalid_grant",
+    "message": "Sorry the originating session for the exchange code was not found.",
+}
+
+
+class _FakeResp:
+    def __init__(self, status: int, payload: dict | None = None, text: str | None = None) -> None:
+        self.status_code = status
+        self._payload = payload
+        self.text = text if text is not None else (json.dumps(payload) if payload else "")
+
+    def json(self) -> dict:
+        if self._payload is None:
+            raise json.JSONDecodeError("no json", self.text or "", 0)
+        return self._payload
+
+
+def _client(tmp_path: Path, resp: _FakeResp) -> EpicClient:
+    client = EpicClient(cache_dir=tmp_path)
+    client.session.post = lambda *a, **k: resp  # type: ignore[assignment]
+    return client
+
+
+def test_epic_error_fields_parses_corrective_json() -> None:
+    fields = epic_error_fields(json.dumps(CORRECTIVE_PAYLOAD))
+    assert fields["errorCode"] == CORRECTIVE_PAYLOAD["errorCode"]
+    assert fields["correctiveAction"] == "PRIVACY_POLICY_ACCEPTANCE"
+    assert fields["continuation"] == "continuation-token-123"
+    assert is_corrective_action(fields)
+
+
+def test_epic_error_fields_handles_html_wrapped_json() -> None:
+    wrapped = (
+        "<html><body><pre>"
+        + json.dumps(CORRECTIVE_PAYLOAD)
+        + "</pre></body></html>"
+    )
+    fields = epic_error_fields(wrapped)
+    assert fields["correctiveAction"] == "PRIVACY_POLICY_ACCEPTANCE"
+    assert is_corrective_action(fields)
+    assert corrective_action_in_text(wrapped) is not None
+
+
+def test_invalid_grant_is_not_corrective() -> None:
+    fields = epic_error_fields(json.dumps(INVALID_GRANT_PAYLOAD))
+    assert not is_corrective_action(fields)
+    assert corrective_action_in_text(json.dumps(INVALID_GRANT_PAYLOAD)) is None
+
+
+def test_request_token_raises_corrective_action(tmp_path: Path) -> None:
+    client = _client(tmp_path, _FakeResp(400, CORRECTIVE_PAYLOAD))
+    with pytest.raises(EpicCorrectiveActionError) as ei:
+        client._request_token({"grant_type": "authorization_code", "code": "x"})
+    err = ei.value
+    assert err.corrective_action == "PRIVACY_POLICY_ACCEPTANCE"
+    assert err.continuation == "continuation-token-123"
+    assert "corrective_action_required" in (err.error_code or "")
+    assert "privacy policy" in str(err).lower()
+
+
+def test_request_token_generic_invalid_grant(tmp_path: Path) -> None:
+    client = _client(tmp_path, _FakeResp(400, INVALID_GRANT_PAYLOAD))
+    with pytest.raises(EpicAuthError) as ei:
+        client._request_token({"grant_type": "authorization_code", "code": "x"})
+    assert not isinstance(ei.value, EpicCorrectiveActionError)
+    assert "invalid_grant" in str(ei.value)
+
+
+def test_request_token_corrective_in_html_body(tmp_path: Path) -> None:
+    wrapped = "<html><body>" + json.dumps(CORRECTIVE_PAYLOAD) + "</body></html>"
+    client = _client(tmp_path, _FakeResp(400, payload=None, text=wrapped))
+    with pytest.raises(EpicCorrectiveActionError):
+        client._request_token({"grant_type": "authorization_code", "code": "x"})
+
+
+def test_runner_helper_detects_corrective_body() -> None:
+    assert runner._epic_error_from_text(json.dumps(CORRECTIVE_PAYLOAD)) is not None
+    assert runner._epic_error_from_text(json.dumps({"authorizationCode": "abc123def456"})) is None
+    assert runner._epic_error_from_text("") is None


### PR DESCRIPTION
## Summary

Epic's OAuth token endpoint can return `errors.com.epicgames.oauth.corrective_action_required` (e.g. `correctiveAction=PRIVACY_POLICY_ACCEPTANCE`) during connect/reconnect. Previously this surfaced as a generic `OAuth 400` or a silent 300s timeout, with zero guidance. This change detects the gate and tells the user to accept Epic's privacy policy in the sign-in window, then refresh/reconnect. We never call Epic's continuation endpoint ourselves — the user completes the gate in the managed browser and retries.

### What changed
- **`epic_client.py`**
  - New `EpicCorrectiveActionError(EpicAuthError)` carrying `.corrective_action`, `.continuation`, `.error_code`.
  - New centralized, pure helpers `epic_error_fields()` / `is_corrective_action()` / `corrective_action_in_text()` that parse Epic's error body and are robust to HTML-wrapped JSON (the redirect `innerText`).
  - `_request_token` now parses the full error JSON; on a corrective-action gate it raises the structured error, otherwise it keeps the existing generic `OAuth <status>: <errorCode>` behavior.
- **`auth/runner.py`** (`_extract_epic_inline`)
  - (a) When the redirect body shows the corrective-action gate and has no `authorizationCode`, emit a targeted `waiting_for_user` SSE hint and keep polling instead of silently timing out.
  - (b) When the code exchange raises the corrective-action error, raise `RuntimeError` with clear accept-privacy-policy guidance. Added sibling helper `_epic_error_from_text` reusing the shared detection.
- **`auth/manager.py`** (`set_form_credentials`) — the manual-paste path now special-cases the corrective-action error with the same accept-privacy-policy guidance, alongside the existing `OAuth 400`/`invalid_grant`/`expired` branch.

## Test plan
- New `tests/test_epic_corrective_action.py`:
  - `epic_error_fields` parses the sample corrective JSON (raw + HTML-wrapped).
  - `_request_token` raises `EpicCorrectiveActionError` with the right attributes for the corrective payload, and still raises the generic `EpicAuthError` for `invalid_grant`.
  - Runner helper `_epic_error_from_text` detects the gate and ignores code-only bodies.
- `pytest tests/ -k "epic or corrective"` — all corrective-action tests pass.
- `pytest tests/test_repo_size_budgets.py` — passes (server.py untouched).
- `ruff check` — clean on changed files.

## Pre-existing failure (out of scope)
`tests/test_fetcher_auth_exit.py::test_auth_error_branches_use_exit_code_4[fetch_epic.py]` already fails on `main` (run #21, `1 failed, 1058 passed`). Its over-strict regex matches the intentionally non-fatal playtime `except EpicAuthError` block in `fetch_epic.py`. This change does not touch `fetch_epic.py` and introduces no new failures.
