### PR TITLE
fix: audit recent-games system (itch first-seen, last_played parsing, first-seen merge, added_at fallback)

### DIFF
--- a/js/creative-metrics.js
+++ b/js/creative-metrics.js
@@ -12,6 +12,7 @@ import {
   combinedPlaytime,
   firstPlayedAt,
   playSessionCount,
+  parseLastPlayedMs,
 } from './game-core.js';
 import { gameGenresCanonical } from './genres.js';
 import { getPersonal } from './personal-storage.js';
@@ -63,16 +64,25 @@ function finishesLast12Months(games) {
   const cutoff = Date.now() - 365 * MS_PER_DAY;
   return games.filter(g => {
     if (statusOf(g) !== 'finished') return false;
-    const lp = g.last_played;
-    if (!lp) return false;
-    const t = Date.parse(String(lp));
-    return !Number.isNaN(t) && t >= cutoff;
+    const t = parseLastPlayedMs(g);
+    return t > 0 && t >= cutoff;
   }).length;
 }
 
+/** Effective add timestamp (ms): manual `added_at`, else library first-seen. */
+function addedAtMs(g) {
+  const t = Date.parse(String(g.added_at || ''));
+  if (Number.isFinite(t)) return t;
+  const seen = firstSeenAt(g);
+  return seen > 0 ? seen : null;
+}
+
 function addedThisYearCount(games) {
-  const y = String(new Date().getFullYear());
-  return games.filter(g => (g.added_at || '').startsWith(y)).length;
+  const y = new Date().getFullYear();
+  return games.filter(g => {
+    const ms = addedAtMs(g);
+    return ms != null && new Date(ms).getFullYear() === y;
+  }).length;
 }
 
 /** @param {object[]} games @param {object} snap */

--- a/js/dashboard-insights.js
+++ b/js/dashboard-insights.js
@@ -838,14 +838,27 @@ export function buildMarqueeItems(games, snapIn, ctxIn) {
     if (oldUnplayed) push('^', 'is-rose', `${oldUnplayed.g.name} · ${oldUnplayed.y}`, 'oldest unplayed');
   }
 
+  // Fetchers never set added_at (only manual adds do); fall back to the
+  // library first-seen stamp so "newest add" / "added in {year}" reflect every
+  // store, not just custom entries.
+  const effectiveAddedMs = (g) => {
+    const t = Date.parse(String(g.added_at || ''));
+    if (Number.isFinite(t)) return t;
+    const seen = (state.libraryFirstSeenByKey || {})[gameKey(g)];
+    const n = Number(seen);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  };
   const withAddDate = games
-    .map(g => ({ g, d: g.added_at || '' }))
-    .filter(x => x.d)
-    .sort((a, b) => b.d.localeCompare(a.d));
+    .map(g => ({ g, ms: effectiveAddedMs(g) }))
+    .filter(x => x.ms != null)
+    .sort((a, b) => b.ms - a.ms);
   if (withAddDate[0]) push('*', 'is-violet', withAddDate[0].g.name, 'newest add');
 
   const thisYear = new Date().getFullYear();
-  const addedThisYear = games.filter(g => (g.added_at || '').startsWith(String(thisYear))).length;
+  const addedThisYear = games.filter(g => {
+    const ms = effectiveAddedMs(g);
+    return ms != null && new Date(ms).getFullYear() === thisYear;
+  }).length;
   if (addedThisYear) push('+', 'is-emerald', formatNum(addedThisYear), `added in ${thisYear}`);
 
   const devCounts = {};

--- a/js/dashboard-spotlight.js
+++ b/js/dashboard-spotlight.js
@@ -3,7 +3,7 @@
 
 import { state } from './state.js';
 import { escapeAttr, escapeHtml } from './dom-util.js';
-import { gameKey, hltbMain, ratingValue, steamAppIdFromGame, spotlightArtCandidates, hasEnoughReviews, combinedPlaytime, parseReleaseForSort, formatDollar, normalizeGame } from './game-core.js';
+import { gameKey, hltbMain, ratingValue, steamAppIdFromGame, spotlightArtCandidates, hasEnoughReviews, combinedPlaytime, parseReleaseForSort, parseLastPlayedMs, formatDollar, normalizeGame } from './game-core.js';
 import { storeLogoHtml, storeDisplayName } from './store-logos.js';
 import { getPersonal, filterOutHidden } from './personal-storage.js';
 import { getDealInfo, cutBucketClass } from './deals.js';
