### PR TITLE
chore: debug-gated claims + recents instrumentation

### DIFF
--- a/build_free_claims.py
+++ b/build_free_claims.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import time
 from datetime import UTC, datetime
@@ -38,6 +39,12 @@ ITAD_GAME_SLUG_RE = re.compile(
     r"isthereanydeal\.com/game/([^/\"'>]+)/info",
     re.IGNORECASE,
 )
+DEBUG_CLAIMS = os.environ.get("BAKLOG_DEBUG_CLAIMS") == "1"
+
+
+def _debug_claims(msg: str) -> None:
+    if DEBUG_CLAIMS:
+        print(f"  [claims-debug] {msg}", flush=True)
 
 
 def _clean_blurb(raw: object) -> str | None:
@@ -1278,6 +1285,12 @@ def main() -> int:
         return stats.finish("build_free_claims", t0, exit_code=1)
 
     auto_items_all = _load_auto_items(AUTO_PATH)
+    if DEBUG_CLAIMS:
+        by_source: dict[str, int] = {}
+        for row in auto_items_all:
+            src = str(row.get("source") or "unknown")
+            by_source[src] = by_source.get(src, 0) + 1
+        _debug_claims(f"auto feed: {len(auto_items_all)} item(s) by source {by_source}")
     approved_ids = _load_approved_ids(APPROVED_PATH)
     dismissed_ids = _load_dismissed_ids(APPROVED_PATH)
     premium_only_ids = _load_premium_only_ids(APPROVED_PATH)
@@ -1367,6 +1380,11 @@ def main() -> int:
         stats.warn(
             f"auto feed: {len(auto_items)} approved of {len(auto_items_all)} available"
         )
+    if DEBUG_CLAIMS:
+        _debug_claims(
+            f"approved selection: {len(auto_items)} of {len(auto_items_all)} auto; "
+            f"dismissed={len(dismissed_ids)} expired_approved={len(expired_approved_ids)}"
+        )
     raw_items = merge_manual_and_auto(manual_items, auto_items)
     if auto_items:
         stats.warn(f"merged {len(auto_items)} auto item(s); {len(raw_items)} total before enrich")
@@ -1398,6 +1416,10 @@ def main() -> int:
             f"carried forward {len(carried)} approved claim(s) missing from the "
             f"source feed: {', '.join(str(c.get('id')) for c in carried)}"
         )
+        if DEBUG_CLAIMS:
+            _debug_claims(
+                f"carry-forward ids: {', '.join(str(c.get('id')) for c in carried)}"
+            )
         items.extend(carried)
 
     _apply_premium_only(
@@ -1422,6 +1444,22 @@ def main() -> int:
     }
     if has_gamerpower:
         profile_payload["attribution"] = [GAMERPOWER_ATTRIBUTION]
+    if DEBUG_CLAIMS:
+        pub_by_source: dict[str, int] = {}
+        for row in items:
+            src = str(row.get("source") or "unknown")
+            pub_by_source[src] = pub_by_source.get(src, 0) + 1
+        title_keys: dict[str, list[str]] = {}
+        for row in items:
+            title = norm_title(row.get("title"))
+            if not title:
+                continue
+            title_keys.setdefault(title, []).append(str(row.get("id") or ""))
+        dup_titles = sum(1 for ids in title_keys.values() if len(ids) > 1)
+        _debug_claims(
+            f"publish: {len(items)} item(s) by source {pub_by_source}; "
+            f"title collisions={dup_titles}"
+        )
     text = json.dumps(payload, indent=2, ensure_ascii=False)
     profile_text = json.dumps(profile_payload, indent=2, ensure_ascii=False)
 

