### PR TITLE
feat: itch nav tab jumps to dashboard itch card when not connected

### DIFF
--- a/app.css
+++ b/app.css
@@ -6110,6 +6110,16 @@ html[data-init-view="wishlist"] .steal-list-footer-passive { display: none; }
   border: 1px solid color-mix(in srgb, var(--brand-itch, #fa5c5c) 55%, transparent);
   box-shadow: 0 0 0 1px color-mix(in srgb, var(--brand-itch, #fa5c5c) 18%, transparent);
 }
+.dash-card-itch.itch-card-jump-pulse {
+  animation: itchCardJumpPulse 1.6s ease-out;
+}
+@keyframes itchCardJumpPulse {
+  0%, 100% { box-shadow: 0 0 0 1px color-mix(in srgb, var(--brand-itch, #fa5c5c) 18%, transparent); }
+  25% { box-shadow: 0 0 0 3px color-mix(in srgb, var(--brand-itch, #fa5c5c) 70%, transparent); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .dash-card-itch.itch-card-jump-pulse { animation: none; }
+}
 .dash-itch-recap { color: #cbd5e1; line-height: 1.5; display: flex; flex-direction: column; gap: 0.65rem; flex: 1; min-height: 0; padding: 0 18px 16px; }
 .itch-card-rail {
   height: 4px;

--- a/js/bind-events.js
+++ b/js/bind-events.js
@@ -65,6 +65,7 @@ import {
   renderWishlistStoreChips,
   renderGenreChips,
   switchView,
+  scrollToItchCard,
   exportCsv,
   exportTopBacklogMarkdown,
   download,
@@ -72,6 +73,7 @@ import {
   clearAllFilters,
   showItchNonGamesFromEmptyState,
 } from './filters-ui.js';
+import { isItchTabAvailable } from './connections.js';
 import {
   getDealInfo,
   syncDealFilterControls,
@@ -585,8 +587,15 @@ export function bindEvents() {
   });
   document.querySelectorAll(".view-tab").forEach(btn => {
     btn.addEventListener("click", () => {
-      const view = btn.dataset.view || "library";
-      if (view === state.activeView) return;
+      let view = btn.dataset.view || "library";
+      // itch tab with no itch account: jump to the dashboard itch card instead
+      // of opening the (quarantined) itch view.
+      const jumpToItchCard = view === "itch" && !isItchTabAvailable();
+      if (jumpToItchCard) view = "dashboard";
+      if (view === state.activeView) {
+        if (jumpToItchCard) scrollToItchCard();
+        return;
+      }
       // Top-tab clicks (never drill-ins, never the dashboard drill helpers)
       // should land the user at the top of the page so they see the header,
       // summary, then picks, then table. Scroll BEFORE switchView so the
@@ -601,6 +610,7 @@ export function bindEvents() {
       }
       window.scrollTo(0, 0);
       switchView(view);
+      if (jumpToItchCard) scrollToItchCard();
     });
   });
   document.getElementById("cleanupModeBtn").addEventListener("click", () => {

--- a/js/filters-ui.js
+++ b/js/filters-ui.js
@@ -552,12 +552,37 @@ export function syncViewTabAria(view) {
   });
 }
 
-/** Quarantine itch.io nav until the user has set up itch (API key) or already has itch data. */
+/**
+ * Smooth-scroll the dashboard itch card into view with a brief highlight pulse.
+ *
+ * The card lives at the bottom of the picks row and is rendered asynchronously
+ * after switchView('dashboard'), so retry on rAF until it exists.
+ */
+export function scrollToItchCard() {
+  const attempt = (tries) => {
+    const card = document.getElementById("dashItchCard");
+    if (!card) {
+      if (tries > 0) requestAnimationFrame(() => attempt(tries - 1));
+      return;
+    }
+    if (typeof card.scrollIntoView === "function") {
+      card.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+    card.classList.add("itch-card-jump-pulse");
+    setTimeout(() => card.classList.remove("itch-card-jump-pulse"), 1600);
+  };
+  attempt(30);
+}
+
+/**
+ * Keep the itch.io nav tab visible at all times. When itch isn't set up, mark
+ * the tab so clicks jump to the dashboard itch card instead of the itch view.
+ */
 export function applyItchTabVisibility() {
   const tab = document.querySelector('.view-tab[data-view="itch"]');
   if (!tab) return;
   const available = isItchTabAvailable();
-  tab.classList.toggle("hidden", !available);
+  tab.classList.toggle("itch-tab-jump", !available);
   // Fail open during boot: until auth status is fetched and the library has
   // loaded, authStatus/itchGames are empty, so a hard refresh on itch would
   // always bounce to dashboard. Only redirect once we truly know.
@@ -566,6 +591,7 @@ export function applyItchTabVisibility() {
     switchView("dashboard");
     state.prefs.activeView = "dashboard";
     savePrefs();
+    scrollToItchCard();
   }
 }
 

--- a/tests/itch-tab-visibility.test.js
+++ b/tests/itch-tab-visibility.test.js
@@ -81,19 +81,22 @@ describe('applyItchTabVisibility', () => {
     state.dashboardDataReady = false;
   });
 
-  it('hides the itch tab when itch is not set up', async () => {
+  it('keeps the itch tab visible but marks it for the dashboard jump when itch is not set up', async () => {
     mockAuthStatus([]);
     await refreshConnections();
     applyItchTabVisibility();
     const tab = document.querySelector('.view-tab[data-view="itch"]');
-    expect(tab.classList.contains('hidden')).toBe(true);
+    expect(tab.classList.contains('hidden')).toBe(false);
+    expect(tab.classList.contains('itch-tab-jump')).toBe(true);
   });
 
-  it('shows the itch tab after itch is connected', async () => {
+  it('clears the jump marker after itch is connected', async () => {
     mockAuthStatus([{ key: 'itch', status: 'connected' }]);
     await refreshConnections();
+    applyItchTabVisibility();
     const tab = document.querySelector('.view-tab[data-view="itch"]');
     expect(tab.classList.contains('hidden')).toBe(false);
+    expect(tab.classList.contains('itch-tab-jump')).toBe(false);
   });
 
   it('does not redirect away from itch during boot before data is known', async () => {


### PR DESCRIPTION
## Summary
- Keep the top-nav `itch.io` tab **visible at all times** instead of hiding it when no itch account is connected.
- When itch is **not** connected/available, clicking the tab now switches to the Dashboard and smooth-scrolls to the `#dashItchCard` (with a brief highlight pulse) rather than opening the quarantined itch view.
- When itch **is** connected/available, behavior is unchanged (opens the itch view).
- The hard-refresh redirect guard for `#itch` when unavailable now routes through the same scroll-to-card behavior.

## Changes
- `js/filters-ui.js`: `applyItchTabVisibility()` toggles an `itch-tab-jump` marker class instead of `hidden`; added `scrollToItchCard()` helper (rAF-retried `scrollIntoView` + transient pulse class); redirect guard now scrolls to the card.
- `js/bind-events.js`: `.view-tab` click handler detects the itch-not-available case and jumps to the dashboard itch card; imports `isItchTabAvailable` and `scrollToItchCard`.
- `app.css`: `.itch-card-jump-pulse` keyframe near the existing `.dash-card-itch` rules (respects `prefers-reduced-motion`).
- `tests/itch-tab-visibility.test.js`: updated expectations — tab is no longer hidden; asserts the `itch-tab-jump` marker is present when disconnected and absent when connected.

## Test plan
- [x] `npm test` — 1094 passed / 7 skipped
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run check:module-size` — within budget
- [x] `npm run build` + `npm run check:bundle-size` — within budget (no `size-budget.json` change needed)
