### PR TITLE
fix: sort epic_client imports to satisfy ruff I001

### DIFF
--- a/fetch_epic.py
+++ b/fetch_epic.py
@@ -13,7 +13,7 @@ from urllib.parse import quote
 from dotenv import load_dotenv
 
 from auth import mark_invalid, resolve_env
-from epic_client import LOGIN_URL, EpicAuthError, EpicCorrectiveActionError, EpicClient, default_epic_cache_dir
+from epic_client import LOGIN_URL, EpicAuthError, EpicClient, EpicCorrectiveActionError, default_epic_cache_dir
 from fetchers._authoritative import EPIC
 from fetchers._base import (
     add_allow_empty_arg,


### PR DESCRIPTION
## Summary
Reorder the epic_client import so EpicClient precedes EpicCorrectiveActionError (ruff isort order-by-type). This clears the red ruff job on main introduced by the audit-remediation merge (#27).

## Test plan
- [x] ruff check . passes locally

Made with [Cursor](https://cursor.com)