### PR TITLE
fix: Xbox wishlist MSA handoff guard and cover image validation

### DIFF
--- a/auth/registry.py
+++ b/auth/registry.py
@@ -204,9 +204,7 @@ PROVIDERS: dict[str, ProviderSpec] = {
         label="Xbox",
         kind="browser",
         description=(
-            "Your Xbox play history (every title you've launched on Xbox network). "
-            "Game Pass titles you've played are tagged \u2014 we don't pull the broader "
-            "Game Pass catalog."
+            "Your Xbox play history (every title you've launched on Xbox network)."
         ),
         env_keys=("XBL_API_KEY",),
         form_fields=(
@@ -224,7 +222,7 @@ PROVIDERS: dict[str, ProviderSpec] = {
             "Stuck on the Microsoft login? Click \u201cSign in another way\u201d and have it email you a "
             "one-time code \u2014 no password or authenticator needed.",
             "Already have a key? Paste it in the field below instead of signing in.",
-            "Pulls titles you've actually launched on Xbox network, not the full Game Pass catalog.",
+            "Pulls titles you've actually launched on Xbox network.",
         ),
     ),
     "xbox_wishlist": ProviderSpec(

--- a/auth/runner.py
+++ b/auth/runner.py
@@ -788,7 +788,8 @@ def _xbox_signed_in_state(context, page=None) -> dict | None:
         try:
             url = (page.url or "").lower()
             if "xbox.com" in url:
-                state = _parse_xbox_preloaded_state(page.content())
+                _html = page.content()
+                state = _parse_xbox_preloaded_state(_html)
                 if state:
                     user = state.get("user") or {}
                     if not user.get("isSignedIn"):
@@ -832,6 +833,12 @@ def _xbox_capture_wishlist_api(page, sniffer, *, timeout_s: float = 12.0) -> Non
         page.wait_for_timeout(500)
 
 
+def _xbox_wishlist_connect_creds(sniffer) -> dict[str, str]:
+    creds = {"XBOX_WISHLIST_PROFILE": "ready"}
+    creds.update(sniffer.creds())
+    return creds
+
+
 def _extract_xbox_wishlist_inline(page, context, session) -> dict[str, str]:
     """Open xbox.com/wishlist, wait for MSA sign-in (detected via SSR HTML),
     then capture the Emerald wishlist API token for headless replay. The
@@ -852,6 +859,7 @@ def _extract_xbox_wishlist_inline(page, context, session) -> dict[str, str]:
 
     deadline = time.time() + SUCCESS_WAIT_SEC
     last_msg = 0.0
+    last_ssr_refresh = 0.0
     while time.time() < deadline:
         url = (page.url or "").lower()
         on_login = (
@@ -860,19 +868,53 @@ def _extract_xbox_wishlist_inline(page, context, session) -> dict[str, str]:
             or "signin" in url
             or "account.microsoft" in url
         )
+        # MSA hands the session back via xbox.com/auth/msa?action=loggedin#code=...
+        # (or an oauth20 redirect). The SPA must process that code to set the
+        # signed-in cookies; navigating away here aborts the exchange and the
+        # session never completes — so treat it like login: wait, do not refresh.
+        on_handoff = (
+            "/auth/msa" in url
+            or "action=loggedin" in url
+            or "#code=" in url
+            or "oauth20" in url
+        )
+        on_wishlist = "wishlist" in url
+        token_ready = bool(sniffer.token)
+        if token_ready and on_wishlist and not on_login:
+            if session:
+                session.emit(
+                    "waiting_for_user",
+                    {"message": "Signed in \u2014 capturing your wishlist session..."},
+                )
+            sniffer.dump()
+            return _xbox_wishlist_connect_creds(sniffer)
         # xbox.com bakes __PRELOADED_STATE__ into the HTML at load time and
-        # never refreshes it client-side, and a cookie-only HTTP GET returns a
-        # signed-out payload. So once the user is back on xbox.com we must
-        # re-navigate to pull a fresh SSR that reflects the new MSA cookies.
-        # Never navigate while they're mid-login on a Microsoft page.
-        if not on_login and "xbox.com" in url:
-            try:
-                page.goto(XBOX_WISHLIST_URL, wait_until="domcontentloaded", timeout=15000)
-                page.wait_for_timeout(1200)
-            except Exception:  # noqa: BLE001
-                pass
+        # never refreshes it client-side. After MSA sign-in we may need one
+        # refresh to pull SSR that reflects the new cookies — but once the user
+        # is on /wishlist, stop hammering reloads or the Emerald API never fires.
+        if not on_login and not on_handoff and "xbox.com" in url:
+            now = time.time()
+            need_refresh = not on_wishlist or (
+                not token_ready and now - last_ssr_refresh >= 8.0
+            )
+            if need_refresh:
+                last_ssr_refresh = now
+                try:
+                    page.goto(XBOX_WISHLIST_URL, wait_until="domcontentloaded", timeout=15000)
+                    page.wait_for_timeout(2500)
+                except Exception:  # noqa: BLE001
+                    pass
 
         state = _xbox_signed_in_state(context, page)
+        token_ready = bool(sniffer.token)
+        if token_ready and on_wishlist and not on_login:
+            if session:
+                session.emit(
+                    "waiting_for_user",
+                    {"message": "Signed in \u2014 capturing your wishlist session..."},
+                )
+            sniffer.dump()
+            return _xbox_wishlist_connect_creds(sniffer)
         if state is not None:
             if session:
                 session.emit(
@@ -881,9 +923,7 @@ def _extract_xbox_wishlist_inline(page, context, session) -> dict[str, str]:
                 )
             _xbox_capture_wishlist_api(page, sniffer)
             sniffer.dump()
-            creds = {"XBOX_WISHLIST_PROFILE": "ready"}
-            creds.update(sniffer.creds())
-            return creds
+            return _xbox_wishlist_connect_creds(sniffer)
 
         now = time.time()
         if session and now - last_msg > 8:

--- a/enrich_cross_store_images.py
+++ b/enrich_cross_store_images.py
@@ -92,6 +92,27 @@ def image_urls(appid: int) -> tuple[str, str]:
     )
 
 
+def image_url_ok(url: str) -> bool:
+    """True only when the Steam CDN actually serves an image at ``url``.
+
+    Steam returns a 200-less ``text/html`` 404 stub for apps whose store art
+    isn't published yet (coming-soon / unreleased titles such as wishlist
+    pre-orders). Writing those steamstatic URLs blind made the enricher claim
+    success while the row rendered a broken/blank cover — so verify before use.
+    """
+    if not url:
+        return False
+    try:
+        r = requests.get(url, headers=HEADERS, timeout=10, stream=True)
+        try:
+            ctype = (r.headers.get("Content-Type") or "").lower()
+            return r.status_code == 200 and ctype.startswith("image")
+        finally:
+            r.close()
+    except Exception:
+        return False
+
+
 def needs_images(g: dict) -> bool:
     lib = g.get("library_image") or ""
     hdr = g.get("header_image") or ""
@@ -120,10 +141,25 @@ def needs_lowres_upgrade(g: dict) -> bool:
     return True
 
 
+def is_steam_search_steamstatic(g: dict) -> bool:
+    """A row already enriched from Steam search with a steamstatic image.
+
+    These can hold a dead 404 URL when the matched app was unreleased at
+    enrich time; we revalidate them once (cached) so stale broken covers heal.
+    """
+    if g.get("image_source") not in ("steam_search", "steam_search_upgrade"):
+        return False
+    lib = g.get("library_image") or ""
+    hdr = g.get("header_image") or ""
+    return is_steamstatic_url(lib) or is_steamstatic_url(hdr)
+
+
 def should_process(g: dict, *, upgrade_lowres: bool) -> bool:
     if needs_images(g):
         return True
     if upgrade_lowres and needs_lowres_upgrade(g):
+        return True
+    if is_steam_search_steamstatic(g):
         return True
     return False
 
@@ -163,17 +199,23 @@ def main() -> int:
     # so a re-click doesn't waste a Steam search hit on Hearthstone again.
     no_steam_match: set[str] = set(meta.get("no_steam_match", []))
     lowres_checked: set[str] = set(meta.get("lowres_checked", []))
+    # Rows whose existing steam_search steamstatic cover we've confirmed is live
+    # (HTTP 200 image). Skips re-checking the same good URL every run.
+    steam_validated: set[str] = set(meta.get("steam_validated", []))
     if args.retry_misses:
         print(f"--retry-misses: clearing {len(no_steam_match)} cached non-matches", flush=True)
         no_steam_match.clear()
         print(f"--retry-misses: clearing {len(lowres_checked)} cached low-res checks", flush=True)
         lowres_checked.clear()
+        print(f"--retry-misses: clearing {len(steam_validated)} cached cover validations", flush=True)
+        steam_validated.clear()
     cache_lock = Lock()
 
     def process(g: dict, store: str) -> dict | None:
         missing = needs_images(g)
         upgrading = args.upgrade_lowres and needs_lowres_upgrade(g)
-        if not missing and not upgrading:
+        revalidating = not missing and not upgrading and is_steam_search_steamstatic(g)
+        if not missing and not upgrading and not revalidating:
             return None
         key = f"{store}:{g.get('id')}"
         with cache_lock:
@@ -181,6 +223,27 @@ def main() -> int:
                 return None
             if upgrading and key in lowres_checked:
                 return None
+            if revalidating and key in steam_validated:
+                return None
+
+        # Heal stale rows: a previously written steam_search cover may now be a
+        # dead 404 (matched while the app was unreleased). Confirm it still
+        # serves an image; if so cache it, else clear it so the broken cover
+        # stops rendering and the row can re-enrich later.
+        if revalidating:
+            if image_url_ok(g.get("library_image") or ""):
+                with cache_lock:
+                    steam_validated.add(key)
+                return None
+            cleared = dict(g)
+            cleared["header_image"] = None
+            cleared["library_image"] = None
+            cleared["steam_appid"] = None
+            cleared["image_source"] = None
+            with cache_lock:
+                no_steam_match.add(key)
+            return cleared
+
         appid = g.get("steam_appid")
         if not appid:
             appid = steam_search_appid(g.get("name", ""))
@@ -191,6 +254,15 @@ def main() -> int:
                     lowres_checked.add(key)
             return None
         header, library = image_urls(appid)
+        # Only assign art that the CDN actually serves. Unreleased / coming-soon
+        # apps resolve to a Steam appid but 404 on their image URLs, which used
+        # to be written blindly and rendered as a blank cover.
+        if not image_url_ok(library):
+            with cache_lock:
+                no_steam_match.add(key)
+                if upgrading:
+                    lowres_checked.add(key)
+            return None
         g = dict(g)
         g["header_image"] = header
         g["library_image"] = library
@@ -199,6 +271,7 @@ def main() -> int:
         with cache_lock:
             if upgrading:
                 lowres_checked.add(key)
+            steam_validated.add(key)
         return g
 
     for rel, store, row_filter in STORE_FILES:
@@ -265,6 +338,7 @@ def main() -> int:
                 "last_updated": updated,
                 "no_steam_match": sorted(no_steam_match),
                 "lowres_checked": sorted(lowres_checked),
+                "steam_validated": sorted(steam_validated),
             },
             indent=2,
         ),

--- a/fetch_xbox_wishlist.py
+++ b/fetch_xbox_wishlist.py
@@ -199,33 +199,51 @@ def _index_products(state: dict) -> dict[str, dict]:
 
 
 def _pick_image(product: dict) -> str | None:
-    """Prefer a poster/box-art image; xbox.com ships a few size variants."""
+    """Prefer a poster/box-art image; xbox.com ships a few size variants.
+
+    The catalog ``images`` field arrives in two shapes: a *list* of
+    ``{url, purpose, width}`` dicts (older shape), or — current xbox.com SSR —
+    a *dict keyed by purpose*, e.g.
+    ``{"poster": {url,width,height}, "boxArt": {...}, "superHeroArt": {...}}``.
+    Only the list shape used to be handled, so every row came back image-less
+    and fell through to (often dead) Steam-search covers. Handle both, and
+    prefer the vertical ``poster`` so the library cover keeps a 2:3 aspect.
+    """
     images = product.get("images") or product.get("Images")
-    candidates: list[tuple[int, str]] = []
+    img_list: list[dict] = []
     if isinstance(images, list):
-        for img in images:
-            if not isinstance(img, dict):
-                continue
-            url = img.get("url") or img.get("Url") or img.get("uri")
-            purpose = (img.get("purpose") or img.get("imagePurpose") or "").lower()
-            width = img.get("width") or img.get("Width") or 0
-            try:
-                width = int(width)
-            except (TypeError, ValueError):
-                width = 0
-            if not url:
-                continue
-            # Posters / box art first
-            rank = 0
-            if "boxart" in purpose or "poster" in purpose:
-                rank = 100
-            elif "tile" in purpose:
-                rank = 50
-            elif "logo" in purpose:
-                rank = 10
-            else:
-                rank = 20
-            candidates.append((rank * 1000 + min(width, 1000), url))
+        img_list = [i for i in images if isinstance(i, dict)]
+    elif isinstance(images, dict):
+        for purpose_key, val in images.items():
+            if isinstance(val, dict):
+                img_list.append({**val, "purpose": val.get("purpose") or purpose_key})
+
+    candidates: list[tuple[int, str]] = []
+    for img in img_list:
+        url = img.get("url") or img.get("Url") or img.get("uri")
+        purpose = (img.get("purpose") or img.get("imagePurpose") or "").lower()
+        width = img.get("width") or img.get("Width") or 0
+        try:
+            width = int(width)
+        except (TypeError, ValueError):
+            width = 0
+        if not url:
+            continue
+        # Vertical poster first (matches the 2:3 library cover), then box art,
+        # then tiles / wide hero art / logos.
+        if "poster" in purpose:
+            rank = 110
+        elif "boxart" in purpose:
+            rank = 100
+        elif "tile" in purpose:
+            rank = 50
+        elif "hero" in purpose:
+            rank = 40
+        elif "logo" in purpose:
+            rank = 10
+        else:
+            rank = 20
+        candidates.append((rank * 1000 + min(width, 1000), url))
     if candidates:
         candidates.sort(reverse=True)
         return _https(candidates[0][1])


### PR DESCRIPTION
## Summary
- Do not navigate away during MSA auth handoff (on_handoff guard)
- fetch_xbox_wishlist _pick_image handles dict and list image schemas
- enrich_cross_store_images validates Steam CDN URLs before writing
- Trim Xbox provider copy in auth/registry

## Test plan
- [x] pytest auth/runner related tests
- [ ] Xbox wishlist connect completes after MSA sign-in
- [ ] Wishlist covers render for new titles

Made with [Cursor](https://cursor.com)