### PR TITLE
fix: wire auth helpers in maybeAutoEnrichNewAdditions when deps omitted

### DIFF
--- a/js/fetcher-auto-refresh.js
+++ b/js/fetcher-auto-refresh.js
@@ -218,9 +218,9 @@ export async function maybeAutoEnrichNewAdditions(newCount, deps = {}) {
   const runFn = deps.runFn ?? ((k, opts) => fetcherRunner?.run(k, opts));
   const waitSlotFn =
     deps.waitForQueueSlot ?? (() => fetcherRunner?.waitForQueueSlot({ batchEpoch }));
-  const credsOkFn = deps.fetcherCredentialsSatisfied;
-  const cooldownFn = deps.authCooldownRemainingMs;
-  const disconnectedFn = deps.isFetcherDisconnected;
+  const credsOkFn = deps.fetcherCredentialsSatisfied ?? wired.fetcherCredentialsSatisfied;
+  const cooldownFn = deps.authCooldownRemainingMs ?? wired.authCooldownRemainingMs;
+  const disconnectedFn = deps.isFetcherDisconnected ?? wired.isFetcherDisconnected;
 
   const keysToRun = ENRICH_ORDER.filter(key => {
     const src = sources.find(s => s.key === key);

--- a/tests/auto-enrich.test.js
+++ b/tests/auto-enrich.test.js
@@ -129,6 +129,21 @@ describe('maybeAutoEnrichNewAdditions', () => {
     expect(appendLine).toHaveBeenCalledWith('[auto-enrich aborted: cancelled]', 'meta');
   });
 
+  it('uses wired auth helpers when deps omit credential/cooldown/disconnect fns', async () => {
+    const runFn = vi.fn().mockResolvedValue(undefined);
+    const ok = await maybeAutoEnrichNewAdditions(2, {
+      isApiAvailable: () => true,
+      now: Date.now() + 60_000,
+      runFn,
+      waitForQueueSlot: async () => {},
+      loadFetcherSources: async () => {},
+      sources: enrichSources,
+      stateFor: () => null,
+    });
+    expect(ok).toBe(true);
+    expect(runFn).toHaveBeenCalled();
+  });
+
   it('stops when waitForQueueSlot rejects cancelled', async () => {
     const runFn = vi.fn();
     await maybeAutoEnrichNewAdditions(1, {


### PR DESCRIPTION
## Summary
- Fixes TypeError cooldownFn/credsOkFn is not a function after Epic fetch adds a game
- maybeAutoEnrichNewAdditions now falls back to wired auth helpers like maybeAutoFetchStale24h
- Regression test in tests/auto-enrich.test.js

## Test plan
- [x] npm test (auto-enrich suite)
- [ ] Live: Epic fetch with new game triggers enrich without crash

Made with [Cursor](https://cursor.com)