### PR TITLE
fix: fill missing dashboard insight-pill tooltips

### DIFF
--- a/js/metric-tips.js
+++ b/js/metric-tips.js
@@ -408,6 +408,34 @@ const PREFIX_TIPS = [
   { prefix: 'playtime in', key: 'playtime in' },
 ];
 
+/**
+ * Insight-pill concepts whose extracted text never matches a METRIC_TIPS key
+ * (year/value suffixes, no colon, or near-duplicate wording). Each maps to a
+ * semantically exact existing key so the pill still gets a tooltip without
+ * minting a new metric id (keeps the admin Metrics catalog sync pair intact).
+ * Matched against the stripped insight text by prefix.
+ */
+const INSIGHT_CONCEPT_ALIASES = [
+  { prefix: 'Playing since', key: 'first PSN session' },
+  { prefix: 'Most sessions', key: 'most PSN sessions' },
+  { prefix: 'PSN sessions', key: 'PSN sessions total' },
+  { prefix: 'PSN tenure', key: 'PSN library tenure' },
+  { prefix: 'Will you die first?', key: 'Will you die first?' },
+];
+
+/**
+ * Resolve an insight's stripped text to a canonical key via the alias table.
+ * @param {string} text
+ * @returns {string}
+ */
+function insightAliasKey(text) {
+  if (!text) return '';
+  for (const { prefix, key } of INSIGHT_CONCEPT_ALIASES) {
+    if (text.startsWith(prefix)) return key;
+  }
+  return '';
+}
+
 function normalizeLabel(label) {
   if (!label) return '';
   let s = String(label).trim();
@@ -494,6 +522,8 @@ export function metricKeyForInsight(html) {
   if (text.includes('still untouched') || text.startsWith('Added')) {
     return metricKeyForLabel('Added');
   }
+  const alias = insightAliasKey(text);
+  if (alias) return metricKeyForLabel(alias);
   return metricKeyForLabel(concept);
 }
 
@@ -523,5 +553,7 @@ export function insightTip(html) {
   if (text.includes('still untouched') || text.startsWith('Added')) {
     return METRIC_TIPS['Added'];
   }
+  const alias = insightAliasKey(text);
+  if (alias && METRIC_TIPS[alias]) return METRIC_TIPS[alias];
   return marqueeTip(concept);
 }

--- a/tests/metric-tips.test.js
+++ b/tests/metric-tips.test.js
@@ -148,6 +148,14 @@ describe('metricKeyForInsight', () => {
   it('resolves pace insight without colon', () => {
     expect(metricKeyForInsight('~<strong>4.2</strong> yrs to clear at your pace')).toBe('to clear at your pace');
   });
+
+  it('resolves previously-untooltipped insight pills via concept aliases', () => {
+    expect(metricKeyForInsight('Playing since <strong>2015</strong>: <strong>Foo</strong>')).toBe('first PSN session');
+    expect(metricKeyForInsight('Most sessions: <strong>Foo</strong> · 42')).toBe('most PSN sessions');
+    expect(metricKeyForInsight('PSN sessions: <strong>120</strong> total')).toBe('PSN sessions total');
+    expect(metricKeyForInsight('PSN tenure: <strong>6.3</strong> yrs since first session')).toBe('PSN library tenure');
+    expect(metricKeyForInsight('Will you die first? <strong>Backlog wins</strong> · finish by age 80')).toBe('Will you die first?');
+  });
 });
 
 describe('insightTip', () => {
@@ -178,6 +186,21 @@ describe('insightTip', () => {
 
   it('returns empty for unknown insight', () => {
     expect(insightTip('Unknown nonsense metric: <strong>1</strong>')).toBe('');
+  });
+
+  it('gives every insight pill a tooltip (no empty inspiration pills)', () => {
+    const insights = [
+      'Playing since <strong>2015</strong>: <strong>Foo</strong>',
+      'Most sessions: <strong>Foo</strong> · 42',
+      'PSN sessions: <strong>120</strong> total',
+      'PSN tenure: <strong>6.3</strong> yrs since first session',
+      'Will you die first? <strong>Backlog wins</strong> · finish by age 80',
+    ];
+    for (const html of insights) {
+      expect(insightTip(html), html).not.toBe('');
+    }
+    expect(insightTip('Playing since <strong>2015</strong>: <strong>Foo</strong>')).toMatch(/PSN|first_played|earliest/i);
+    expect(insightTip('Will you die first? <strong>Backlog wins</strong> · finish by age 80')).toMatch(/backlog|life expectancy/i);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add prefix aliases in \js/metric-tips.js\ so five dashboard insight ticker concepts resolve to existing \METRIC_TIPS\ copy
- Covers Playing since, Most sessions, PSN sessions, PSN tenure, and Will you die first? pills that previously had empty tooltips
- No new metric ids (admin Metrics catalog sync pair unchanged)

## Test plan
- [x] \
px vitest run tests/metric-tips.test.js\ (35 tests)
- [ ] Hover rotating insight ticker when PSN / mortality insights appear

Made with [Cursor](https://cursor.com)