### PR TITLE
fix: recover dashboard marquee after sparse metrics auto-disable

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -36,7 +36,7 @@ import {
 import { renderDashboardCoopSpotlight, replaceCoopSponsorRow, renderDashboardPicksVersus, renderDashboardRecentAdditions, renderDashboardWishlistStats, renderDashboardItchRecap, renderDashboardSponsoredPick, renderDashboardFeatureBanner } from './dashboard-cards.js';
 import { pickSpotlightGames, renderSpotlightHtml, syncSpotlightInMega, primeSpotlightArt, startSpotlightRotation, stopSpotlightRotation, getSpotlightPool, setSpotlightCurrentKey } from './dashboard-spotlight.js';
 import { buildInsightPool, buildMarqueeItems, buildMegaLibraryContext, renderMarqueeHtml, renderMarqueeTrackInner, applyMarqueeSpeed, startInsightRotation, stopInsightRotation, observeMarqueeSpeed } from './dashboard-insights.js';
-import { commitRenderedMetrics } from './metrics-rendered.js';
+import { commitRenderedMetrics, noteRenderedKeysFromArtifacts } from './metrics-rendered.js';
 import { connectedProviderCount, authStatusLoaded } from './connections.js';
 import { getLibrarySnapshot } from './sabermetrics.js';
 import { THEME_CHANGE_EVENT } from './theme.js';
@@ -139,7 +139,10 @@ function megaContentFingerprint() {
 
 function buildMegaArtifacts(games, snap) {
   const key = megaContentFingerprint();
-  if (key === _megaArtifactsKey && _megaArtifactsCache) return _megaArtifactsCache;
+  if (key === _megaArtifactsKey && _megaArtifactsCache) {
+    noteRenderedKeysFromArtifacts(_megaArtifactsCache.marqueeItems, _megaArtifactsCache.insightPool);
+    return _megaArtifactsCache;
+  }
   const megaCtx = buildMegaLibraryContext(games);
   _megaArtifactsCache = {
     insightPool: buildInsightPool(games, snap, megaCtx),

--- a/js/metrics-rendered.js
+++ b/js/metrics-rendered.js
@@ -5,7 +5,7 @@
 // preserved. The admin Metrics tab just reads the result — no button needed.
 
 import { state } from './state.js';
-import { METRIC_KEYS } from './metric-tips.js';
+import { METRIC_KEYS, metricKeyForLabel, metricKeyForInsight } from './metric-tips.js';
 import { savePrefs } from './prefs.js';
 import { mergeUntappedBatchSeed } from './metrics-untapped-batch.js';
 
@@ -48,17 +48,22 @@ function writeRenderedMetricKeys(keys) {
 /**
  * Effective disabled set for "no-data metrics go to Unused", preserving the
  * user's manual hides of metrics that DO have data.
- * disabled = (currentDisabled ∩ rendered) ∪ (catalog − rendered)
+ * disabled = (catalog − rendered) ∪ manualHides
+ * manualHides = currentDisabled ∩ rendered ∩ previousRendered
+ * (only re-keep a hide when the metric had data last commit — not when a sparse
+ * render pass auto-disabled it because it was missing from rendered).
  * @param {string[]} catalogKeys
  * @param {string[]} renderedKeys
  * @param {string[]} currentDisabled
+ * @param {string[]} [previousRenderedKeys]
  * @returns {string[]}
  */
-export function computeAutoDisabled(catalogKeys, renderedKeys, currentDisabled = []) {
+export function computeAutoDisabled(catalogKeys, renderedKeys, currentDisabled = [], previousRenderedKeys = []) {
   const rendered = new Set(renderedKeys);
-  const preserved = currentDisabled.filter((k) => rendered.has(k));
+  const previousRendered = new Set(previousRenderedKeys);
   const noData = catalogKeys.filter((k) => !rendered.has(k));
-  return [...new Set([...preserved, ...noData])];
+  const manualHides = currentDisabled.filter((k) => rendered.has(k) && previousRendered.has(k));
+  return [...new Set([...noData, ...manualHides])];
 }
 
 // Per-render-pass key buckets. Builders note their pre-disable keys here; the
@@ -76,11 +81,21 @@ export function noteInsightMetricKeys(keys) {
   _insightKeys = [...new Set([...keys].filter(Boolean))];
 }
 
-function applyAutoDisabled(rendered) {
+/** Re-note keys when mega artifacts are served from cache (builders did not run). */
+export function noteRenderedKeysFromArtifacts(marqueeItems, insightPool) {
+  if (marqueeItems?.length) {
+    noteMarqueeMetricKeys(marqueeItems.map((it) => metricKeyForLabel(it.label)));
+  }
+  if (insightPool?.length) {
+    noteInsightMetricKeys(insightPool.map((e) => metricKeyForInsight(typeof e === 'string' ? e : e.html)));
+  }
+}
+
+function applyAutoDisabled(rendered, previousRendered) {
   try {
     let current = Array.isArray(state.prefs?.metricsDisabled) ? state.prefs.metricsDisabled : [];
     current = mergeUntappedBatchSeed(current);
-    const next = computeAutoDisabled(METRIC_KEYS, rendered, current);
+    const next = computeAutoDisabled(METRIC_KEYS, rendered, current, previousRendered);
     const curSet = new Set(current);
     const changed = next.length !== current.length || next.some((k) => !curSet.has(k));
     if (changed) {
@@ -100,6 +115,7 @@ function applyAutoDisabled(rendered) {
 export function commitRenderedMetrics() {
   const union = [...new Set([..._marqueeKeys, ..._insightKeys])];
   if (!union.length) return;
+  const previousRendered = loadRenderedMetricKeys();
+  applyAutoDisabled(union, previousRendered);
   writeRenderedMetricKeys(union);
-  applyAutoDisabled(union);
 }

--- a/tests/metrics-rendered.test.js
+++ b/tests/metrics-rendered.test.js
@@ -1,5 +1,33 @@
-import { describe, expect, it } from 'vitest';
-import { computeAutoDisabled } from '../js/metrics-rendered.js';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('../js/personal-storage.js', () => ({
+  getPersonal: vi.fn((g) => g._personal || { status: 'backlog' }),
+}));
+
+vi.mock('../js/deals.js', () => ({
+  getDealInfo: vi.fn(() => null),
+  dealScore: vi.fn(() => 0),
+  isStealDeal: vi.fn(() => false),
+  cutBucketClass: vi.fn(() => 'cut-low'),
+  computeWishlistWoba: vi.fn(() => null),
+  isCleanupCandidate: vi.fn(() => false),
+  parsePriceLike: vi.fn((v) => {
+    if (v == null) return null;
+    if (typeof v === 'number') return v;
+    const m = String(v).match(/-?\d+(?:\.\d+)?/);
+    return m ? parseFloat(m[0]) : null;
+  }),
+}));
+
+import { state } from '../js/state.js';
+import { buildMarqueeItems, buildMegaLibraryContext } from '../js/dashboard-insights.js';
+import { getLibrarySnapshot, invalidateLibrarySnapshot } from '../js/sabermetrics.js';
+import {
+  computeAutoDisabled,
+  noteMarqueeMetricKeys,
+  commitRenderedMetrics,
+  loadRenderedMetricKeys,
+} from '../js/metrics-rendered.js';
 
 describe('metrics-rendered computeAutoDisabled', () => {
   const catalog = ['games owned', 'stores', 'gamerscore earned', 'first PSN session'];
@@ -10,13 +38,12 @@ describe('metrics-rendered computeAutoDisabled', () => {
   });
 
   it('preserves manual hides of data-having metrics', () => {
-    const next = computeAutoDisabled(catalog, ['games owned', 'stores'], ['stores']);
-    expect(next).toEqual(['stores', 'gamerscore earned', 'first PSN session']);
+    const rendered = ['games owned', 'stores'];
+    const next = computeAutoDisabled(catalog, rendered, ['stores'], rendered);
+    expect(next.sort()).toEqual(['stores', 'gamerscore earned', 'first PSN session'].sort());
   });
 
   it('does not re-enable a no-data metric the user tried to keep used', () => {
-    // 'first PSN session' has no data; even if the user removed it from disabled,
-    // the auto-sync re-disables it because it can never render.
     const next = computeAutoDisabled(catalog, ['games owned', 'stores'], []);
     expect(next).toContain('first PSN session');
   });
@@ -25,5 +52,74 @@ describe('metrics-rendered computeAutoDisabled', () => {
     const next = computeAutoDisabled(catalog, ['games owned'], ['gamerscore earned']);
     expect(next).toEqual(['stores', 'gamerscore earned', 'first PSN session']);
     expect(new Set(next).size).toBe(next.length);
+  });
+
+  it('re-enables metrics after a sparse render pass auto-disabled them', () => {
+    const sparse = ['finish streak', 'league avg rating'];
+    const full = ['games owned', 'stores', 'finish streak', 'league avg rating'];
+    const bloatedDisabled = catalog.filter((k) => !sparse.includes(k));
+    const next = computeAutoDisabled(catalog, full, bloatedDisabled, sparse);
+    expect(next).not.toContain('games owned');
+    expect(next).not.toContain('stores');
+    expect(next).toEqual(['gamerscore earned', 'first PSN session']);
+  });
+});
+
+describe('commitRenderedMetrics marquee recovery', () => {
+  function game(overrides = {}) {
+    return {
+      store: 'steam',
+      id: overrides.id ?? String(Math.random()),
+      name: overrides.name ?? 'Test Game',
+      steam_review_percent: overrides.steam_review_percent ?? 85,
+      steam_review_count: overrides.steam_review_count ?? 500,
+      hltb_main_hours: overrides.hltb_main_hours ?? 10,
+      playtime_minutes: overrides.playtime_minutes ?? 0,
+      genres: overrides.genres ?? ['Action'],
+      last_played: overrides.last_played,
+      _personal: { status: overrides.status ?? 'backlog' },
+      ...overrides,
+    };
+  }
+
+  function makeLibrary(n = 200) {
+    const statuses = ['backlog', 'finished', 'playing', 'next', 'unfinished'];
+    return Array.from({ length: n }, (_, i) => game({
+      id: String(i),
+      name: `Game ${i}`,
+      status: statuses[i % statuses.length],
+      playtime_minutes: i % 3 === 0 ? 120 + i : 0,
+      last_played: i % 5 === 0 ? '2026-06-01' : '2024-01-01',
+    }));
+  }
+
+  beforeEach(() => {
+    state.prefs = { quickWinMaxHours: 15, metricsDisabled: [] };
+    state.wishlistGames = [];
+    state.itchGames = [];
+    window._dataVersion = 0;
+    invalidateLibrarySnapshot();
+    localStorage.clear();
+  });
+
+  it('does not permanently collapse marquee after a sparse rendered commit', () => {
+    const games = makeLibrary(200);
+    const snap = getLibrarySnapshot(games);
+    const ctx = buildMegaLibraryContext(games);
+
+    noteMarqueeMetricKeys(['finish streak', 'league avg rating']);
+    commitRenderedMetrics();
+
+    const broken = buildMarqueeItems(games, snap, ctx);
+    expect(broken.length).toBeLessThan(10);
+
+    buildMarqueeItems(games, snap, ctx);
+    commitRenderedMetrics();
+
+    expect(loadRenderedMetricKeys()).toContain('games owned');
+    expect(state.prefs.metricsDisabled).not.toContain('games owned');
+
+    const healed = buildMarqueeItems(games, snap, ctx);
+    expect(healed.length).toBeGreaterThan(20);
   });
 });


### PR DESCRIPTION
## Summary
- Fix `commitRenderedMetrics` writing rendered keys before `applyAutoDisabled`, which caused wrongly auto-disabled metrics to be preserved as manual hides and permanently collapse the marquee to ~2 chips.
- Only preserve manual hides when a metric was in both `previousRendered` and the new rendered set; re-note keys on mega-artifact cache hits.
- Add regression tests in `tests/metrics-rendered.test.js`.

## Test plan
- [x] `npm test -- tests/metrics-rendered.test.js tests/dashboard-marquee.test.js`
- [ ] Reload dashboard on a large library; marquee shows many chips and scrolls
- [ ] Confirm stale `metricsDisabled` clears after one or two reloads