--- a/fetch_claim_sources.py
+++ b/fetch_claim_sources.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -19,6 +20,7 @@ from shared.free_claims_sources import (
     ITAD_GIVEAWAYS_RSS,
     carry_claim_enrichment,
     dedup_claim_items_by_id,
+    norm_title,
     parse_epic_payload,
     parse_gamerpower_payload,
     parse_itad_rss,
@@ -28,6 +30,12 @@ from shared.safe_write import safe_write_text
 OUTPUT_PATH = Path("curated/free_claims.auto.json")
 USER_AGENT = "BAKLOG-fetch_claim_sources/1.0"
 REQUEST_TIMEOUT = 30
+DEBUG_CLAIMS = os.environ.get("BAKLOG_DEBUG_CLAIMS") == "1"
+
+
+def _debug_claims(msg: str) -> None:
+    if DEBUG_CLAIMS:
+        print(f"  [claims-debug] {msg}", flush=True)
 
 
 def _fetch_json(url: str) -> dict | list:
@@ -109,6 +117,22 @@ def collect_claims(
                 stats.warn(f"ITAD source skipped: {exc}")
 
     deduped = dedup_claim_items_by_id(collected)
+    if DEBUG_CLAIMS:
+        _debug_claims(f"per-source counts: {counts or {}}")
+        _debug_claims(f"collected before id-dedup: {len(collected)}")
+        _debug_claims(f"after dedup_claim_items_by_id: {len(deduped)}")
+        title_keys: dict[str, list[str]] = {}
+        for item in deduped:
+            title = norm_title(item.get("title"))
+            if not title:
+                continue
+            title_keys.setdefault(title, []).append(str(item.get("id") or ""))
+        dup_titles = {k: v for k, v in title_keys.items() if len(v) > 1}
+        if dup_titles:
+            _debug_claims(
+                f"title collisions (kept for admin DUPE stamp): "
+                f"{len(dup_titles)} title(s), e.g. {list(dup_titles.items())[:3]}"
+            )
     return deduped, counts
 
 

--- a/js/claimable.js
+++ b/js/claimable.js
@@ -10,6 +10,7 @@ import { syncCoverFits } from './covers.js';
 import { getAdsForLocation, sponsoredClaimCardHtml } from './sponsored-deals.js';
 import { isPro } from './auth-gate.js';
 import { affiliateUrl } from './affiliate.js';
+import { isDebugEnabled } from './debug-overlay.js';
 import {
   stripClaimTitleDecorations,
   dedupeClaims,
@@ -134,27 +135,65 @@ function claimTitleNorms(title) {
   return [...norms];
 }
 
-export function isClaimOwned(claim) {
-  if (!claim) return false;
+function claimOwnedReason(claim) {
+  if (!claim) return null;
   const appid = claim.steam_appid;
-  let appidMatched = false;
   if (appid != null) {
     const sid = String(appid);
     const ownedAppids = state.ownedSteamAppids;
     if (ownedAppids instanceof Set) {
-      // O(1) lookup against the precomputed set (buildOwnedNormNames).
-      appidMatched = ownedAppids.has(sid);
+      if (ownedAppids.has(sid)) return 'owned-by-appid';
     } else {
-      // Fallback for the brief boot window before the set is built.
-      appidMatched = state.allGames.some(g => g.store === 'steam' && String(g.appid ?? g.id) === sid)
+      const appidMatched = state.allGames.some(g => g.store === 'steam' && String(g.appid ?? g.id) === sid)
         || state.allGames.some(g => gameKey(g) === `steam:${sid}`);
+      if (appidMatched) return 'owned-by-appid';
     }
   }
   const norms = claimTitleNorms(claim.title);
-  const titleMatched = norms.some(n => state.ownedNormNames?.has(n));
-  if (appidMatched) return true;
-  if (titleMatched) return true;
-  return false;
+  if (norms.some(n => state.ownedNormNames?.has(n))) return 'owned-by-title';
+  return null;
+}
+
+export function isClaimOwned(claim) {
+  return claimOwnedReason(claim) != null;
+}
+
+/** Debug-only: why a feed row is visible, hidden, or filtered out. */
+export function claimDispositionReason(c, now = Date.now(), pro = isPro()) {
+  if (!isClaimFeedItemValid(c)) return 'invalid';
+  if (isClaimExpired(c, now)) return 'expired';
+  const owned = claimOwnedReason(c);
+  if (owned) return owned;
+  if (isClaimDismissed(c)) return 'dismissed';
+  if (c.premium_only && !pro) return 'premium-gated';
+  return 'eligible';
+}
+
+function logClaimsFeedDebug(doc, source) {
+  if (!isDebugEnabled()) return;
+  const items = doc?.items || [];
+  console.debug('[baklog-claims] feed loaded', {
+    source,
+    generated_at: doc?.generated_at ?? null,
+    fetched_at: doc?.fetched_at ?? null,
+    total: items.length,
+    visible: state.claimableNow?.length ?? 0,
+    owned: getOwnedClaims(items).length,
+    dismissed: getHiddenClaims(items).length,
+  });
+}
+
+function logClaimsDispositionDebug(items) {
+  if (!isDebugEnabled()) return;
+  const now = Date.now();
+  const pro = isPro();
+  console.debug('[baklog-claims] dispositions', (items || []).map((c) => ({
+    id: c.id,
+    store: c.store,
+    source: c.source,
+    title: c.title,
+    disposition: claimDispositionReason(c, now, pro),
+  })));
 }
 
 // Every stable identity a claim can be matched on. A claim's appid is filled in
@@ -353,11 +392,13 @@ function applyFeedDoc(doc, source = 'unknown') {
   // happens to carry a single claim.
   _claimDismissedSinceLoad = false;
   applyVisibleClaims();
+  logClaimsFeedDebug(state.claimableFeed, source);
 }
 
 function applyVisibleClaims() {
   const items = state.claimableFeed?.items || [];
   state.claimableNow = getVisibleClaims(items);
+  logClaimsDispositionDebug(items);
 }
 
 async function loadLocalClaimsFile() {
@@ -617,7 +658,20 @@ export function handleClaimableClick(e) {
     const id = goBtn.dataset.claimGo;
     const claim = (state.claimableFeed?.items || []).find(c => c.id === id)
       || state.claimableNow.find(c => c.id === id);
-    if (isSafeHttpUrl(claim?.claim_url)) window.open(affiliateUrl(claim.claim_url), '_blank', 'noopener,noreferrer');
+    if (isSafeHttpUrl(claim?.claim_url)) {
+      const outbound = affiliateUrl(claim.claim_url);
+      if (isDebugEnabled()) {
+        console.debug('[baklog-claims] claim open', {
+          id: claim.id,
+          store: claim.store,
+          source: claim.source,
+          claim_url: claim.claim_url,
+          affiliateApplied: outbound !== claim.claim_url,
+          outbound,
+        });
+      }
+      window.open(outbound, '_blank', 'noopener,noreferrer');
+    }
     return true;
   }
   const card = e.target.closest('[data-claim-id]');

--- a/js/dashboard-spotlight.js
+++ b/js/dashboard-spotlight.js
@@ -13,6 +13,7 @@ import * as MetricTips from './metric-tips.js';
 import { familyForEyebrow, spreadByFamily, FAMILY } from './stat-families.js';
 import { registerPausable } from './visibility.js';
 import { getAdsForLocation, getSpotlightHouseAds, sponsorToSpotlightGame, spotlightLogoMarkHtml, SPOTLIGHT_PREMIUM_SCHEMES, sponsorActionAttrs } from './sponsored-deals.js';
+import { isDebugEnabled } from './debug-overlay.js';
 
 // Namespace import avoids link-time failure if metric-tips.js is stale/truncated
 // (data maps may load while named function exports are missing).
@@ -459,6 +460,7 @@ export function computeRecentAdditions(games, cap = 10) {
   const seen = state.libraryFirstSeenByKey || {};
   const picked = new Set();
   const out = [];
+  const debugEntries = isDebugEnabled() ? [] : null;
 
   const tracked = games
     .map(g => ({ g, at: seen[gameKey(g)] ?? 0 }))
@@ -471,6 +473,7 @@ export function computeRecentAdditions(games, cap = 10) {
     if (picked.has(key)) continue;
     picked.add(key);
     out.push({ ...e.g, _addedAt: e.at });
+    debugEntries?.push({ name: e.g.name, _addedAt: e.at, source: 'tracked' });
   }
 
   if (out.length < cap) {
@@ -482,8 +485,23 @@ export function computeRecentAdditions(games, cap = 10) {
       if (out.length >= cap) break;
       const key = gameKey(e.g);
       picked.add(key);
-      out.push({ ...e.g, _addedAt: displayAddedAtForRecent(e.g, 0) });
+      const addedAt = displayAddedAtForRecent(e.g, 0);
+      out.push({ ...e.g, _addedAt: addedAt });
+      debugEntries?.push({ name: e.g.name, _addedAt: addedAt, source: 'backfill' });
     }
+  }
+
+  if (debugEntries) {
+    const trackedInCard = debugEntries.filter((e) => e.source === 'tracked').length;
+    const backfillInCard = debugEntries.length - trackedInCard;
+    console.debug('[baklog-recents] computeRecentAdditions', {
+      inputCount: games.length,
+      cap,
+      trackedPool: tracked.length,
+      trackedInCard,
+      backfillInCard,
+      entries: debugEntries,
+    });
   }
 
   return out;

--- a/js/library-load.js
+++ b/js/library-load.js
@@ -33,6 +33,7 @@ import {
   libraryGamesBase,
 } from './personal-storage.js';
 import { savePrefs } from './prefs.js';
+import { isDebugEnabled } from './debug-overlay.js';
 import { invalidateTableCache } from './table-ui.js';
 import {
   refreshFilterUI,
@@ -214,6 +215,7 @@ export function recordLibraryFirstSeen() {
   const effectiveSeeded = seeded && !mapWasEmpty;
   let changed = false;
   let newlyStamped = 0;
+  const debugNewKeys = isDebugEnabled() && effectiveSeeded ? [] : null;
   // itch games live in state.itchGames (their own tab), not state.allGames.
   // Stamp them too so itch additions get a first-seen timestamp and can
   // surface in recents / the +N added flash instead of vanishing silently.
@@ -223,7 +225,20 @@ export function recordLibraryFirstSeen() {
     if (key in state.libraryFirstSeenByKey) continue;
     state.libraryFirstSeenByKey[key] = effectiveSeeded ? Date.now() : 0;
     changed = true;
-    if (effectiveSeeded) newlyStamped += 1;
+    if (effectiveSeeded) {
+      newlyStamped += 1;
+      debugNewKeys?.push(key);
+    }
+  }
+  if (isDebugEnabled()) {
+    console.debug('[baklog-recents] recordLibraryFirstSeen', {
+      mapWasEmpty,
+      seeded,
+      effectiveSeeded,
+      totalKeys: Object.keys(state.libraryFirstSeenByKey).length,
+      newlyStamped,
+      newlyStampedKeys: debugNewKeys ?? [],
+    });
   }
   if (!state.prefs.librarySeenSeeded) {
     state.prefs.librarySeenSeeded = true;


### PR DESCRIPTION
## Summary
- **Claims frontend** (\?debug=1\): feed provenance, per-claim disposition (\claimDispositionReason\), outbound claim click with affiliate flag
- **Claims backend** (\BAKLOG_DEBUG_CLAIMS=1\): per-source counts, dedup summary, title collisions in \etch_claim_sources.py\; auto/approved/publish summary in \uild_free_claims.py\
- **Recents frontend** (\?debug=1\): \ecordLibraryFirstSeen\ stamping stats + \computeRecentAdditions\ tracked vs backfill split

## Test plan
- [x] \
pm test\ recent-additions + claimable + claim-card (72/72)
- [x] \	est-all.ps1 -Full\ green
- [ ] User live verify with \?debug=1\: fetch sweep + claim-and-verify owned drop

Made with [Cursor](https://cursor.com)