### PR TITLE
chore: remove Game Pass filter badge and surface copy

### DIFF
--- a/app.css
+++ b/app.css
@@ -875,7 +875,6 @@ button[disabled] { cursor: not-allowed; }
 .store-badge,
 .pick-store,
 .ea-pill,
-.game-pass-pill,
 .ea-ribbon,
 .coop-pill,
 .deal-cut-badge,
@@ -986,19 +985,6 @@ button[disabled] { cursor: not-allowed; }
 }
 .coop-pill-online { background: linear-gradient(180deg, #38bdf8 0%, #0284c7 100%); color: #06141f; }
 .coop-pill-local { background: linear-gradient(180deg, #34d399 0%, #047857 100%); color: #052017; }
-.game-pass-pill {
-  display: inline-flex; align-items: center;
-  background: linear-gradient(180deg, #9ae6b4 0%, #38a169 100%);
-  color: #052e16;
-  font-size: 9px;
-  font-weight: 800;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  padding: 1px 5px;
-  border-radius: 3px;
-  line-height: 1.4;
-  flex-shrink: 0;
-}
 .plat-badge {
   display: inline-flex; align-items: center;
   background: linear-gradient(180deg, #e8eef5 0%, #9eb4cc 55%, #6b7f96 100%);

--- a/fetch_ea.py
+++ b/fetch_ea.py
@@ -160,8 +160,6 @@ def _tags_for(item: dict) -> list[str]:
     tags: list[str] = []
     if methods & EA_PLAY_OWNERSHIP and not (methods & REAL_OWNERSHIP):
         tags.append("ea_play")
-    if methods & XGP_ONLY:
-        tags.append("game-pass")
     return tags
 
 
@@ -224,7 +222,6 @@ def _build_row(
         "release_date": None,
         "genres": [],
         "tags": _tags_for(item),
-        "game_pass": bool(_ownership_methods(item) & XGP_ONLY),
         "steam_review_percent": None,
         "steam_review_count": None,
         "steam_review_desc": None,

--- a/fetch_xbox.py
+++ b/fetch_xbox.py
@@ -64,12 +64,8 @@ def _build_row(title: dict, hltb: dict | None) -> dict:
     tid = str(title.get("titleId") or title.get("modernTitleId") or "")
     ach = title.get("achievement") or {}
     hist = title.get("titleHistory") or {}
-    gp = title.get("gamePass") or {}
     image = _https(title.get("displayImage"))
     tags: list[str] = []
-    is_gp = bool(gp.get("isGamePass"))
-    if is_gp:
-        tags.append("game-pass")
     devices = title.get("devices") or []
     if devices:
         tags.extend(str(d).lower() for d in devices)
@@ -103,7 +99,6 @@ def _build_row(title: dict, hltb: dict | None) -> dict:
         "currency": None,
         "xbox_gamerscore_current": ach.get("currentGamerscore"),
         "xbox_gamerscore_total": ach.get("totalGamerscore"),
-        "game_pass": is_gp,
     }
     if hltb:
         row.update(

--- a/fetchers/_authoritative.py
+++ b/fetchers/_authoritative.py
@@ -61,7 +61,6 @@ XBOX = library_authoritative(
     "trophy_progress",
     "xbox_gamerscore_current",
     "xbox_gamerscore_total",
-    "game_pass",
 )
 BATTLENET = library_authoritative("battlenet_id")
 UBISOFT = library_authoritative("ubisoft_id")
@@ -71,4 +70,4 @@ HUMBLE = library_authoritative(
     "humble_gamekey",
     "humble_steam_app_id",
 )
-EA = library_authoritative("ea_id", "ea_offer_id", "ea_game_slug", "game_pass")
+EA = library_authoritative("ea_id", "ea_offer_id", "ea_game_slug")

--- a/index.html
+++ b/index.html
@@ -810,17 +810,6 @@
           <span class="ea-pill ml-1" title="Early Access">EA</span>
         </label>
       </div>
-      <div id="gamePassSection" class="drawer-section">
-        <div class="drawer-section-head">
-          <span class="drawer-section-label">Game Pass</span>
-          <button type="button" class="drawer-info" aria-label="About Game Pass filter" title="Xbox and EA rows available via Game Pass or EA Play subscription.">?</button>
-        </div>
-        <label class="flex items-center gap-2 text-xs text-slate-300">
-          <input id="gamePassOnly" type="checkbox" class="rounded" />
-          Game Pass only
-          <span class="game-pass-pill ml-1" title="Xbox Game Pass">GP</span>
-        </label>
-      </div>
       <div id="libraryMiscSection" class="drawer-section">
         <label class="flex items-center gap-2 text-xs text-slate-300">
           <input id="unplayedOnly" type="checkbox" class="rounded" title="Only games with zero recorded playtime" />

--- a/js/active-filters.js
+++ b/js/active-filters.js
@@ -35,7 +35,6 @@ export function collectActiveFilters() {
   for (const g of state.prefs.genreFilters || []) pills.push({ kind: "genre", value: g, label: g });
   if (sp.unplayedOnly) pills.push({ kind: "unplayed", value: "1", label: "Unplayed only" });
   if (sp.earlyAccessOnly) pills.push({ kind: "earlyAccess", value: "1", label: "Early Access only" });
-  if (sp.gamePassOnly) pills.push({ kind: "gamePass", value: "1", label: "Game Pass only" });
   if (sp.staleOnly) pills.push({ kind: "stale", value: "1", label: "Stale sync only" });
   const coopMode = getCoopFilterMode();
   if (coopMode !== "off") {

--- a/js/bind-events.js
+++ b/js/bind-events.js
@@ -314,7 +314,6 @@ export function bindEvents() {
     statusFilter:     el => ({ key: "statusFilter",    val: el.value }),
     unplayedOnly:     el => ({ key: "unplayedOnly",    val: !!el.checked }),
     earlyAccessOnly:  el => ({ key: "earlyAccessOnly", val: !!el.checked }),
-    gamePassOnly:     el => ({ key: "gamePassOnly", val: !!el.checked }),
     minRating:        el => ({ key: "minRating",       val: +el.value || 0 }),
     maxHours:         el => ({ key: "maxHours",        val: +el.value || 0 }),
   };

--- a/js/dashboard-insights.js
+++ b/js/dashboard-insights.js
@@ -49,7 +49,6 @@ import {
   acquireToPlayDaysAvg,
   dayOnePlayerCount,
   extraInningsAvg,
-  gamePassCount,
   doubleDipCount,
   costPerFinish,
   sunkCostUnplayed,
@@ -998,10 +997,6 @@ export function buildMarqueeItems(games, snapIn, ctxIn) {
   const extraInn = extraInningsAvg(snap);
   if (extraInn != null) {
     push('~', 'is-amber', `${formatNum(extraInn)}h`, 'extra innings', null, { weight: W.moderate });
-  }
-  const gpCount = gamePassCount(snap);
-  if (gpCount != null) {
-    push('*', 'is-violet', formatNum(gpCount), "subscriber's dividend", null, { weight: W.friendly });
   }
   const dDips = doubleDipCount();
   if (dDips != null) {

--- a/js/filters-ui.js
+++ b/js/filters-ui.js
@@ -213,7 +213,6 @@ export function removeActiveFilter(kind, value) {
     case "status":          return applyPrefsChange({ sessionPrefs: { statusFilter: "" } });
     case "unplayed":        return applyPrefsChange({ sessionPrefs: { unplayedOnly: false } });
     case "earlyAccess":     return applyPrefsChange({ sessionPrefs: { earlyAccessOnly: false } });
-    case "gamePass":        return applyPrefsChange({ sessionPrefs: { gamePassOnly: false } });
     case "stale":           return applyPrefsChange({ sessionPrefs: { staleOnly: false } });
     case "minRating":       return applyPrefsChange({ sessionPrefs: { minRating: 0 } });
     case "maxHours":        return applyPrefsChange({ sessionPrefs: { maxHours: 200 } });
@@ -296,7 +295,6 @@ export function clearAllFilters() {
         statusFilter: "",
         unplayedOnly: false,
         earlyAccessOnly: false,
-        gamePassOnly: false,
         staleOnly: false,
         minRating: 0,
         maxHours: 200,
@@ -512,7 +510,6 @@ export function updateViewChrome(options) {
   }
   document.getElementById("libraryMiscSection")?.classList.toggle("hidden", isWish || isItch || isDash || isConn || isProView);
   document.getElementById("displayToolsSection")?.classList.toggle("hidden", isWish || isItch || isDash || isConn || isProView);
-  document.getElementById("gamePassSection")?.classList.toggle("hidden", isWish || isItch || isDash || isConn || isProView);
   document.getElementById("earlyAccessSection")?.classList.toggle("hidden", isItch || isDash || isConn || isProView);
   document.getElementById("coopSection")?.classList.toggle("hidden", isItch || isDash || isConn || isProView);
   if (isDash && !options?.skipDashboardSchedule) scheduleDashboardRender();

--- a/js/game-core.js
+++ b/js/game-core.js
@@ -5,7 +5,7 @@ import {
   isCleanupCandidateFromParts,
 } from './state.js';
 import { escapeHtml, escapeAttr } from './dom-util.js';
-import { isEarlyAccess, isGamePass } from './table-query.js';
+import { isEarlyAccess } from './table-query.js';
 import { STATUS_LABELS, WISHLIST_STATUS_LABELS } from './row-templates.js';
 import { getPersonal, hasPersonalEntry } from './personal-storage.js';
 import { COOP_NAME_OVERRIDES } from './coop-overrides.js';
@@ -614,12 +614,6 @@ export function earlyAccessRibbonHtml(g, { label = "EARLY ACCESS" } = {}) {
 
 export function earlyAccessPillHtml(g) {
   return isEarlyAccess(g) ? '<span class="ea-pill" title="Early Access">EA</span>' : "";
-}
-
-export function gamePassBadgeHtml(g) {
-  return isGamePass(g)
-    ? '<span class="game-pass-pill" title="Xbox Game Pass or EA Play via subscription">GP</span>'
-    : "";
 }
 
 export function coopPillsHtml(g) {

--- a/js/metric-tips.js
+++ b/js/metric-tips.js
@@ -126,7 +126,7 @@ export const METRIC_TIPS = {
   'PSN library tenure': 'Years since your earliest recorded PSN first_played date.',
   'session grinder': 'High session count relative to hours played (short repeat launches).',
 
-  // New-data sabermetrics (Metacritic, acquired_at, early access, controller, HLTB depth, Game Pass, cross-store)
+  // New-data sabermetrics (Metacritic, acquired_at, early access, controller, HLTB depth, cross-store)
   'critic gap (avg)': 'Mean |Steam review % − Metacritic| across games with both scores.',
   "people's champ": 'Owned title with the biggest positive critic gap (players rate higher than critics).',
   "critics' darling": 'Highest Metacritic score among owned games you have never launched.',
@@ -136,7 +136,6 @@ export const METRIC_TIPS = {
   'aging curve': 'Average days from acquired_at to first recorded play session.',
   'day-one player': 'Games you launched within 24 hours of acquiring.',
   'extra innings': 'Average HLTB completionist − main gap (optional content beyond the main story).',
-  "subscriber's dividend": 'Titles playable via Xbox Game Pass or EA Play (game_pass flag).',
   'double dips': 'Same game owned on two or more storefronts (cross-store dedup).',
   'cost per finish': 'Total library MSRP (priced rows) ÷ games marked finished.',
   'sunk cost': 'Sum of MSRP for owned games with zero playtime.',

--- a/js/prefs.js
+++ b/js/prefs.js
@@ -109,7 +109,6 @@ export function loadSessionPrefs() {
     statusFilter: "",
     unplayedOnly: false,
     earlyAccessOnly: false,
-    gamePassOnly: false,
     minRating: 0,
     maxHours: 200,
   };
@@ -140,7 +139,6 @@ export function syncFilterDomFromState() {
   setVal("statusFilter", s.statusFilter || "");
   setChecked("unplayedOnly", s.unplayedOnly);
   setChecked("earlyAccessOnly", s.earlyAccessOnly);
-  setChecked("gamePassOnly", s.gamePassOnly);
   const minR = s.minRating || 0;
   setVal("minRating", minR);
   const minRVal = document.getElementById("minRatingVal");

--- a/js/sabermetrics.js
+++ b/js/sabermetrics.js
@@ -592,11 +592,6 @@ export function extraInningsAvg(snap) {
   return Math.round((gaps.reduce((s, h) => s + h, 0) / gaps.length) * 10) / 10;
 }
 
-export function gamePassCount(snap) {
-  const n = snap.games.filter(g => g.game_pass === true).length;
-  return n > 0 ? n : null;
-}
-
 /** Games owned on 2+ stores (cross-store dedup map). */
 export function doubleDipCount() {
   const map = state.crossStoreOwnedStores;

--- a/js/stat-families.js
+++ b/js/stat-families.js
@@ -102,7 +102,7 @@ export function familyForLabel(label) {
     'completion avg', 'start rate', 'abandon rate', 'closer power', 'rookie finish',
     'veteran finish', 'below mendoza', 'critic gap', "people's champ", "critics' darling",
     'overrated index', 'perpetual beta', 'couch-ready', 'aging curve', 'day-one player',
-    'extra innings', "subscriber's dividend", 'double dips', 'cost per finish', 'sunk cost',
+    'extra innings', 'double dips', 'cost per finish', 'sunk cost',
     'will you die first',
   ])) {
     return FAMILY.SABER;

--- a/js/state.js
+++ b/js/state.js
@@ -78,7 +78,6 @@ export const state = {
     statusFilter: "",
     unplayedOnly: false,
     earlyAccessOnly: false,
-    gamePassOnly: false,
     staleOnly: false,
     minRating: 0,
     maxHours: 200,

--- a/js/table-query.js
+++ b/js/table-query.js
@@ -43,7 +43,6 @@ export function collectTableParams(sessionPrefs) {
     status: s.statusFilter || '',
     unplayed: !!s.unplayedOnly,
     earlyAccess: !!s.earlyAccessOnly,
-    gamePass: !!s.gamePassOnly,
     staleOnly: !!s.staleOnly,
     minRating: +(s.minRating || 0),
     maxHours: s.maxHours == null ? 200 : +s.maxHours,
@@ -76,17 +75,6 @@ export function isEarlyAccess(g) {
   for (let i = 0; i < tokens.length; i++) {
     const t = tokens[i];
     if (typeof t === 'string' && t.toLowerCase().includes('early access')) return true;
-  }
-  return false;
-}
-
-export function isGamePass(g) {
-  if (!g) return false;
-  if (g.game_pass === true) return true;
-  for (const t of g.tags || []) {
-    if (typeof t !== 'string') continue;
-    const norm = t.toLowerCase().replace(/_/g, '-');
-    if (norm === 'game-pass' || norm === 'xbox-game-pass') return true;
   }
   return false;
 }
@@ -350,7 +338,6 @@ function passesFilter(ctx, g) {
   }
   if (params.unplayed && rowPlaytime(ctx, g) > 0) return false;
   if (params.earlyAccess && !isEarlyAccess(g)) return false;
-  if (params.gamePass && !isGamePass(g)) return false;
   if (params.staleOnly && !g.stale) return false;
   if (!passesCoopFilter(g, resolveCoopFilterMode(prefs))) return false;
   const rating = ratingValue(g);

--- a/tests/game-core.test.js
+++ b/tests/game-core.test.js
@@ -30,7 +30,6 @@ import {
   trophyProgressPillHtml,
   platinumBadgeHtml,
   storeBadgeHtml,
-  gamePassBadgeHtml,
   coverArtCandidates,
   landscapeArtCandidates,
   spotlightArtCandidates,
@@ -626,18 +625,6 @@ describe('trophyProgressPillHtml', () => {
     });
     expect(html).toContain('data-tro-cur="12"');
     expect(html).toContain('data-tro-total="33"');
-  });
-});
-
-describe('gamePassBadgeHtml', () => {
-  it('renders GP pill for subscription rows', () => {
-    const html = gamePassBadgeHtml({ store: 'xbox', id: '1', game_pass: true });
-    expect(html).toContain('game-pass-pill');
-    expect(html).toContain('GP');
-  });
-
-  it('returns empty for non-subscription rows', () => {
-    expect(gamePassBadgeHtml({ store: 'steam', id: 1 })).toBe('');
   });
 });
 

--- a/tests/table-query.test.js
+++ b/tests/table-query.test.js
@@ -11,7 +11,6 @@ import {
   resolveCoopFilterMode,
   passesCoopFilter,
   isEarlyAccess,
-  isGamePass,
   queryGames,
   buildQueryContext,
   collectTableParams,
@@ -131,34 +130,6 @@ describe('isEarlyAccess', () => {
   });
 });
 
-describe('isGamePass', () => {
-  it('returns true when game_pass flag is set', () => {
-    expect(isGamePass({ game_pass: true })).toBe(true);
-  });
-
-  it('detects legacy xbox_game_pass tag', () => {
-    expect(isGamePass({ tags: ['xbox_game_pass'] })).toBe(true);
-  });
-
-  it('returns false for owned purchases', () => {
-    expect(isGamePass({ tags: ['pc'], game_pass: false })).toBe(false);
-  });
-});
-
-describe('gamePass filter', () => {
-  it('filters to subscription rows only', () => {
-    const gp = { ...baseGame, store: 'xbox', id: 'x1', game_pass: true };
-    const owned = { ...baseGame, store: 'xbox', id: 'x2', game_pass: false };
-    const source = [gp, owned];
-    const out = queryGames({
-      source,
-      ctx: ctx({ params: collectTableParams({ gamePassOnly: true }) }),
-    });
-    expect(out).toHaveLength(1);
-    expect(out[0].id).toBe('x1');
-  });
-});
-
 describe('gameKey', () => {
   it('builds store:id from explicit fields', () => {
     expect(gameKey({ store: 'gog', id: 42 })).toBe('gog:42');
@@ -267,7 +238,6 @@ describe('collectTableParams', () => {
       status: '',
       unplayed: false,
       earlyAccess: false,
-      gamePass: false,
       staleOnly: false,
       minRating: 0,
       maxHours: 200,
@@ -280,7 +250,6 @@ describe('collectTableParams', () => {
       status: '',
       unplayed: false,
       earlyAccess: false,
-      gamePass: false,
       staleOnly: false,
       minRating: 0,
       maxHours: 200,
@@ -294,7 +263,6 @@ describe('collectTableParams', () => {
         statusFilter: 'next',
         unplayedOnly: true,
         earlyAccessOnly: true,
-        gamePassOnly: true,
         staleOnly: true,
         minRating: 70,
         maxHours: 12,
@@ -304,7 +272,6 @@ describe('collectTableParams', () => {
       status: 'next',
       unplayed: true,
       earlyAccess: true,
-      gamePass: true,
       staleOnly: true,
       minRating: 70,
       maxHours: 12,
@@ -317,7 +284,6 @@ describe('collectTableParams', () => {
       status: '',
       unplayed: false,
       earlyAccess: false,
-      gamePass: false,
       staleOnly: false,
       minRating: 40,
       maxHours: 5,

--- a/tests/test_metadata_rollout.py
+++ b/tests/test_metadata_rollout.py
@@ -4,40 +4,10 @@ from __future__ import annotations
 
 import argparse
 
-import fetch_ea as fe
 import fetch_gog as fg
 import fetch_itch as fi
 import fetch_nintendo as fn
-import fetch_xbox as fx
 from fetch_epic import _acquired_at_from_record, _build_game_row_from_record
-
-
-class TestGamePassRows:
-    def test_xbox_sets_game_pass_flag(self) -> None:
-        row = fx._build_row(
-            {
-                "titleId": "abc",
-                "name": "Halo",
-                "gamePass": {"isGamePass": True},
-            },
-            None,
-        )
-        assert row["game_pass"] is True
-        assert "game-pass" in row["tags"]
-
-    def test_ea_normalizes_game_pass_tag(self) -> None:
-        item = {
-            "originOfferId": "offer-1",
-            "product": {
-                "name": "GP Title",
-                "id": "p1",
-                "gameProductUser": {"ownershipMethods": ["XGP_VAULT"]},
-            },
-        }
-        tags = fe._tags_for(item)
-        assert tags == ["game-pass"]
-        row = fe._build_row(item, hltb=None, play_by_slug={})
-        assert row["game_pass"] is True
 
 
 class TestGogNeedsDetails:


### PR DESCRIPTION
## Summary
- Remove gamePassOnly filter, GP badge, and related tests
- Simplify Xbox provider copy and fetcher metadata

## Test plan
- [x] npm test
- [x] pytest test_metadata_rollout

Made with [Cursor](https://cursor.com)