### PR TITLE
feat: Pro funnel hero banner + license activation polish

### DIFF
--- a/app.css
+++ b/app.css
@@ -6702,13 +6702,34 @@ html[data-init-view="wishlist"] .steal-list-footer-passive { display: none; }
   flex-direction: column;
   gap: 1.35rem;
 }
+.pro-view-funnel--yearly {
+  --accent: #a855f7;
+  --accent-bright: #9333ea;
+}
+.pro-view-funnel--monthly {
+  --accent: #38bdf8;
+  --accent-bright: #0ea5e9;
+}
 .pro-view-hero {
-  padding: 1.35rem 1.5rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0.85rem 1rem 1.1rem;
   border-radius: 14px;
   border: 1px solid color-mix(in srgb, var(--accent, #38bdf8) 35%, var(--border));
   background:
     radial-gradient(ellipse 80% 60% at 100% 0%, color-mix(in srgb, var(--accent) 14%, transparent), transparent 55%),
     linear-gradient(165deg, color-mix(in srgb, var(--accent) 8%, var(--bg-panel)), var(--bg-panel));
+}
+.pro-view-hero-banner {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--accent) 12%, transparent),
+    0 12px 40px color-mix(in srgb, var(--accent) 18%, transparent);
 }
 .pro-view-headline {
   margin: 0 0 0.5rem;

--- a/js/pro-view.js
+++ b/js/pro-view.js
@@ -23,10 +23,13 @@ import { savePrefs } from './prefs.js';
 
 export const PRO_WELCOME_STORAGE_KEY = 'baklog-pro-welcome';
 
+const PRO_BANNER_MONTHLY = 'assets/baklog-pro-polar.png';
+const PRO_BANNER_YEARLY = 'assets/baklog-pro-polar-yearly.png';
+
 let proViewWired = false;
 let checkoutSuccessPending = false;
 let licenseActivating = false;
-let selectedProPlan = 'monthly';
+let selectedProPlan = 'yearly';
 
 /** True while checkout return or license activation is still in flight (before reload). */
 export function isProActivationPending() {
@@ -78,6 +81,15 @@ function successBannerHtml() {
     <p class="pro-view-success-title">Payment received</p>
     <p class="pro-view-success-lead">Finish activation below - hosted accounts refresh automatically; local installs paste the license key from your Polar receipt.</p>
   </div>`;
+}
+
+function proHeroBannerSrc(plan) {
+  return plan === 'yearly' ? PRO_BANNER_YEARLY : PRO_BANNER_MONTHLY;
+}
+
+function proHeroBannerHtml(plan) {
+  const src = escapeAttr(proHeroBannerSrc(plan));
+  return `<img class="pro-view-hero-banner" data-pro-hero-banner src="${src}" alt="BAKLOG Pro - one honest backlog across every store" width="1200" height="630" loading="lazy" decoding="async" />`;
 }
 
 function proFeaturesListHtml({ compact = false } = {}) {
@@ -191,10 +203,11 @@ function proActiveHtml() {
 }
 
 function proPitchHtml({ showSuccess = false } = {}) {
+  const planClass = selectedProPlan === 'yearly' ? 'pro-view-funnel--yearly' : 'pro-view-funnel--monthly';
   return `${showSuccess ? successBannerHtml() : ''}
-    <div class="pro-view-funnel" role="region" aria-label="BAKLOG Pro">
+    <div class="pro-view-funnel ${planClass}" role="region" aria-label="BAKLOG Pro">
       <header class="pro-view-hero">
-        <p class="pro-view-eyebrow">${escapeHtml(PRO_PROMO.label)}</p>
+        ${proHeroBannerHtml(selectedProPlan)}
         <h1 class="pro-view-headline">${escapeHtml(PRO_PROMO.title)}</h1>
         <p class="pro-view-subhead">${escapeHtml(PRO_PROMO.tagline)}</p>
       </header>
@@ -223,6 +236,13 @@ function applyProPlanToggle(root, plan) {
   if (checkout) {
     checkout.href = selectedProPlan === 'yearly' ? yearly : monthly;
     checkout.textContent = selectedProPlan === 'yearly' ? PRO_PROMO.ctaYearly : PRO_PROMO.cta;
+  }
+  const banner = root.querySelector('[data-pro-hero-banner]');
+  if (banner) banner.src = proHeroBannerSrc(selectedProPlan);
+  const funnel = root.querySelector('.pro-view-funnel');
+  if (funnel) {
+    funnel.classList.toggle('pro-view-funnel--yearly', selectedProPlan === 'yearly');
+    funnel.classList.toggle('pro-view-funnel--monthly', selectedProPlan === 'monthly');
   }
 }
 

--- a/js/pro-view.js
+++ b/js/pro-view.js
@@ -10,7 +10,6 @@ import {
   getAccountProfileId,
   isAccountAuthMode,
   isPro,
-  licenseActivationEnabled,
   proCheckoutUrls,
   refreshAccountPlan,
 } from './auth-gate.js';
@@ -172,24 +171,20 @@ function proActivationHtml() {
         </div>
       </div>`;
   }
-  if (licenseActivationEnabled()) {
-    return `
-      <div class="pro-view-activate">
-        <h3 class="pro-view-section-title">Activate with your license key</h3>
-        <p class="pro-view-note">Subscribe above, then paste the <code>BAKLOG-XXXX</code> license key from your Polar receipt. Validation runs against Polar from this machine only.</p>
-        <form class="pro-view-license" data-pro-license-form>
-          <label class="pro-view-license-label" for="proViewLicenseKey">License key</label>
-          <div class="pro-view-license-row">
-            <input id="proViewLicenseKey" class="pro-view-license-input" type="text" name="license_key" placeholder="BAKLOG-XXXX-XXXX" autocomplete="off" spellcheck="false" />
-            <button type="submit" class="pro-view-btn">Activate</button>
-          </div>
-        </form>
-      </div>`;
-  }
   return `
     <div class="pro-view-activate">
       <h3 class="pro-view-section-title">After checkout</h3>
-      <p class="pro-view-note">Subscribe above, then paste your license key here. Set <code>BAKLOG_POLAR_ORG_ID</code> on the server to enable activation.</p>
+      <p class="pro-view-note">Subscribe above, then paste the <code>BAKLOG-XXXX</code> license key from your Polar receipt.</p>
+      <form class="pro-view-license" data-pro-license-form>
+        <label class="pro-view-license-label" for="proViewLicenseKey">License key</label>
+        <div class="pro-view-license-row">
+          <input id="proViewLicenseKey" class="pro-view-license-input" type="text" name="license_key" placeholder="BAKLOG-XXXX-XXXX" autocomplete="off" spellcheck="false" />
+          <button type="submit" class="pro-view-btn">Activate</button>
+        </div>
+      </form>
+      <div class="pro-view-actions">
+        <button type="button" class="pro-view-btn pro-view-btn--ghost" data-pro-refresh>Refresh Pro status</button>
+      </div>
     </div>`;
 }
 

--- a/shared/entitlement.py
+++ b/shared/entitlement.py
@@ -141,7 +141,7 @@ def activate_local_license_key(key: str) -> tuple[bool, str]:
     except Exception as exc:  # noqa: BLE001
         return False, f"License activation unavailable ({exc})"
     if not polar_configured():
-        return False, "Set BAKLOG_POLAR_ORG_ID on the server to enable license activation."
+        return False, "License activation isn't available right now. Try again later or contact support."
     cleaned = (key or "").strip()
     if not cleaned:
         return False, "Enter your license key."

--- a/tests/pro-view.test.js
+++ b/tests/pro-view.test.js
@@ -36,13 +36,16 @@ describe('renderProView', () => {
     document.body.innerHTML = '<div id="proContainer"><div id="proViewRoot"></div></div>';
   });
 
-  it('renders conversion funnel with toggle, six perks, and license field', async () => {
+  it('renders conversion funnel with hero banner, toggle, six perks, and license field', async () => {
     const { renderProView } = await import('../js/pro-view.js');
     renderProView();
     const root = document.getElementById('proViewRoot');
     expect(root.innerHTML).toContain(PRO_PROMO.title);
-    expect(root.innerHTML).toContain('Get Pro - $5/mo');
+    expect(root.innerHTML).toContain('Get Pro - $50/yr');
     expect(root.innerHTML).toContain('buy.polar.sh');
+    expect(root.querySelector('[data-pro-hero-banner]')).toBeTruthy();
+    expect(root.querySelector('[data-pro-hero-banner]')?.getAttribute('src')).toContain('baklog-pro-polar-yearly');
+    expect(root.querySelector('.pro-view-funnel--yearly')).toBeTruthy();
     expect(root.querySelector('[data-pro-plan="monthly"]')).toBeTruthy();
     expect(root.querySelector('[data-pro-plan="yearly"]')).toBeTruthy();
     expect(root.querySelector('[data-pro-checkout]')).toBeTruthy();
@@ -52,13 +55,15 @@ describe('renderProView', () => {
     expect(root.querySelector('[data-pro-license-form]')).toBeTruthy();
   });
 
-  it('switches checkout label when yearly plan is selected', async () => {
+  it('switches checkout label and hero banner when monthly plan is selected', async () => {
     const { renderProView, wireProView } = await import('../js/pro-view.js');
     wireProView();
     renderProView();
     const root = document.getElementById('proViewRoot');
-    root.querySelector('[data-pro-plan="yearly"]')?.click();
-    expect(root.querySelector('[data-pro-checkout]')?.textContent).toContain('$50/yr');
+    root.querySelector('[data-pro-plan="monthly"]')?.click();
+    expect(root.querySelector('[data-pro-checkout]')?.textContent).toContain('$5/mo');
+    expect(root.querySelector('[data-pro-hero-banner]')?.getAttribute('src')).toContain('baklog-pro-polar.png');
+    expect(root.querySelector('.pro-view-funnel--monthly')).toBeTruthy();
   });
 
   it('shows active state for Pro users', async () => {

--- a/tests/pro-view.test.js
+++ b/tests/pro-view.test.js
@@ -55,6 +55,17 @@ describe('renderProView', () => {
     expect(root.querySelector('[data-pro-license-form]')).toBeTruthy();
   });
 
+  it('shows license field and refresh even when license activation is disabled in config', async () => {
+    const authGate = await import('../js/auth-gate.js');
+    authGate.licenseActivationEnabled.mockReturnValue(false);
+    const { renderProView } = await import('../js/pro-view.js');
+    renderProView();
+    const root = document.getElementById('proViewRoot');
+    expect(root.querySelector('[data-pro-license-form]')).toBeTruthy();
+    expect(root.querySelector('[data-pro-refresh]')).toBeTruthy();
+    expect(root.innerHTML).not.toContain('BAKLOG_POLAR_ORG_ID');
+  });
+
   it('switches checkout label and hero banner when monthly plan is selected', async () => {
     const { renderProView, wireProView } = await import('../js/pro-view.js');
     wireProView();


### PR DESCRIPTION
## Summary
- Purple Pro funnel hero banner that swaps blue/purple with the monthly/yearly billing toggle
- Always show license activation form on Pro tab (drop licenseActivationEnabled gate); add Refresh Pro status beside the form

## Test plan
- [x] pro-view.test.js updated
- [ ] Visual check Pro tab hero + billing toggle in browser

Made with [Cursor](https://cursor.com)