### PR TITLE
fix: exclude itch non-games from libraryGamesBase universe

### DIFF
--- a/js/personal-storage.js
+++ b/js/personal-storage.js
@@ -18,6 +18,7 @@ import {
   getSameTitleKeys,
   getTitleKeyIndex,
   normalizeNameForDedup,
+  itchIsGame,
 } from './game-core.js';
 import { PRE_HIDDEN_KEYS, getPreHiddenFallback } from './hidden-defaults.js';
 
@@ -543,7 +544,7 @@ export function filterCounted(list) {
 
 /** Main catalog + itch tab games, minus cross-store dupes and user-hidden rows. */
 export function libraryGamesBase() {
-  const itch = Array.isArray(state.itchGames) ? state.itchGames : [];
+  const itch = (Array.isArray(state.itchGames) ? state.itchGames : []).filter(itchIsGame);
   const main = state.allGames.filter(g => !state.crossStoreHiddenKeys.has(gameKey(g)));
   const seen = new Set();
   const out = [];

--- a/tests/library-universe.test.js
+++ b/tests/library-universe.test.js
@@ -21,4 +21,37 @@ describe('libraryGamesBase itch universe', () => {
     state.personal = {};
     expect(dashboardLibraryGames()).toHaveLength(1);
   });
+
+  it('dashboardLibraryGames excludes itch non-games (physical_game, assets, etc.)', async () => {
+    const { state } = await import('../js/state.js');
+    const { dashboardLibraryGames } = await import('../js/dashboard-shared.js');
+    state.allGames = [];
+    state.itchGames = [
+      {
+        name: 'Real Game',
+        store: 'itch',
+        id: 'itch-game',
+        classification: 'game',
+        header_image: 'https://example.com/g.jpg',
+      },
+      {
+        name: 'Physical Copy',
+        store: 'itch',
+        id: 'itch-physical',
+        classification: 'physical_game',
+        header_image: 'https://example.com/p.jpg',
+      },
+      {
+        name: 'Asset Pack',
+        store: 'itch',
+        id: 'itch-assets',
+        classification: 'assets',
+        header_image: 'https://example.com/a.jpg',
+      },
+    ];
+    state.crossStoreHiddenKeys = new Set();
+    state.personal = {};
+    expect(dashboardLibraryGames()).toHaveLength(1);
+    expect(dashboardLibraryGames()[0].name).toBe('Real Game');
+  });
 });


### PR DESCRIPTION
## Summary
Filter physical_game, assets, and other non-game itch classifications out of dashboard metrics so library totals match real playable titles.

## Test plan
- [x] library-universe.test.js covers itch non-game exclusion

Made with [Cursor](https://cursor.com)