@@ -423,15 +423,6 @@ function parseAddedAtMs(g) {
   if (!raw) return 0;
   const ms = Date.parse(raw);
   return Number.isFinite(ms) ? ms : 0;
-}
-
-function parseLastPlayedMs(g) {
-  const lp = g.last_played;
-  if (lp == null || lp === '') return 0;
-  const n = Number(lp);
-  if (!Number.isFinite(n) || n <= 0) return 0;
-  // Steam rtime_last_played is epoch seconds; values already in ms stay valid.
-  return n < 1e12 ? n * 1000 : n;
 }
 
 /** Sort key for backfill rows (baseline games without first-seen > 0). */

--- a/js/game-core.js
+++ b/js/game-core.js
@@ -745,6 +745,25 @@ export function parseReleaseForSort(d) {
   return isNaN(t) ? 0 : t;
 }
 
+/**
+ * Parse a `last_played` value into epoch milliseconds. Stores disagree on the
+ * format: Steam emits `rtime_last_played` as epoch SECONDS, some caches store
+ * epoch milliseconds, and manual/other paths use ISO date strings. Returns 0
+ * when missing or unparseable so callers can treat it as "never played".
+ */
+export function parseLastPlayedMs(g) {
+  const lp = g?.last_played;
+  if (lp == null || lp === "") return 0;
+  const n = Number(lp);
+  if (Number.isFinite(n)) {
+    if (n <= 0) return 0;
+    // Values below ~1e12 are epoch seconds (year ~33658 otherwise); scale up.
+    return n < 1e12 ? n * 1000 : n;
+  }
+  const t = Date.parse(String(lp));
+  return Number.isFinite(t) ? t : 0;
+}
+
 export function formatReleaseDate(d) {
   if (!d) return " - ";
   const s = String(d).trim();

--- a/js/library-load.js
+++ b/js/library-load.js
@@ -212,7 +212,11 @@ export function recordLibraryFirstSeen() {
   const effectiveSeeded = seeded && !mapWasEmpty;
   let changed = false;
   let newlyStamped = 0;
-  for (const g of state.allGames) {
+  // itch games live in state.itchGames (their own tab), not state.allGames.
+  // Stamp them too so itch additions get a first-seen timestamp and can
+  // surface in recents / the +N added flash instead of vanishing silently.
+  const itchGames = Array.isArray(state.itchGames) ? state.itchGames : [];
+  for (const g of [...state.allGames, ...itchGames]) {
     const key = gameKey(g);
     if (key in state.libraryFirstSeenByKey) continue;
     state.libraryFirstSeenByKey[key] = effectiveSeeded ? Date.now() : 0;

--- a/js/metric-tips.js
+++ b/js/metric-tips.js
@@ -104,7 +104,7 @@ export const METRIC_TIPS = {
   'newest release owned': 'Owned game with the latest release year.',
   'top decade': 'Decade with the most owned releases.',
   'oldest unplayed': 'Oldest release-year backlog game still unplayed.',
-  'newest add': 'Most recently added game by added_at date.',
+  'newest add': 'Most recently added game (by added date, or when it first appeared in your library).',
   'top developer': 'Developer with the most owned titles.',
   'top publisher': 'Publisher with the most owned titles.',
   'unique developers': 'Count of distinct developers in the library.',

--- a/js/personal-store.js
+++ b/js/personal-store.js
@@ -95,7 +95,25 @@ export const personalStore = (() => {
     // rowHeroBackdrop:false must not undo the local toggle/migration each boot.
     'rowHeroBackdrop',
     'rowHeroBackdropDefaulted',
+    // Local-only seed flag: a stale server copy must not re-arm the one-shot
+    // first-seen seed, which would flood "Recently added" on the next boot.
+    'librarySeenSeeded',
   ];
+
+  // Merge first-seen maps. The server doc is normally authoritative, but a
+  // stale/reset server map can carry `0` (placeholder seed) for a key the
+  // local cache already stamped with a real timestamp. Never let a server `0`
+  // (or non-numeric junk) clobber a real local timestamp.
+  function _mergeFirstSeen(localSeen, serverSeen) {
+    const out = { ...localSeen };
+    for (const [key, sv] of Object.entries(serverSeen || {})) {
+      const sn = Number(sv);
+      const ln = Number(out[key]);
+      if ((!Number.isFinite(sn) || sn <= 0) && Number.isFinite(ln) && ln > 0) continue;
+      out[key] = sv;
+    }
+    return out;
+  }
 
   function _nonBacklogCount(personalObj) {
     let n = 0;
@@ -218,7 +236,7 @@ export const personalStore = (() => {
     const serverSeen = (doc.libraryFirstSeen && typeof doc.libraryFirstSeen === 'object')
       ? doc.libraryFirstSeen
       : {};
-    state.libraryFirstSeenByKey = { ...localSeen, ...serverSeen };
+    state.libraryFirstSeenByKey = _mergeFirstSeen(localSeen, serverSeen);
     const manual = Array.isArray(doc.manual) ? doc.manual : [];
     localStorage.setItem(personalStorageKey(), JSON.stringify(state.personal));
     localStorage.setItem(prefsStorageKey(), JSON.stringify(state.prefs));

--- a/js/picks-ui.js
+++ b/js/picks-ui.js
@@ -10,6 +10,7 @@ import {
   coverFallbackFor,
   libraryCoverFor,
   earlyAccessRibbonHtml,
+  parseLastPlayedMs,
 } from './game-core.js';
 import { safeCoverAttrUrl } from './covers.js';
 import { storeLogoHtml } from './store-logos.js';
@@ -156,8 +157,8 @@ export function renderPicks() {
   const returnTo = visible
     .filter(g => getPersonal(g).status === "unfinished")
     .sort((a, b) => {
-      const la = a.last_played ? Date.parse(a.last_played) : 0;
-      const lb = b.last_played ? Date.parse(b.last_played) : 0;
+      const la = parseLastPlayedMs(a);
+      const lb = parseLastPlayedMs(b);
       if (lb !== la) return lb - la;
       return ratingValue(b) - ratingValue(a);
     });

--- a/js/sabermetrics.js
+++ b/js/sabermetrics.js
@@ -2,7 +2,7 @@
 // Pure functions; snapshot built once per dashboard render and reused.
 
 import { state } from './state.js';
-import { gameKey, hltbMain, ratingValue, hasEnoughReviews, combinedPlaytime, normalizeGame, firstPlayedAt, playSessionCount } from './game-core.js';
+import { gameKey, hltbMain, ratingValue, hasEnoughReviews, combinedPlaytime, normalizeGame, firstPlayedAt, playSessionCount, parseLastPlayedMs } from './game-core.js';
 import { getPersonal } from './personal-storage.js';
 import { getDealInfo, computeWishlistWoba, isCleanupCandidate, parsePriceLike } from './deals.js';
 
@@ -348,13 +348,12 @@ export function gamerscoreEfficiency(snap) {
 
 export function hotColdStreak(snap) {
   const finished = snap.games
-    .filter(g => (getPersonal(g).status || '') === 'finished' && g.last_played)
-    .sort((a, b) => String(b.last_played).localeCompare(String(a.last_played)));
+    .filter(g => (getPersonal(g).status || '') === 'finished' && parseLastPlayedMs(g) > 0)
+    .sort((a, b) => parseLastPlayedMs(b) - parseLastPlayedMs(a));
   if (!finished.length) return 'cold';
   if (finished.length < 2) return 'warm';
-  const latest = finished[0].last_played;
-  const t = Date.parse(String(latest));
-  if (Number.isFinite(t) && (Date.now() - t) > 90 * 86400000) return 'cold';
+  const t = parseLastPlayedMs(finished[0]);
+  if (t > 0 && (Date.now() - t) > 90 * 86400000) return 'cold';
   return finished.length >= 3 ? 'hot' : 'warm';
 }
 
@@ -820,10 +819,8 @@ export function recentlyPlayedCount(games, days = 30) {
   const cutoff = Date.now() - days * MS_PER_DAY;
   let n = 0;
   for (const g of games || []) {
-    const lp = g.last_played;
-    if (!lp) continue;
-    const t = Date.parse(String(lp));
-    if (Number.isFinite(t) && t >= cutoff) n++;
+    const t = parseLastPlayedMs(g);
+    if (t > 0 && t >= cutoff) n++;
   }
   return n > 0 ? n : null;
 }
@@ -834,10 +831,8 @@ export function longestDormant(games) {
   let oldest = Infinity;
   for (const g of games || []) {
     if (combinedPlaytime(g) <= 0) continue;
-    const lp = g.last_played;
-    if (!lp) continue;
-    const t = Date.parse(String(lp));
-    if (!Number.isFinite(t) || t >= oldest) continue;
+    const t = parseLastPlayedMs(g);
+    if (t <= 0 || t >= oldest) continue;
     oldest = t;
     best = g;
   }

--- a/tests/addremove-state-integrity.test.js
+++ b/tests/addremove-state-integrity.test.js
@@ -63,6 +63,53 @@ describe('manual[] vs personal{} vs hidden', () => {
   });
 });
 
+describe('add-to-library: itch platform routing + first-seen (Step 1 regression)', () => {
+  let state;
+  let storage;
+  let libraryLoad;
+  let gameKey;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    localStorage.clear();
+    const ps = await import('../js/personal-store.js');
+    vi.spyOn(ps.personalStore, 'notify').mockImplementation(() => {});
+    ({ state } = await import('../js/state.js'));
+    storage = await import('../js/personal-storage.js');
+    libraryLoad = await import('../js/library-load.js');
+    ({ gameKey } = await import('../js/game-core.js'));
+    state.personal = {};
+    state.allGames = [];
+    state.itchGames = [];
+    state.wishlistGames = [];
+    state.libraryMeta = {};
+    state.prefs = { librarySeenSeeded: false };
+    state.libraryFirstSeenByKey = {};
+    window._dataVersion = 0;
+  });
+
+  it('a game added under the itch platform lands in state.itchGames, not the library catalog', () => {
+    storage.addManualGame({ store: 'itch', id: 'manual-zed', name: 'Zed', manual: true, playtime_minutes: 0 });
+    libraryLoad.rebuildAllGamesFromMetas();
+    expect(state.itchGames.some(g => g.id === 'manual-zed')).toBe(true);
+    expect(state.allGames.some(g => g.id === 'manual-zed')).toBe(false);
+  });
+
+  it('an itch add gets a first-seen stamp so it is not invisible in recents', () => {
+    // First boot seeds the existing library baseline (steam:1 -> 0).
+    state.allGames = [{ store: 'steam', id: '1', name: 'Owned' }];
+    libraryLoad.recordLibraryFirstSeen();
+    // The user then adds a game under the itch platform.
+    storage.addManualGame({ store: 'itch', id: 'manual-zed', name: 'Zed', manual: true, playtime_minutes: 0 });
+    libraryLoad.rebuildAllGamesFromMetas();
+    const stamped = libraryLoad.recordLibraryFirstSeen();
+    const itchGame = state.itchGames.find(g => g.id === 'manual-zed');
+    expect(itchGame).toBeDefined();
+    expect(stamped).toBe(1);
+    expect(state.libraryFirstSeenByKey[gameKey(itchGame)]).toBeGreaterThan(0);
+  });
+});
+
 describe('multi-tab sync boundary', () => {
   let state;
   let storage;

--- a/tests/auto-enrich.test.js
+++ b/tests/auto-enrich.test.js
@@ -163,6 +163,7 @@ describe('recordLibraryFirstSeen', () => {
     ({ gameKey } = await import('../js/game-core.js'));
     state.prefs = { librarySeenSeeded: false };
     state.libraryFirstSeenByKey = {};
+    state.itchGames = [];
     state.allGames = [
       { store: 'steam', id: '1', name: 'A' },
       { store: 'steam', id: '2', name: 'B' },
@@ -182,6 +183,15 @@ describe('recordLibraryFirstSeen', () => {
     const n = recordLibraryFirstSeen();
     expect(n).toBe(1);
     expect(state.libraryFirstSeenByKey[gameKey({ store: 'gog', id: '9', name: 'New' })]).toBeGreaterThan(0);
+  });
+
+  it('stamps itch games (state.itchGames) so itch adds are not invisible in recents', () => {
+    recordLibraryFirstSeen();
+    const itch = { store: 'itch', id: 'manual-zed', name: 'Zed', manual: true };
+    state.itchGames = [itch];
+    const n = recordLibraryFirstSeen();
+    expect(n).toBe(1);
+    expect(state.libraryFirstSeenByKey[gameKey(itch)]).toBeGreaterThan(0);
   });
 
   it('re-seeds as baseline when the map is empty but seeded flag is true (desync)', () => {

--- a/tests/recent-additions.test.js
+++ b/tests/recent-additions.test.js
@@ -82,6 +82,19 @@ describe('computeRecentAdditions', () => {
     expect(result[3]._addedAt).toBeNull();
   });
 
+  it('backfills using ISO last_played dates, not only epoch seconds', () => {
+    // The spotlight last_played parser used to ignore ISO strings (Number(ISO)
+    // is NaN), so an ISO-dated row sorted as "no signal". The shared parser
+    // now handles both, so the recently-played ISO row leads the backfill.
+    const games = [
+      game('a', 'Alpha', { release_date: '2010-01-01' }),
+      game('b', 'Bravo', { last_played: new Date('2024-06-01T00:00:00.000Z').toISOString() }),
+    ];
+    for (const g of games) state.libraryFirstSeenByKey[gameKey(g)] = 0;
+    const result = computeRecentAdditions(games, 10);
+    expect(result.map(g => g.id)).toEqual(['b', 'a']);
+  });
+
   it('prefers tracked first-seen over backfill proxies', () => {
     const tracked = game('t', 'Tracked', { last_played: 1 });
     const manual = game('m', 'Manual', { added_at: '2025-01-01T00:00:00.000Z' });

--- a/tests/sabermetrics.test.js
+++ b/tests/sabermetrics.test.js
@@ -324,6 +324,17 @@ describe('sabermetrics', () => {
       expect(metacriticClubCount(games)).toBe(1);
     });
 
+    it('counts Steam epoch-seconds last_played, not just ISO strings', () => {
+      const recentSec = Math.floor((Date.now() - 5 * 86400000) / 1000);
+      const oldSec = Math.floor((Date.now() - 400 * 86400000) / 1000);
+      const games = [
+        game({ id: '1', last_played: recentSec, playtime_minutes: 60 }),
+        game({ id: '2', name: 'Dusty', last_played: oldSec, playtime_minutes: 120 }),
+      ];
+      expect(recentlyPlayedCount(games)).toBe(1);
+      expect(longestDormant(games)?.g.name).toBe('Dusty');
+    });
+
     it('wishlist helpers prefer wishlist_added', () => {
       const wl = [
         { name: 'New', wishlist_added: Math.floor(Date.now() / 1000) - 86400 },


### PR DESCRIPTION
## Summary

Audit and fix the three overlapping "recent games" systems and the underlying "can't add to library" pain.

### Add-to-library diagnosis (Step 1)
The mechanical add path works, but adds made under the **itch.io platform silently disappear from the user's perspective**:
- The add-target buttons only expose **Library** / **Wishlist** (`index.html`), yet the **Platform `<select>` still offers `itch.io`**. Picking it builds a game with `store: "itch"`.
- `refreshAfterManualChange()` correctly routes `store === "itch"` rows into `state.itchGames` (their own tab), **but `recordLibraryFirstSeen()` only iterated `state.allGames`** — so itch adds never got a first-seen stamp, never appeared in "Recently added", and never fired the "+N added" flash. The add looked like it failed.

**Root cause fixed:** `recordLibraryFirstSeen()` now also stamps `state.itchGames`. Decision: the dashboard "Recently added" card stays library-only (itch has its own tab/picks — mixing would be incoherent), but stamping itch first-seen makes itch adds observably "land" and surface in itch recents / the count flash.

### Confirmed gaps fixed (Step 2)
1. **itch first-seen** — `recordLibraryFirstSeen()` (`js/library-load.js`) now iterates `state.allGames` + `state.itchGames`.
2. **`last_played` format split** — extracted a single epoch-seconds/ms **and** ISO-aware `parseLastPlayedMs()` into `js/game-core.js` and routed all parsing through it: `dashboard-spotlight.js` (removed the local copy, which ignored ISO), `sabermetrics.js` (`recentlyPlayedCount`, `longestDormant`, `hotColdStreak`), `creative-metrics.js` (`finishesLast12Months`), and `picks-ui.js` "return to" sort.
3. **Server merge wiping local first-seen with stale zeros** — `js/personal-store.js` `applyServerDoc` now uses `_mergeFirstSeen()` so a server `0` (or junk) never clobbers a real local timestamp; added `librarySeenSeeded` to `LOCAL_FIRST_PREF_KEYS` so a stale server pref can't re-arm the one-shot seed.
4. **`added_at` metrics broken (fetchers never set `added_at`)** — `js/dashboard-insights.js` ("newest add" / "added in {year}") and `js/creative-metrics.js` (`addedThisYearCount`) now fall back to `libraryFirstSeenByKey[gameKey(g)]`. Updated the `js/metric-tips.js` "newest add" copy to match the new semantics.

## Test plan
- `tests/auto-enrich.test.js` — `recordLibraryFirstSeen` now stamps `state.itchGames`.
- `tests/addremove-state-integrity.test.js` — new Step 1 regression: itch-platform add lands in `state.itchGames` (not the library catalog) **and** gets a first-seen stamp.
- `tests/sabermetrics.test.js` — added a Steam epoch-seconds `last_played` case (was ISO-only) for `recentlyPlayedCount` + `longestDormant`.
- `tests/recent-additions.test.js` — added an ISO `last_played` backfill case (old spotlight parser ignored ISO).
- Local: `npm test` (108 files, 1099 pass / 7 skipped), `npm run lint` (0 errors), `npm run check:module-size` (OK), `npm run check:bundle-size` (entryJs 72.9 KB / CSS 234.4 KB — within budget, no `size-budget.json` change).
