### PR TITLE
fix: heal dashboard marquee cache re-poison on second boot render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,12 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Fixed
 
+- **Dashboard marquee stuck at two chips after hard reload** — boot’s second
+  `scheduleDashboardRender` could cache-hit a sparse marquee built under stale
+  `metricsDisabled` and re-poison metric keys from filtered chips. Mega-artifact
+  fingerprint now includes `metricsDisabled`, cache stores pre-filter
+  `marqueeMetricKeys`, and a corruption guard heals implausibly bloated disabled
+  sets (`js/dashboard.js`, `js/metrics-rendered.js`).
 - **App shell 404 with Supabase auth** — `GET /` returned 404 because Python
   3.13 `translate_path` no longer maps directory requests to `index.html`.
 - **Vitest unhandled rejection** — `cancel-in-flight.test.js` now stubs

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -36,7 +36,7 @@ import {
 import { renderDashboardCoopSpotlight, replaceCoopSponsorRow, renderDashboardPicksVersus, renderDashboardRecentAdditions, renderDashboardWishlistStats, renderDashboardItchRecap, renderDashboardSponsoredPick, renderDashboardFeatureBanner } from './dashboard-cards.js';
 import { pickSpotlightGames, renderSpotlightHtml, syncSpotlightInMega, primeSpotlightArt, startSpotlightRotation, stopSpotlightRotation, getSpotlightPool, setSpotlightCurrentKey } from './dashboard-spotlight.js';
 import { buildInsightPool, buildMarqueeItems, buildMegaLibraryContext, renderMarqueeHtml, renderMarqueeTrackInner, applyMarqueeSpeed, startInsightRotation, stopInsightRotation, observeMarqueeSpeed } from './dashboard-insights.js';
-import { commitRenderedMetrics, noteRenderedKeysFromArtifacts } from './metrics-rendered.js';
+import { commitRenderedMetrics, restoreNotedMetricKeysFromArtifacts, snapshotNotedMetricKeys } from './metrics-rendered.js';
 import { connectedProviderCount, authStatusLoaded } from './connections.js';
 import { getLibrarySnapshot } from './sabermetrics.js';
 import { THEME_CHANGE_EVENT } from './theme.js';
@@ -72,7 +72,7 @@ const _dashLastCounters = {};
 let _marqueeItemsKey = "";
 let _marqueeSpeedDisconnect = null;
 let _megaArtifactsKey = "";
-/** @type {{ insightPool: unknown[], marqueeItems: unknown[], spotlightPool: object[] } | null} */
+/** @type {{ insightPool: unknown[], marqueeItems: unknown[], spotlightPool: object[], marqueeMetricKeys?: string[], insightMetricKeys?: string[] } | null} */
 let _megaArtifactsCache = null;
 
 // Entrance animations may only replay when switchView('dashboard') sets the
@@ -131,6 +131,8 @@ function megaContentFingerprint() {
   try {
     const fp = JSON.parse(dashboardFingerprint());
     delete fp.th;
+    const md = state.prefs?.metricsDisabled;
+    fp.md = Array.isArray(md) && md.length ? [...md].sort().join('\0') : '';
     return JSON.stringify(fp);
   } catch (_) {
     return dashboardFingerprint();
@@ -140,14 +142,19 @@ function megaContentFingerprint() {
 function buildMegaArtifacts(games, snap) {
   const key = megaContentFingerprint();
   if (key === _megaArtifactsKey && _megaArtifactsCache) {
-    noteRenderedKeysFromArtifacts(_megaArtifactsCache.marqueeItems, _megaArtifactsCache.insightPool);
+    restoreNotedMetricKeysFromArtifacts(_megaArtifactsCache);
     return _megaArtifactsCache;
   }
   const megaCtx = buildMegaLibraryContext(games);
+  const insightPool = buildInsightPool(games, snap, megaCtx);
+  const marqueeItems = buildMarqueeItems(games, snap, megaCtx);
+  const { marqueeMetricKeys, insightMetricKeys } = snapshotNotedMetricKeys();
   _megaArtifactsCache = {
-    insightPool: buildInsightPool(games, snap, megaCtx),
-    marqueeItems: buildMarqueeItems(games, snap, megaCtx),
+    insightPool,
+    marqueeItems,
     spotlightPool: pickSpotlightGames(games, snap),
+    marqueeMetricKeys,
+    insightMetricKeys,
   };
   _megaArtifactsKey = key;
   return _megaArtifactsCache;

--- a/js/metrics-rendered.js
+++ b/js/metrics-rendered.js
@@ -5,7 +5,7 @@
 // preserved. The admin Metrics tab just reads the result — no button needed.
 
 import { state } from './state.js';
-import { METRIC_KEYS, metricKeyForLabel, metricKeyForInsight } from './metric-tips.js';
+import { METRIC_KEYS, metricKeyForInsight } from './metric-tips.js';
 import { savePrefs } from './prefs.js';
 import { mergeUntappedBatchSeed } from './metrics-untapped-batch.js';
 
@@ -81,20 +81,47 @@ export function noteInsightMetricKeys(keys) {
   _insightKeys = [...new Set([...keys].filter(Boolean))];
 }
 
-/** Re-note keys when mega artifacts are served from cache (builders did not run). */
-export function noteRenderedKeysFromArtifacts(marqueeItems, insightPool) {
-  if (marqueeItems?.length) {
-    noteMarqueeMetricKeys(marqueeItems.map((it) => metricKeyForLabel(it.label)));
+/** Snapshot pre-disable keys noted by builders (for mega-artifact cache). */
+export function snapshotNotedMetricKeys() {
+  return {
+    marqueeMetricKeys: [..._marqueeKeys],
+    insightMetricKeys: [..._insightKeys],
+  };
+}
+
+/**
+ * Restore noted keys from cached mega artifacts. Never derive marquee keys from
+ * post-filter visible chips — that re-poisons metricsDisabled on cache hits.
+ * @param {{ marqueeMetricKeys?: string[], insightMetricKeys?: string[], insightPool?: unknown[] }} artifacts
+ */
+export function restoreNotedMetricKeysFromArtifacts(artifacts) {
+  if (!artifacts) return;
+  if (artifacts.marqueeMetricKeys?.length) {
+    noteMarqueeMetricKeys(artifacts.marqueeMetricKeys);
   }
-  if (insightPool?.length) {
-    noteInsightMetricKeys(insightPool.map((e) => metricKeyForInsight(typeof e === 'string' ? e : e.html)));
+  if (artifacts.insightMetricKeys?.length) {
+    noteInsightMetricKeys(artifacts.insightMetricKeys);
+  } else if (artifacts.insightPool?.length) {
+    noteInsightMetricKeys(artifacts.insightPool.map((e) => metricKeyForInsight(typeof e === 'string' ? e : e.html)));
   }
+}
+
+/** True when a huge disabled set meets a tiny rendered union (cache re-poison). */
+export function isImplausibleDisabledBloat(currentDisabled, renderedUnion) {
+  const catalogSize = METRIC_KEYS.length;
+  if (!catalogSize || !Array.isArray(currentDisabled) || !currentDisabled.length) return false;
+  if (currentDisabled.length / catalogSize <= 0.8) return false;
+  const unionLen = Array.isArray(renderedUnion) ? renderedUnion.length : 0;
+  return unionLen > 0 && unionLen < 15;
 }
 
 function applyAutoDisabled(rendered, previousRendered) {
   try {
     let current = Array.isArray(state.prefs?.metricsDisabled) ? state.prefs.metricsDisabled : [];
     current = mergeUntappedBatchSeed(current);
+    if (isImplausibleDisabledBloat(current, rendered)) {
+      current = [];
+    }
     const next = computeAutoDisabled(METRIC_KEYS, rendered, current, previousRendered);
     const curSet = new Set(current);
     const changed = next.length !== current.length || next.some((k) => !curSet.has(k));

--- a/tests/metrics-rendered.test.js
+++ b/tests/metrics-rendered.test.js
@@ -22,11 +22,16 @@ vi.mock('../js/deals.js', () => ({
 import { state } from '../js/state.js';
 import { buildMarqueeItems, buildMegaLibraryContext } from '../js/dashboard-insights.js';
 import { getLibrarySnapshot, invalidateLibrarySnapshot } from '../js/sabermetrics.js';
+import { METRIC_KEYS } from '../js/metric-tips.js';
 import {
   computeAutoDisabled,
   noteMarqueeMetricKeys,
+  noteInsightMetricKeys,
   commitRenderedMetrics,
   loadRenderedMetricKeys,
+  snapshotNotedMetricKeys,
+  restoreNotedMetricKeysFromArtifacts,
+  isImplausibleDisabledBloat,
 } from '../js/metrics-rendered.js';
 
 describe('metrics-rendered computeAutoDisabled', () => {
@@ -118,6 +123,103 @@ describe('commitRenderedMetrics marquee recovery', () => {
 
     expect(loadRenderedMetricKeys()).toContain('games owned');
     expect(state.prefs.metricsDisabled).not.toContain('games owned');
+
+    const healed = buildMarqueeItems(games, snap, ctx);
+    expect(healed.length).toBeGreaterThan(20);
+  });
+});
+
+describe('marquee cache re-poison guard', () => {
+  function game(overrides = {}) {
+    return {
+      store: 'steam',
+      id: overrides.id ?? String(Math.random()),
+      name: overrides.name ?? 'Test Game',
+      steam_review_percent: overrides.steam_review_percent ?? 85,
+      steam_review_count: overrides.steam_review_count ?? 500,
+      hltb_main_hours: overrides.hltb_main_hours ?? 10,
+      playtime_minutes: overrides.playtime_minutes ?? 0,
+      genres: overrides.genres ?? ['Action'],
+      last_played: overrides.last_played,
+      _personal: { status: overrides.status ?? 'backlog' },
+      ...overrides,
+    };
+  }
+
+  function makeLibrary(n = 200) {
+    const statuses = ['backlog', 'finished', 'playing', 'next', 'unfinished'];
+    return Array.from({ length: n }, (_, i) => game({
+      id: String(i),
+      name: `Game ${i}`,
+      status: statuses[i % statuses.length],
+      playtime_minutes: i % 3 === 0 ? 120 + i : 0,
+      last_played: i % 5 === 0 ? '2026-06-01' : '2024-01-01',
+    }));
+  }
+
+  beforeEach(() => {
+    state.prefs = { quickWinMaxHours: 15, metricsDisabled: [] };
+    state.wishlistGames = [];
+    state.itchGames = [];
+    window._dataVersion = 0;
+    invalidateLibrarySnapshot();
+    localStorage.clear();
+  });
+
+  it('restoreNotedMetricKeysFromArtifacts uses cached pre-filter keys, not filtered chips', () => {
+    const games = makeLibrary(200);
+    const snap = getLibrarySnapshot(games);
+    const ctx = buildMegaLibraryContext(games);
+
+    buildMarqueeItems(games, snap, ctx);
+    const { marqueeMetricKeys, insightMetricKeys } = snapshotNotedMetricKeys();
+    expect(marqueeMetricKeys.length).toBeGreaterThan(15);
+
+    noteMarqueeMetricKeys(['finish streak', 'league avg rating']);
+    restoreNotedMetricKeysFromArtifacts({
+      marqueeItems: [{ label: 'hot finish streak' }, { label: '83% league avg rating' }],
+      marqueeMetricKeys,
+      insightMetricKeys,
+    });
+
+    commitRenderedMetrics();
+    const rendered = loadRenderedMetricKeys();
+    expect(rendered.length).toBeGreaterThan(15);
+    expect(rendered).toContain('games owned');
+  });
+
+  it('isImplausibleDisabledBloat detects bloated disabled with tiny rendered union', () => {
+    const bloated = METRIC_KEYS.slice(0, Math.ceil(METRIC_KEYS.length * 0.85));
+    expect(isImplausibleDisabledBloat(bloated, ['finish streak', 'league avg rating'])).toBe(true);
+    expect(isImplausibleDisabledBloat(bloated, Array.from({ length: 20 }, (_, i) => `metric-${i}`))).toBe(false);
+    expect(isImplausibleDisabledBloat(['games owned'], ['finish streak'])).toBe(false);
+  });
+
+  it('does not re-bloat metricsDisabled after cache-hit restore on second render pass', () => {
+    const games = makeLibrary(200);
+    const snap = getLibrarySnapshot(games);
+    const ctx = buildMegaLibraryContext(games);
+
+    buildMarqueeItems(games, snap, ctx);
+    const cached = snapshotNotedMetricKeys();
+    // Simulate persisted corruption: almost the whole catalog disabled, including data-having keys.
+    state.prefs.metricsDisabled = METRIC_KEYS.filter((k) => k !== 'finish streak' && k !== 'league avg rating');
+    expect(state.prefs.metricsDisabled).toContain('games owned');
+
+    noteMarqueeMetricKeys(['finish streak', 'league avg rating']);
+    noteInsightMetricKeys([]);
+    commitRenderedMetrics();
+    expect(state.prefs.metricsDisabled).toContain('games owned');
+
+    restoreNotedMetricKeysFromArtifacts({
+      marqueeItems: [{ label: 'hot finish streak' }, { label: '83% league avg rating' }],
+      marqueeMetricKeys: cached.marqueeMetricKeys,
+      insightMetricKeys: cached.insightMetricKeys,
+    });
+    commitRenderedMetrics();
+
+    expect(state.prefs.metricsDisabled).not.toContain('games owned');
+    expect(loadRenderedMetricKeys().length).toBeGreaterThan(15);
 
     const healed = buildMarqueeItems(games, snap, ctx);
     expect(healed.length).toBeGreaterThan(20);


### PR DESCRIPTION
## Summary
- Include `metricsDisabled` in mega-artifact fingerprint so prefs healing between boot renders invalidates stale 2-chip cache entries.
- Cache pre-filter `marqueeMetricKeys` on mega artifacts and restore them on cache hit instead of deriving keys from filtered chip labels.
- Add corruption guard for implausibly bloated `metricsDisabled` sets (>80% catalog disabled with tiny rendered union).
- Add regression tests and changelog entry.

Follow-up to PR #33 — fixes marquee stuck at two chips after hard reload on large libraries.

## Test plan
- [x] `npm test -- tests/metrics-rendered.test.js tests/dashboard-marquee.test.js` (18/18)
- [x] Manual hard reload on large library — full scrolling marquee on first paint (user verified)