### PR TITLE
fix: re-stamp dist manifest version on every build

### DIFF
--- a/scripts/build-frontend.mjs
+++ b/scripts/build-frontend.mjs
@@ -172,10 +172,13 @@ async function main() {
     }
   }
 
+  // Preserve prior keys (needed for partial --css-only / --js-only rebuilds),
+  // but always re-stamp builtAt/version last so a version bump can't be shadowed
+  // by a stale prior manifest (else check:dist-integrity fails forever).
   const manifest = {
+    ...prior,
     builtAt: new Date().toISOString(),
     version: JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8')).version,
-    ...prior,
   };
 
   if (!jsOnly) {

--- a/tests/test_server_built_frontend.py
+++ b/tests/test_server_built_frontend.py
@@ -97,3 +97,50 @@ def test_immutable_built_asset_detection(server_mod):
     assert server_mod._is_immutable_built_asset("/dist/js/app-CCCC.js")
     assert not server_mod._is_immutable_built_asset("/app.css")
     assert not server_mod._is_immutable_built_asset("/js/app.js")
+
+
+def test_built_table_query_worker_served_as_public_static(tmp_path, monkeypatch):
+    """The worker that js/table-query.js spawns in built mode resolves to
+    /dist/js/table-query.worker.js (tableQueryWorkerUrl, built branch). Guard
+    that this path is classified public AND actually served over HTTP, so the
+    off-main-thread filter/sort path can't silently 404 in a frozen build."""
+    import threading
+    import urllib.request
+    from functools import partial
+    from http.server import ThreadingHTTPServer
+
+    import server
+    import shared.install_paths as ip
+    from shared.server_static import static_class
+
+    assert static_class("/dist/js/table-query.worker.js") == "public"
+
+    worker = tmp_path / "dist" / "js" / "table-query.worker.js"
+    worker.parent.mkdir(parents=True)
+    worker.write_text("self.onmessage = () => {};\n", encoding="utf-8")
+
+    # _resolved_static_path_allowed (translate_path) validates against bundle_root.
+    monkeypatch.setattr(ip, "bundle_root", lambda: tmp_path)
+    monkeypatch.setattr(server, "ROOT", tmp_path)
+
+    httpd = ThreadingHTTPServer(
+        ("127.0.0.1", 0), partial(server.Handler, directory=str(tmp_path))
+    )
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        with urllib.request.urlopen(
+            f"http://127.0.0.1:{port}/dist/js/table-query.worker.js", timeout=5
+        ) as resp:
+            status = resp.status
+            ctype = resp.headers.get("Content-Type", "")
+            body = resp.read().decode("utf-8")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "javascript" in ctype.lower()
+    assert "onmessage" in body


### PR DESCRIPTION
## Summary
Spread prior manifest keys first but write builtAt/version last so a version bump cannot be shadowed by stale dist/manifest.json (check:dist-integrity would fail forever otherwise). Add HTTP test that built-mode serves table-query.worker.js.

## Test plan
- [x] npm run check:dist-integrity OK after build
- [x] test_server_built_frontend.py worker serve test passes

Made with [Cursor](https://cursor.com)