### PR TITLE
chore: run ruff in test-all.ps1 to mirror CI Python job

### DIFF
--- a/scripts/test-all.ps1
+++ b/scripts/test-all.ps1
@@ -6,6 +6,10 @@ param(
 $ErrorActionPreference = "Stop"
 Set-Location (Split-Path -Parent $PSScriptRoot)
 
+Write-Host "==> ruff"
+python -m ruff check .
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
 Write-Host "==> pytest"
 python -m pytest -q
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }


### PR DESCRIPTION
## Summary
Add a ruff check . step before pytest in test-all.ps1 so local CI-parity runs catch Python lint/import-sort drift. This is the gap that let the fetch_epic.py I001 failure (PR #31) reach main.

## Test plan
- [x] python -m ruff check . passes locally

Made with [Cursor](https://cursor.com)