### PR TITLE
chore: sync curated free-claims feeds and landing snapshot

### DIFF
--- a/curated/free_claims.approved.json
+++ b/curated/free_claims.approved.json
@@ -1,18 +1,29 @@
 {
   "ids": [
+    "epic-warhammer-40k-speed-freeks-12879c",
     "gamerpower-1604",
     "gamerpower-2204",
     "gamerpower-2386",
     "gamerpower-3096",
     "gamerpower-3266",
     "gamerpower-3446",
+    "gamerpower-3477",
+    "gamerpower-3548",
+    "gamerpower-3553",
     "gamerpower-3665",
     "gamerpower-3671",
     "gamerpower-3676",
+    "gamerpower-3677",
+    "gamerpower-3678",
+    "gamerpower-3679",
+    "gamerpower-3680",
+    "gamerpower-3682",
+    "gamerpower-3684",
     "itad-073a56345192",
     "itad-0c69ed1f1bd8",
     "itad-0d4598c53ffe",
     "itad-1b0433806065",
+    "itad-330faa9821bf",
     "itad-6d00ffeb0fdc",
     "itad-7a69412dd110",
     "itad-b07aac9ebd26",
@@ -47,6 +58,15 @@
     "gamerpower-3446": {
       "title": "GigaBash"
     },
+    "gamerpower-3477": {
+      "title": "CALLUS"
+    },
+    "gamerpower-3548": {
+      "title": "Static Voice"
+    },
+    "gamerpower-3553": {
+      "title": "Sleep Demon"
+    },
     "gamerpower-3665": {
       "title": "Gravity Circuit"
     },
@@ -55,6 +75,24 @@
     },
     "gamerpower-3676": {
       "title": "Dire Echo"
+    },
+    "gamerpower-3677": {
+      "title": "Not A Customer"
+    },
+    "gamerpower-3678": {
+      "title": "MicroCrawl"
+    },
+    "gamerpower-3679": {
+      "title": "Happy's Humble Burger Farm"
+    },
+    "gamerpower-3680": {
+      "title": "The Ouroboros King"
+    },
+    "gamerpower-3682": {
+      "title": "The Red Lantern"
+    },
+    "gamerpower-3684": {
+      "title": "Eets"
     },
     "itad-073a56345192": {
       "title": "Songs of Conquest"
@@ -68,9 +106,12 @@
     "itad-1b0433806065": {
       "title": "Die Young: Prologue"
     },
+    "itad-330faa9821bf": {
+      "title": "Guild of Dungeoneering Ultimate Edition"
+    },
     "itad-6d00ffeb0fdc": {
-      "title": "Another World Adventures",
-      "claim_url": "https://s-xavier-uy.itch.io/another-world-adventures"
+      "claim_url": "https://s-xavier-uy.itch.io/another-world-adventures",
+      "title": "Another World Adventures"
     },
     "itad-7a69412dd110": {
       "title": "Relaxing Simulator"
@@ -85,8 +126,8 @@
       "title": "Smiley Dusty"
     },
     "itad-f0cffe659c19": {
-      "title": "Blacklist Mafia",
-      "claim_url": "https://freebies.indiegala.com/blacklist-mafia"
+      "claim_url": "https://freebies.indiegala.com/blacklist-mafia",
+      "title": "Blacklist Mafia"
     }
   },
   "dismissed": [
@@ -106,6 +147,13 @@
     "gamerpower-3272",
     "itad-50a2b5b1d7a6",
     "itad-047270155013",
-    "gamerpower-3279"
+    "gamerpower-3279",
+    "itad-8738c881d524",
+    "epic-the-ouroboros-king-e1d547",
+    "itad-d2d983178b48",
+    "itad-caf022eee569",
+    "itad-8ca7cd481f36",
+    "gamerpower-3681",
+    "itad-0d845ad1210c"
   ]
 }

--- a/curated/free_claims.auto.json
+++ b/curated/free_claims.auto.json
@@ -1,33 +1,179 @@
 {
-  "fetched_at": "2026-06-10T02:25:43.492986+00:00",
+  "fetched_at": "2026-06-11T22:55:16.977190+00:00",
   "sources": {
     "epic": 2,
-    "gamerpower": 15,
-    "itad": 17
+    "gamerpower": 23,
+    "itad": 18
   },
   "attribution": [
     "GamerPower.com"
   ],
   "items": [
     {
-      "id": "epic-rogue-waters-9764d6",
+      "id": "epic-the-ouroboros-king-e1d547",
       "store": "epic",
-      "title": "Rogue Waters",
-      "claim_url": "https://store.epicgames.com/en-US/p/rogue-waters-9764d6",
-      "ends_at": "2026-06-11T15:00:00Z",
-      "header_image": "https://cdn1.epicgames.com/offer/d5241c76f178492ea1540fce45616757/rogue-waters-wide_2560x1440-81c0f87c8e7c4bb09e2d7d9c94213104",
+      "title": "The Ouroboros King",
+      "claim_url": "https://store.epicgames.com/en-US/p/the-ouroboros-king-e1d547",
+      "ends_at": "2026-06-18T15:00:00Z",
+      "header_image": "https://cdn1.epicgames.com/spt-assets/33630d7105014582a478094e89953f49/the-ouroboros-king-jwabx.jpg",
       "blurb": null,
-      "source": "epic"
+      "source": "epic",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
-      "id": "epic-songs-of-conquest",
+      "id": "epic-warhammer-40k-speed-freeks-12879c",
       "store": "epic",
-      "title": "Songs of Conquest",
-      "claim_url": "https://store.epicgames.com/en-US/p/songs-of-conquest",
-      "ends_at": "2026-06-11T15:00:00Z",
-      "header_image": "https://cdn1.epicgames.com/offer/d5241c76f178492ea1540fce45616757/s2_2560x1440-5c396b18c3e1460fb4a268cc6bbdfaa2",
+      "title": "Warhammer 40K Speed Freeks",
+      "claim_url": "https://store.epicgames.com/en-US/p/warhammer-40k-speed-freeks-12879c",
+      "ends_at": "2026-06-18T15:00:00Z",
+      "header_image": "https://cdn1.epicgames.com/spt-assets/a1af14251fb748fc9bda63bfc260f933/warhammer-40k-speed-freeks-1k4pq.jpg",
       "blurb": null,
-      "source": "epic"
+      "source": "epic",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "gamerpower-3684",
+      "store": "steam",
+      "title": "Eets (Steam) Giveaway",
+      "claim_url": "https://www.gamerpower.com/open/eets-steam-giveaway",
+      "ends_at": "2026-06-15T23:59:00Z",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/6100/b97e6e9de18d08941c872fc73abae7c2dc91ccfe/header.jpg?t=1781207036",
+      "blurb": "Claim Eets for free on Steam until June 15! Eets is a 2D puzzle game, something like Lemmings meets The Incredible Machine.",
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00",
+      "review_percent": 59,
+      "steam_appid": 6100,
+      "genres": [
+        "Casual",
+        "Indie",
+        "Strategy"
+      ]
+    },
+    {
+      "id": "gamerpower-3682",
+      "store": "steam",
+      "title": "The Red Lantern (Steam) Giveaway",
+      "claim_url": "https://www.gamerpower.com/open/the-red-lantern-steam-giveaway",
+      "ends_at": "2026-06-18T23:59:00Z",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/1053710/library_600x900_2x.jpg",
+      "blurb": "This giveaway is for the dog lovers! Grab The Red Lantern for free on Steam until June 18! The Red Lantern is a 3d first person dog sledding game with very positive reviews. Don´t miss it!",
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00",
+      "review_percent": 82,
+      "steam_appid": 1053710,
+      "genres": [
+        "Adventure",
+        "Casual",
+        "Indie",
+        "RPG"
+      ]
+    },
+    {
+      "id": "gamerpower-3681",
+      "store": "epic",
+      "title": "Warhammer 40,000: Speed Freeks (Epic Games) Giveaway",
+      "claim_url": "https://www.gamerpower.com/open/warhammer-40-000-speed-freeks-epic-games-giveaway",
+      "ends_at": "2026-06-18T23:59:00Z",
+      "header_image": "https://www.gamerpower.com/offers/1b/6a2ace194c587.jpg",
+      "blurb": "You don't need to race to grab this giveaway! Score Warhammer 40,000: Speed Freeks for free on Epic Games Store until June 18! Warhammer 40,000: Speed Freeks is a cool combat racing game in the Warhammer 40,000 universe!",
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "gamerpower-3680",
+      "store": "epic",
+      "title": "The Ouroboros King (Epic Games) Giveaway",
+      "claim_url": "https://www.gamerpower.com/open/the-ouroboros-king-epic-games-giveaway",
+      "ends_at": "2026-06-18T23:59:00Z",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2096510/library_600x900_2x.jpg",
+      "blurb": "Checkmate your boredom! Download The Ouroboros King without any cost via Epic Games Store! The Ouroboros King combines chess with the replayability of roguelikes. Check it out!",
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00",
+      "review_percent": 81,
+      "steam_appid": 2096510
+    },
+    {
+      "id": "gamerpower-3679",
+      "store": "steam",
+      "title": "Happy's Humble Burger Farm (Steam) Giveaway",
+      "claim_url": "https://www.gamerpower.com/open/happy-s-humble-burger-farm-steam-giveaway",
+      "ends_at": "2026-06-15T23:59:00Z",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/1433340/library_600x900_2x.jpg",
+      "blurb": "Start grilling patties today with this giveaway! Grab Happy’s Humble Burger Farm for free on Steam until June 15. Happy’s Humble Burger Farm is a first-person sim game about serving customers and maintaining a restaurant. Don´t miss it!",
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00",
+      "review_percent": 92,
+      "steam_appid": 1433340,
+      "genres": [
+        "Action",
+        "Adventure",
+        "Indie",
+        "Simulation"
+      ]
+    },
+    {
+      "id": "gamerpower-3678",
+      "store": "itch",
+      "title": "MicroCrawl (itch.io) Giveaway",
+      "claim_url": "https://www.gamerpower.com/open/microcrawl-itch-io-giveaway",
+      "ends_at": "2026-06-13T23:59:00Z",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2250400/library_600x900_2x.jpg",
+      "blurb": "80s Nostalgia! Get MicroCrawl for free on itch.io! MicroCrawl is a small 2D point-and-click adventure game with a first-person perspective that evokes memories of old-school dungeon crawlers from the 80s.",
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00",
+      "review_percent": 91,
+      "steam_appid": 2250400
+    },
+    {
+      "id": "gamerpower-3677",
+      "store": "itch",
+      "title": "Not A Customer (itch.io) Giveaway",
+      "claim_url": "https://www.gamerpower.com/open/not-a-customer-itch-io-giveaway",
+      "ends_at": "2026-06-14T23:59:00Z",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4747110/f8247728e4974286b897788cecda406069ab2068/header.jpg?t=1781116480",
+      "blurb": "Download Not A Customer for free on itch.io. Not A Customer is a 3d first person grocery store sim game with old school Playstation 1 graphics. Check it out!",
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00",
+      "steam_appid": 4747110
+    },
+    {
+      "id": "gamerpower-3548",
+      "store": "itch",
+      "title": "Static Voice (Itch.io) Giveaway",
+      "claim_url": "https://www.gamerpower.com/open/static-voice-itch-io-giveaway",
+      "ends_at": "2026-06-19T23:59:00Z",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4207170/5b734a735246cf374806d41ec31076c84772566a/header.jpg?t=1776267157",
+      "blurb": "Claim Static Voice for free on Itch.io! Static Voice is a first-person survival game where you play as a resident of an old Soviet apartment block.",
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00",
+      "review_percent": 93,
+      "steam_appid": 4207170
+    },
+    {
+      "id": "gamerpower-3553",
+      "store": "itch",
+      "title": "Sleep Demon (Itchio) Giveaway",
+      "claim_url": "https://www.gamerpower.com/open/sleep-demon-itchio-giveaway",
+      "ends_at": "2026-06-14T23:59:00Z",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4465030/d04ad74487b126388fee536474bcb258c642239c/header.jpg?t=1773513774",
+      "blurb": "Download Sleep Demon for free on Itch.io until June 14, a indie single player walking simulator game about sleep paralysis.",
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00",
+      "review_percent": 83,
+      "steam_appid": 4465030
+    },
+    {
+      "id": "gamerpower-3477",
+      "store": "itch",
+      "title": "CALLUS (itch.io) Giveaway",
+      "claim_url": "https://www.gamerpower.com/open/callus-itch-io-giveaway",
+      "ends_at": "2026-06-15T23:59:00Z",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4258330/6bdf7e7240b40e22c54c407ebe860b7397c53fd8/header.jpg?t=1781111625",
+      "blurb": "Want to go for a walk? Grab CALLUS for free on itch.io! Callus is a small indie psychological walking simulator with realistic gameplay.",
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00",
+      "review_percent": 76,
+      "steam_appid": 4258330
     },
     {
       "id": "gamerpower-3676",
@@ -39,7 +185,8 @@
       "blurb": "Explore deep space with this giveaway. Get Dire Echo for free on itch.io, a 3d sci-fi first-person exploration game featuring impressive visuals.",
       "source": "gamerpower",
       "review_percent": 75,
-      "steam_appid": 3743180
+      "steam_appid": 3743180,
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-3279",
@@ -49,7 +196,8 @@
       "ends_at": null,
       "header_image": "https://www.gamerpower.com/offers/1b/68ca9583aca60.jpg",
       "blurb": "Live your mafia fantasy! Grab Blacklist Mafia for free on IndieGala. Blacklist Mafia is a small 2D adventure game where you experience life in the mafia.",
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-3673",
@@ -59,7 +207,8 @@
       "ends_at": "2026-06-14T23:59:00Z",
       "header_image": "https://www.gamerpower.com/offers/1b/6a25c2413d322.jpg",
       "blurb": "Just relax and grab Relaxing Simulator for free on the Epic Games Store for the ultimate relaxing experience!",
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-3671",
@@ -69,27 +218,8 @@
       "ends_at": "2026-06-14T23:59:00Z",
       "header_image": "https://www.gamerpower.com/offers/1b/6a25903df2853.jpg",
       "blurb": "Flufftopia is free on itch.io until June 14th 2026. Flufftopia is a small clicker game with a story. Check it out!",
-      "source": "gamerpower"
-    },
-    {
-      "id": "gamerpower-3668",
-      "store": "epic",
-      "title": "Songs of Conquest (Epic Games) Giveaway",
-      "claim_url": "https://www.gamerpower.com/open/songs-of-conquest-epic-games-giveaway",
-      "ends_at": "2026-06-11T23:59:00Z",
-      "header_image": "https://www.gamerpower.com/offers/1b/6a2194d7915ac.jpg",
-      "blurb": "Claim Songs of Conquest for free on the Epic Games Store. Songs of Conquest is a turn-based strategy game with tactical combat and kingdom management. This game has lots of positive reviews, so don't miss it!",
-      "source": "gamerpower"
-    },
-    {
-      "id": "gamerpower-3667",
-      "store": "epic",
-      "title": "Rogue Waters (Epic Games) Giveaway",
-      "claim_url": "https://www.gamerpower.com/open/rogue-waters-epic-games-giveaway",
-      "ends_at": "2026-06-11T23:59:00Z",
-      "header_image": "https://www.gamerpower.com/offers/1b/6a2193ea2f810.jpg",
-      "blurb": "Set sail with this giveaway! Grab Rogue Waters for free on Epic Games Store until 11 June. Rogue Waters is a 3d tactical turn-based rogue-lite game set in a pirate world.",
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-2386",
@@ -97,7 +227,7 @@
       "title": "Tell Me Why (Steam) Giveaway",
       "claim_url": "https://www.gamerpower.com/open/tell-me-why-steam-giveaway",
       "ends_at": "2026-07-01T23:59:59Z",
-      "header_image": "https://www.gamerpower.com/offers/1b/6478b9dcae7be.jpg",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/1180660/library_600x900_2x.jpg",
       "blurb": "Dive into the Riveting World of Tell Me Why for FREE on Steam! Tell Me Why is a multi-award winning episodic adventure game from Dontnod Entertainment! Don't pass up the chance to experience this extraordinary game for free!",
       "source": "gamerpower",
       "review_percent": 82,
@@ -105,7 +235,8 @@
       "genres": [
         "Adventure",
         "Free To Play"
-      ]
+      ],
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-3665",
@@ -113,7 +244,7 @@
       "title": "Gravity Circuit (Steam) Giveaway",
       "claim_url": "https://www.gamerpower.com/open/gravity-circuit-steam-giveaway",
       "ends_at": "2026-06-14T23:59:00Z",
-      "header_image": "https://www.gamerpower.com/offers/1b/6a1dbddf722cd.jpg",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/858710/library_600x900_2x.jpg",
       "blurb": "Looking for a cool Steam game? Grab Gravity Circuit for free via Steam until June 14. Gravity Circuit is a action packed 2D platformer in the spirit of console classics. Don´t miss this one.",
       "source": "gamerpower",
       "review_percent": 92,
@@ -121,7 +252,8 @@
       "genres": [
         "Action",
         "Indie"
-      ]
+      ],
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-3287",
@@ -131,7 +263,8 @@
       "ends_at": null,
       "header_image": "https://www.gamerpower.com/offers/1b/68ce9db7d6736.jpg",
       "blurb": "Your fight against fast food begins today! Download Mr.Brocco And Co for free via IndieGala. Mr.Brocco And Co is a 2D platform game where junk food is trying to take over!",
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-3272",
@@ -141,7 +274,8 @@
       "ends_at": null,
       "header_image": "https://www.gamerpower.com/offers/1b/68bafea6b0b4d.jpg",
       "blurb": "Save the world… as a cloud. Download The Brave Little Cloud for free on IndieGala! The Brave Little Cloud is a 2D platformer where you play as a small cloud on a quest to battle evil.",
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-3266",
@@ -149,11 +283,12 @@
       "title": "Carlos the Taco (IndieGala) Giveaway",
       "claim_url": "https://www.gamerpower.com/open/carlos-the-taco-pc-giveaway",
       "ends_at": null,
-      "header_image": "https://www.gamerpower.com/offers/1b/68b1ae1e5c9ce.jpg",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2081930/library_600x900_2x.jpg",
       "blurb": "Become the Taco! Finally, a free game made for taco fans! Download Carlos the Taco for free on IndieGala. Carlos the Taco is a 2D platformer set in Mexico where you play as a taco!",
       "source": "gamerpower",
       "review_percent": 85,
-      "steam_appid": 2081930
+      "steam_appid": 2081930,
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-3096",
@@ -161,11 +296,12 @@
       "title": "Madness Inside (itch.io) Giveaway",
       "claim_url": "https://www.gamerpower.com/open/madness-inside-itch-io-giveaway",
       "ends_at": "2026-08-01T23:59:59Z",
-      "header_image": "https://www.gamerpower.com/offers/1b/67c76007697b3.jpg",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/3102000/library_600x900_2x.jpg",
       "blurb": "Download Madness Inside for free on Itch.io! Madness Inside is an indie psychological walking simulator where you explore a psychiatric hospital.",
       "source": "gamerpower",
       "review_percent": 76,
-      "steam_appid": 3102000
+      "steam_appid": 3102000,
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-3446",
@@ -173,11 +309,12 @@
       "title": "GigaBash (Stove) Giveaway",
       "claim_url": "https://www.gamerpower.com/open/gigabash-pc-giveaway",
       "ends_at": null,
-      "header_image": "https://www.gamerpower.com/offers/1b/69567c4ee0fa3.jpg",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/1546400/library_600x900_2x.jpg",
       "blurb": "Score GigaBash for free via Stove and claim your place as king among Titans! GigaBash is a multiplayer arena brawler with gigantic film-inspired kaiju and fully destructible environments.",
       "source": "gamerpower",
       "review_percent": 94,
-      "steam_appid": 1546400
+      "steam_appid": 1546400,
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-2204",
@@ -185,11 +322,12 @@
       "title": "Dual Chroma: Academy Carols (itch.io) Giveaway",
       "claim_url": "https://www.gamerpower.com/open/dual-chroma-academy-carols-itch-io-giveaway",
       "ends_at": null,
-      "header_image": "https://www.gamerpower.com/offers/1b/63c6f67bb9c8b.jpg",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2299730/library_600x900_2x.jpg",
       "blurb": "Grab Dual Chroma: Academy Carols for free on itch.io! Dual Chroma: Academy Carols is a slice-of-life Visual Novel. Check it out, If you are a fan of this type of game!",
       "source": "gamerpower",
       "review_percent": 86,
-      "steam_appid": 2299730
+      "steam_appid": 2299730,
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-1604",
@@ -199,7 +337,76 @@
       "ends_at": null,
       "header_image": "https://www.gamerpower.com/offers/1b/62dec9fa9312b.jpg",
       "blurb": "Grab Dora Diginoid for free on itch.io! Dora Diginoid is an indie Metroidvania sci-fi adventure game where you explore the base 17.",
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "itad-caf022eee569",
+      "store": "steam",
+      "title": "Eets - FREE on Steam on Steam",
+      "claim_url": "https://isthereanydeal.com/giveaways/16263/",
+      "ends_at": null,
+      "header_image": null,
+      "blurb": "<a href=\"https://isthereanydeal.com/game/eets/info/\">Eets</a>\n                        \n                                                \n                        <br />\n                    \n                    \n                    <br />\n                                            expires on Mon, 15 Jun 2026 19:11:00 +0200\n                                        | <a href=https://store.steampowered.com/app/6100/Eets/>go to giveaway</a>",
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "itad-330faa9821bf",
+      "store": "epic",
+      "title": "Guild of Dungeoneering Ultimate Edition free on mobile on Epic Game Store",
+      "claim_url": "https://isthereanydeal.com/giveaways/16262/",
+      "ends_at": null,
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/317820/library_600x900_2x.jpg",
+      "blurb": "Guild of Dungeoneering Ultimate Edition",
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00",
+      "review_percent": 77,
+      "steam_appid": 317820
+    },
+    {
+      "id": "itad-d2d983178b48",
+      "store": "steam",
+      "title": "The Red Lantern - FREE on Steam on Steam",
+      "claim_url": "https://isthereanydeal.com/giveaways/16261/",
+      "ends_at": null,
+      "header_image": null,
+      "blurb": "<a href=\"https://isthereanydeal.com/game/the-red-lantern/info/\">The Red Lantern</a>\n                        \n                                                \n                        <br />\n                    \n                    \n                    <br />\n                                            expires on Thu, 18 Jun 2026 17:06:00 +0200\n                                        | <a href=https://store.steampowered.com/app/1053710/The_Red_Lantern/>go to giveaway</a>",
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "itad-8738c881d524",
+      "store": "steam",
+      "title": "Happy's Humble Burger Farm - FREE on Steam on Steam",
+      "claim_url": "https://isthereanydeal.com/giveaways/16259/",
+      "ends_at": null,
+      "header_image": null,
+      "blurb": "<a href=\"https://isthereanydeal.com/game/happys-humble-burger-farm/info/\">Happy&#039;s Humble Burger Farm</a>\n                        \n                                                \n                        <br />\n                    \n                    \n                    <br />\n                                            expires on Mon, 15 Jun 2026 15:00:00 +0200\n                                        | <a href=https://store.steampowered.com/app/1433340/Happys_Humble_Burger_Farm/>go to giveaway</a>",
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "itad-8ca7cd481f36",
+      "store": "epic",
+      "title": "Warhammer 40,000: Speed Freeks - FREE on Epic Games on Epic Game Store",
+      "claim_url": "https://isthereanydeal.com/giveaways/16258/",
+      "ends_at": null,
+      "header_image": null,
+      "blurb": "<a href=\"https://isthereanydeal.com/game/warhammer-40000-speed-freeks/info/\">Warhammer 40,000: Speed Freeks</a>\n                        \n                                                \n                        <br />\n                    \n                    \n                    <br />\n                                            expires on Thu, 18 Jun 2026 17:00:00 +0200\n                                        | <a href=https://store.epicgames.com/p/warhammer-40k-speed-freeks-12879c>go to giveaway</a>",
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "itad-0d845ad1210c",
+      "store": "epic",
+      "title": "The Ouroboros King - FREE on Epic Games on Epic Game Store",
+      "claim_url": "https://isthereanydeal.com/giveaways/16257/",
+      "ends_at": null,
+      "header_image": null,
+      "blurb": "<a href=\"https://isthereanydeal.com/game/the-ouroboros-king/info/\">The Ouroboros King</a>\n                        \n                                                \n                        <br />\n                    \n                    \n                    <br />\n                                            expires on Thu, 18 Jun 2026 17:00:00 +0200\n                                        | <a href=https://store.epicgames.com/p/the-ouroboros-king-e1d547>go to giveaway</a>",
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "itad-f0cffe659c19",
@@ -208,10 +415,11 @@
       "claim_url": "https://isthereanydeal.com/giveaways/16253/",
       "ends_at": null,
       "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2800500/library_600x900_2x.jpg",
-      "blurb": "<a href=\"https://isthereanydeal.com/game/blacklist-mafia/info/\">Blacklist Mafia</a>\n                        \n                                                \n                        <br />\n                    \n                    \n                    <br />\n                                            unknown expiry\n                                        | <a href=https://freebies.indiegala.com/blacklist-mafia>go to giveaway</a>",
+      "blurb": "Blacklist Mafia",
       "source": "itad",
       "review_percent": 82,
-      "steam_appid": 2800500
+      "steam_appid": 2800500,
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "itad-6d00ffeb0fdc",
@@ -220,10 +428,11 @@
       "claim_url": "https://isthereanydeal.com/giveaways/16251/",
       "ends_at": null,
       "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/3445980/library_600x900_2x.jpg",
-      "blurb": "<a href=\"https://isthereanydeal.com/game/another-world-adventures/info/\">Another World Adventures</a>\n                        \n                                                \n                        <br />\n                    \n                    \n                    <br />\n                                            expires on Sat, 20 Jun 2026 03:00:00 +0200\n                                        | <a href=https://s-xavier-uy.itch.io/another-world-adventures>go to giveaway</a>",
+      "blurb": "Another World Adventures",
       "source": "itad",
       "review_percent": 50,
-      "steam_appid": 3445980
+      "steam_appid": 3445980,
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "itad-7a69412dd110",
@@ -232,46 +441,11 @@
       "claim_url": "https://isthereanydeal.com/giveaways/16247/",
       "ends_at": null,
       "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2965380/library_600x900_2x.jpg",
-      "blurb": "<a href=\"https://isthereanydeal.com/game/relaxing-simulator/info/\">Relaxing Simulator</a>\n                        \n                                                \n                        <br />\n                    \n                    \n                    <br />\n                                            expires on Mon, 15 Jun 2026 07:00:00 +0200\n                                        | <a href=https://store.epicgames.com/p/relaxing-simulator-4cca47>go to giveaway</a>",
+      "blurb": "Relaxing Simulator",
       "source": "itad",
       "review_percent": 89,
-      "steam_appid": 2965380
-    },
-    {
-      "id": "itad-b07aac9ebd26",
-      "store": "epic",
-      "title": "Wytchwood free for mobile on EGS on Epic Game Store",
-      "claim_url": "https://isthereanydeal.com/giveaways/16242/",
-      "ends_at": null,
-      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/729000/library_600x900_2x.jpg",
-      "blurb": "<a href=\"https://isthereanydeal.com/game/wytchwood/info/\">Wytchwood</a>\n                        \n                                                \n                        <br />\n                    \n                    \n                    <br />\n                                            expires on Thu, 11 Jun 2026 16:59:00 +0200\n                                        | <a href=https://store.epicgames.com/purchase?offers=1-8bd7d123bc59474ebb2552793dc0fdbb-69657a7a252741bdbc72fbaebe5bb07b&amp;offers=1-8bd7d123bc59474ebb2552793dc0fdbb-e503745d0b2e4391b4454a3d1b75f22e>go to giveaway</a>",
-      "source": "itad",
-      "review_percent": 93,
-      "steam_appid": 729000
-    },
-    {
-      "id": "itad-073a56345192",
-      "store": "epic",
-      "title": "Songs of Conquest free at EGS on Epic Game Store",
-      "claim_url": "https://isthereanydeal.com/giveaways/16239/",
-      "ends_at": null,
-      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/867210/library_600x900_2x.jpg",
-      "blurb": "<a href=\"https://isthereanydeal.com/game/songs-of-conquest/info/\">Songs of Conquest</a>\n                        \n                                                \n                        <br />\n                    \n                    \n                    <br />\n                                            expires on Thu, 11 Jun 2026 16:59:00 +0200\n                                        | <a href=https://store.epicgames.com/p/songs-of-conquest>go to giveaway</a>",
-      "source": "itad",
-      "review_percent": 86,
-      "steam_appid": 867210
-    },
-    {
-      "id": "itad-0c69ed1f1bd8",
-      "store": "epic",
-      "title": "Rogue Waters free at EGS on Epic Game Store",
-      "claim_url": "https://isthereanydeal.com/giveaways/16240/",
-      "ends_at": null,
-      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/1691190/library_600x900_2x.jpg",
-      "blurb": "<a href=\"https://isthereanydeal.com/game/rogue-waters/info/\">Rogue Waters</a>\n                        \n                                                \n                        <br />\n                    \n                    \n                    <br />\n                                            expires on Thu, 11 Jun 2026 16:59:00 +0200\n                                        | <a href=https://store.epicgames.com/p/rogue-waters-9764d6>go to giveaway</a>",
-      "source": "itad",
-      "review_percent": 76,
-      "steam_appid": 1691190
+      "steam_appid": 2965380,
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "itad-50a2b5b1d7a6",
@@ -281,7 +455,8 @@
       "ends_at": null,
       "header_image": null,
       "blurb": "<a href=\"https://isthereanydeal.com/game/tell-me-why/info/\">Tell Me Why</a>\n                        \n                                                \n                        <br />\n                                            <a href=\"https://isthereanydeal.com/game/tell-me-why-chapter-2/info/\">Tell Me Why: Chapter 2</a>\n                        \n                                                \n                        <br />\n                                            <a href=\"https://isthereanydeal.com/game/tell-me-why-chapter-3/info/\">Tell Me Why: Chapter 3</a>\n                        \n                                                \n                        <br />\n                    \n                    \n                    <br />\n                                            expires on Wed, 01 Jul 2026 19:00:00 +0200\n                                        | <a href=https://store.steampowered.com/app/1180660/Tell_Me_Why>go to giveaway</a>",
-      "source": "itad"
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "itad-047270155013",
@@ -291,7 +466,8 @@
       "ends_at": null,
       "header_image": null,
       "blurb": "<a href=\"https://isthereanydeal.com/game/gravity-circuit/info/\">Gravity Circuit</a>\n                        \n                                                \n                        <br />\n                    \n                    \n                    <br />\n                                            expires on Tue, 14 Jul 2026 19:00:00 +0200\n                                        | <a href=https://store.steampowered.com/app/858710/Gravity_Circuit/>go to giveaway</a>",
-      "source": "itad"
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "itad-0d4598c53ffe",
@@ -300,10 +476,11 @@
       "claim_url": "https://isthereanydeal.com/giveaways/16196/",
       "ends_at": null,
       "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2074560/library_600x900_2x.jpg",
-      "blurb": "<a href=\"https://isthereanydeal.com/game/mr-brocco-and-co/info/\">Mr.Brocco &amp; Co</a>\n                        \n                                                \n                        <br />\n                    \n                    \n                    <br />\n                                            unknown expiry\n                                        | <a href=https://freebies.indiegala.com/mrbrocco-co>go to giveaway</a>",
+      "blurb": "Mr.Brocco & Co",
       "source": "itad",
       "review_percent": 83,
-      "steam_appid": 2074560
+      "steam_appid": 2074560,
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "itad-78f8867f4481",
@@ -313,27 +490,8 @@
       "ends_at": null,
       "header_image": null,
       "blurb": "<a href=\"https://isthereanydeal.com/game/world-of-warships-x-azur-lane-quest-for-al-avrora--1/info/\">World of Warships x Azur Lane — Quest for AL Avrora</a>\n                        \n                                                \n                        <br />\n                    \n                    \n                    <br />\n                                            expires on Thu, 18 Jun 2026 19:00:00 +0200\n                                        | <a href=https://store.steampowered.com/app/4627430/World_of_Warships_x_Azur_Lane__Quest_for_AL_Avrora/>go to giveaway</a>",
-      "source": "itad"
-    },
-    {
-      "id": "itad-239f10d33b17",
-      "store": "epic",
-      "title": "MONGIL: STAR DIVE free in game items. on Epic Game Store",
-      "claim_url": "https://isthereanydeal.com/giveaways/16166/",
-      "ends_at": null,
-      "header_image": null,
-      "blurb": "<a href=\"https://isthereanydeal.com/game/divers-mega-pack/info/\">Divers Mega Pack</a>\n                        \n                                                \n                        <br />\n                    \n                    \n                    <br />\n                                            expires on Thu, 11 Jun 2026 17:00:00 +0200\n                                        | <a href=https://store.epicgames.com/p/mongil-star-dive-divers-mega-pack-a3d25d>go to giveaway</a>",
-      "source": "itad"
-    },
-    {
-      "id": "itad-48cfa4ebeae5",
-      "store": "epic",
-      "title": "RAVEN II in game currency pack on Epic Game Store",
-      "claim_url": "https://isthereanydeal.com/giveaways/16165/",
-      "ends_at": null,
-      "header_image": null,
-      "blurb": "<a href=\"https://isthereanydeal.com/game/raven2-half-anniversary-starter-pack/info/\">RAVEN2 Half anniversary Starter Pack</a>\n                        \n                                                \n                        <br />\n                    \n                    \n                    <br />\n                                            expires on Thu, 11 Jun 2026 17:00:00 +0200\n                                        | <a href=https://store.epicgames.com/p/raven2-raven2-half-anniversary-starter-pack-6b8076>go to giveaway</a>",
-      "source": "itad"
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "itad-dd5b5b16e035",
@@ -342,10 +500,11 @@
       "claim_url": "https://isthereanydeal.com/giveaways/16143/",
       "ends_at": null,
       "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2635070/library_600x900_2x.jpg",
-      "blurb": "<a href=\"https://isthereanydeal.com/game/the-brave-little-cloud/info/\">The Brave Little Cloud</a>\n                        \n                                                \n                        <br />\n                    \n                    \n                    <br />\n                                            unknown expiry\n                                        | <a href=https://freebies.indiegala.com/the-brave-little-cloud>go to giveaway</a>",
+      "blurb": "The Brave Little Cloud",
       "source": "itad",
       "review_percent": 97,
-      "steam_appid": 2635070
+      "steam_appid": 2635070,
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "itad-98730029b14b",
@@ -355,7 +514,8 @@
       "ends_at": null,
       "header_image": null,
       "blurb": "<a href=\"https://isthereanydeal.com/game/carlos-the-taco/info/\">Carlos the Taco</a>\n                        \n                                                \n                        <br />\n                    \n                    \n                    <br />\n                                            unknown expiry\n                                        | <a href=https://freebies.indiegala.com/carlos-the-taco>go to giveaway</a>",
-      "source": "itad"
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "itad-d85d5bb4128d",
@@ -365,7 +525,8 @@
       "ends_at": null,
       "header_image": null,
       "blurb": "<a href=\"https://isthereanydeal.com/game/madness-inside/info/\">Madness inside</a>\n                        \n                                                \n                        <br />\n                    \n                    \n                    <br />\n                                            expires on Sat, 01 Aug 2026 18:00:00 +0200\n                                        | <a href=https://zv-games.itch.io/madness-inside>go to giveaway</a>",
-      "source": "itad"
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "itad-de23882e1f39",
@@ -374,8 +535,9 @@
       "claim_url": "https://isthereanydeal.com/giveaways/15746/",
       "ends_at": null,
       "header_image": null,
-      "blurb": "<a href=\"https://isthereanydeal.com/game/smiley-dusty/info/\">Smiley Dusty</a>\n                        \n                                                \n                        <br />\n                    \n                    \n                    <br />\n                                            expires on Sat, 21 Nov 2026 17:00:00 +0100\n                                        | <a href=https://polypaw.itch.io/smiley-dusty>go to giveaway</a>",
-      "source": "itad"
+      "blurb": "Smiley Dusty",
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "itad-1b0433806065",
@@ -384,10 +546,11 @@
       "claim_url": "https://isthereanydeal.com/giveaways/7433/",
       "ends_at": null,
       "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/973000/header.jpg?t=1669757014",
-      "blurb": "<a href=\"https://isthereanydeal.com/game/die-young-prologue/info/\">Die Young: Prologue</a>\n                        \n                                                \n                        <br />\n                    \n                    \n                    <br />\n                                            unknown expiry\n                                        | <a href=https://freebies.indiegala.com/die-young-prologue>go to giveaway</a>",
+      "blurb": "Die Young: Prologue",
       "source": "itad",
       "review_percent": 78,
-      "steam_appid": 973000
+      "steam_appid": 973000,
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     }
   ]
 }

--- a/curated/free_claims.fallback.json
+++ b/curated/free_claims.fallback.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-10T02:28:16.129220+00:00",
+  "generated_at": "2026-06-11T23:08:29.203734+00:00",
   "items": [
     {
       "id": "itad-9dcfdf2b0b35",
@@ -19,17 +19,169 @@
       "source": "itad"
     },
     {
+      "id": "epic-warhammer-40k-speed-freeks-12879c",
+      "store": "epic",
+      "title": "Warhammer 40K Speed Freeks",
+      "claim_url": "https://store.epicgames.com/en-US/p/warhammer-40k-speed-freeks-12879c",
+      "header_image": "https://cdn1.epicgames.com/spt-assets/a1af14251fb748fc9bda63bfc260f933/warhammer-40k-speed-freeks-1k4pq.jpg",
+      "genres": [],
+      "blurb": null,
+      "ends_at": "2026-06-18T15:00:00Z",
+      "source": "epic",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "gamerpower-3684",
+      "store": "steam",
+      "title": "Eets",
+      "claim_url": "https://www.gamerpower.com/open/eets-steam-giveaway",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/6100/b97e6e9de18d08941c872fc73abae7c2dc91ccfe/header.jpg?t=1781207036",
+      "genres": [
+        "Casual",
+        "Indie",
+        "Strategy"
+      ],
+      "blurb": "Claim Eets for free on Steam until June 15! Eets is a 2D puzzle game, something like Lemmings meets The Incredible Machine.",
+      "ends_at": "2026-06-15T23:59:00Z",
+      "steam_appid": 6100,
+      "review_percent": 59,
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "gamerpower-3682",
+      "store": "steam",
+      "title": "The Red Lantern",
+      "claim_url": "https://www.gamerpower.com/open/the-red-lantern-steam-giveaway",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/1053710/library_600x900_2x.jpg",
+      "genres": [
+        "Adventure",
+        "Casual",
+        "Indie",
+        "RPG"
+      ],
+      "blurb": "This giveaway is for the dog lovers! Grab The Red Lantern for free on Steam until June 18! The Red Lantern is a 3d first person dog sledding game with very positive reviews. Don´t miss it!",
+      "ends_at": "2026-06-18T23:59:00Z",
+      "steam_appid": 1053710,
+      "review_percent": 82,
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "gamerpower-3680",
+      "store": "epic",
+      "title": "The Ouroboros King",
+      "claim_url": "https://www.gamerpower.com/open/the-ouroboros-king-epic-games-giveaway",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2096510/library_600x900_2x.jpg",
+      "genres": [],
+      "blurb": "Checkmate your boredom! Download The Ouroboros King without any cost via Epic Games Store! The Ouroboros King combines chess with the replayability of roguelikes. Check it out!",
+      "ends_at": "2026-06-18T23:59:00Z",
+      "steam_appid": 2096510,
+      "review_percent": 81,
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "gamerpower-3679",
+      "store": "steam",
+      "title": "Happy's Humble Burger Farm",
+      "claim_url": "https://www.gamerpower.com/open/happy-s-humble-burger-farm-steam-giveaway",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/1433340/library_600x900_2x.jpg",
+      "genres": [
+        "Action",
+        "Adventure",
+        "Indie",
+        "Simulation"
+      ],
+      "blurb": "Start grilling patties today with this giveaway! Grab Happy’s Humble Burger Farm for free on Steam until June 15. Happy’s Humble Burger Farm is a first-person sim game about serving customers and maintaining a restaurant. Don´t miss it!",
+      "ends_at": "2026-06-15T23:59:00Z",
+      "steam_appid": 1433340,
+      "review_percent": 92,
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "gamerpower-3678",
+      "store": "itch",
+      "title": "MicroCrawl",
+      "claim_url": "https://www.gamerpower.com/open/microcrawl-itch-io-giveaway",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2250400/library_600x900_2x.jpg",
+      "genres": [],
+      "blurb": "80s Nostalgia! Get MicroCrawl for free on itch.io! MicroCrawl is a small 2D point-and-click adventure game with a first-person perspective that evokes memories of old-school dungeon crawlers from the 80s.",
+      "ends_at": "2026-06-13T23:59:00Z",
+      "steam_appid": 2250400,
+      "review_percent": 91,
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "gamerpower-3677",
+      "store": "itch",
+      "title": "Not A Customer",
+      "claim_url": "https://www.gamerpower.com/open/not-a-customer-itch-io-giveaway",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4747110/f8247728e4974286b897788cecda406069ab2068/header.jpg?t=1781116480",
+      "genres": [],
+      "blurb": "Download Not A Customer for free on itch.io. Not A Customer is a 3d first person grocery store sim game with old school Playstation 1 graphics. Check it out!",
+      "ends_at": "2026-06-14T23:59:00Z",
+      "steam_appid": 4747110,
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "gamerpower-3548",
+      "store": "itch",
+      "title": "Static Voice",
+      "claim_url": "https://www.gamerpower.com/open/static-voice-itch-io-giveaway",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4207170/5b734a735246cf374806d41ec31076c84772566a/header.jpg?t=1776267157",
+      "genres": [],
+      "blurb": "Claim Static Voice for free on Itch.io! Static Voice is a first-person survival game where you play as a resident of an old Soviet apartment block.",
+      "ends_at": "2026-06-19T23:59:00Z",
+      "steam_appid": 4207170,
+      "review_percent": 93,
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "gamerpower-3553",
+      "store": "itch",
+      "title": "Sleep Demon",
+      "claim_url": "https://www.gamerpower.com/open/sleep-demon-itchio-giveaway",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4465030/d04ad74487b126388fee536474bcb258c642239c/header.jpg?t=1773513774",
+      "genres": [],
+      "blurb": "Download Sleep Demon for free on Itch.io until June 14, a indie single player walking simulator game about sleep paralysis.",
+      "ends_at": "2026-06-14T23:59:00Z",
+      "steam_appid": 4465030,
+      "review_percent": 83,
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "gamerpower-3477",
+      "store": "itch",
+      "title": "CALLUS",
+      "claim_url": "https://www.gamerpower.com/open/callus-itch-io-giveaway",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4258330/6bdf7e7240b40e22c54c407ebe860b7397c53fd8/header.jpg?t=1781111625",
+      "genres": [],
+      "blurb": "Want to go for a walk? Grab CALLUS for free on itch.io! Callus is a small indie psychological walking simulator with realistic gameplay.",
+      "ends_at": "2026-06-15T23:59:00Z",
+      "steam_appid": 4258330,
+      "review_percent": 76,
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
       "id": "gamerpower-3676",
       "store": "itch",
       "title": "Dire Echo",
       "claim_url": "https://www.gamerpower.com/open/dire-echo-itchio-giveaway",
-      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/3743180/05c22cf5ef7893b5dd61c756ce94e5d5ebfb3d53/header.jpg?t=1780936347",
+      "header_image": "https://www.gamerpower.com/offers/1b/6a27eafa35794.jpg",
       "genres": [],
       "blurb": "Explore deep space with this giveaway. Get Dire Echo for free on itch.io, a 3d sci-fi first-person exploration game featuring impressive visuals.",
       "ends_at": "2026-06-11T23:59:00Z",
       "steam_appid": 3743180,
       "review_percent": 75,
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-3671",
@@ -40,7 +192,8 @@
       "genres": [],
       "blurb": "Flufftopia is free on itch.io until June 14th 2026. Flufftopia is a small clicker game with a story. Check it out!",
       "ends_at": "2026-06-14T23:59:00Z",
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-2386",
@@ -56,7 +209,8 @@
       "ends_at": "2026-07-01T23:59:59Z",
       "steam_appid": 1180660,
       "review_percent": 82,
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-3665",
@@ -72,7 +226,8 @@
       "ends_at": "2026-06-14T23:59:00Z",
       "steam_appid": 858710,
       "review_percent": 92,
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-3266",
@@ -85,7 +240,8 @@
       "ends_at": null,
       "steam_appid": 2081930,
       "review_percent": 85,
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-3096",
@@ -98,7 +254,8 @@
       "ends_at": "2026-08-01T23:59:59Z",
       "steam_appid": 3102000,
       "review_percent": 76,
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-3446",
@@ -111,7 +268,8 @@
       "ends_at": null,
       "steam_appid": 1546400,
       "review_percent": 94,
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-2204",
@@ -124,7 +282,8 @@
       "ends_at": null,
       "steam_appid": 2299730,
       "review_percent": 86,
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-1604",
@@ -135,7 +294,22 @@
       "genres": [],
       "blurb": "Grab Dora Diginoid for free on itch.io! Dora Diginoid is an indie Metroidvania sci-fi adventure game where you explore the base 17.",
       "ends_at": null,
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "itad-330faa9821bf",
+      "store": "epic",
+      "title": "Guild of Dungeoneering Ultimate Edition",
+      "claim_url": "https://isthereanydeal.com/giveaways/16262/",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/317820/library_600x900_2x.jpg",
+      "genres": [],
+      "blurb": "Guild of Dungeoneering Ultimate Edition",
+      "ends_at": null,
+      "steam_appid": 317820,
+      "review_percent": 77,
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "itad-f0cffe659c19",
@@ -148,7 +322,8 @@
       "ends_at": null,
       "steam_appid": 2800500,
       "review_percent": 82,
-      "source": "itad"
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "itad-6d00ffeb0fdc",
@@ -161,7 +336,8 @@
       "ends_at": null,
       "steam_appid": 3445980,
       "review_percent": 50,
-      "source": "itad"
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "itad-7a69412dd110",
@@ -174,6 +350,74 @@
       "ends_at": null,
       "steam_appid": 2965380,
       "review_percent": 89,
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "itad-0d4598c53ffe",
+      "store": "indiegala",
+      "title": "Mr.Brocco & Co",
+      "claim_url": "https://isthereanydeal.com/giveaways/16196/",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2074560/library_600x900_2x.jpg",
+      "genres": [],
+      "blurb": "Mr.Brocco & Co",
+      "ends_at": null,
+      "steam_appid": 2074560,
+      "review_percent": 83,
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "itad-dd5b5b16e035",
+      "store": "indiegala",
+      "title": "The Brave Little Cloud",
+      "claim_url": "https://isthereanydeal.com/giveaways/16143/",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2635070/library_600x900_2x.jpg",
+      "genres": [],
+      "blurb": "The Brave Little Cloud",
+      "ends_at": null,
+      "steam_appid": 2635070,
+      "review_percent": 97,
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "itad-de23882e1f39",
+      "store": "itch",
+      "title": "Smiley Dusty",
+      "claim_url": "https://isthereanydeal.com/giveaways/15746/",
+      "header_image": null,
+      "genres": [],
+      "blurb": "Smiley Dusty",
+      "ends_at": null,
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "itad-1b0433806065",
+      "store": "indiegala",
+      "title": "Die Young: Prologue",
+      "claim_url": "https://isthereanydeal.com/giveaways/7433/",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/973000/header.jpg?t=1669757014",
+      "genres": [],
+      "blurb": "Die Young: Prologue",
+      "ends_at": null,
+      "steam_appid": 973000,
+      "review_percent": 78,
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "itad-0c69ed1f1bd8",
+      "store": "epic",
+      "title": "Rogue Waters",
+      "claim_url": "https://isthereanydeal.com/giveaways/16240/",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/1691190/library_600x900_2x.jpg",
+      "genres": [],
+      "blurb": "Rogue Waters",
+      "ends_at": null,
+      "steam_appid": 1691190,
+      "review_percent": 76,
       "source": "itad"
     },
     {
@@ -200,69 +444,6 @@
       "ends_at": null,
       "steam_appid": 867210,
       "review_percent": 86,
-      "source": "itad"
-    },
-    {
-      "id": "itad-0c69ed1f1bd8",
-      "store": "epic",
-      "title": "Rogue Waters",
-      "claim_url": "https://isthereanydeal.com/giveaways/16240/",
-      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/1691190/library_600x900_2x.jpg",
-      "genres": [],
-      "blurb": "Rogue Waters",
-      "ends_at": null,
-      "steam_appid": 1691190,
-      "review_percent": 76,
-      "source": "itad"
-    },
-    {
-      "id": "itad-0d4598c53ffe",
-      "store": "indiegala",
-      "title": "Mr.Brocco & Co",
-      "claim_url": "https://isthereanydeal.com/giveaways/16196/",
-      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2074560/library_600x900_2x.jpg",
-      "genres": [],
-      "blurb": "Mr.Brocco & Co",
-      "ends_at": null,
-      "steam_appid": 2074560,
-      "review_percent": 83,
-      "source": "itad"
-    },
-    {
-      "id": "itad-dd5b5b16e035",
-      "store": "indiegala",
-      "title": "The Brave Little Cloud",
-      "claim_url": "https://isthereanydeal.com/giveaways/16143/",
-      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2635070/library_600x900_2x.jpg",
-      "genres": [],
-      "blurb": "The Brave Little Cloud",
-      "ends_at": null,
-      "steam_appid": 2635070,
-      "review_percent": 97,
-      "source": "itad"
-    },
-    {
-      "id": "itad-de23882e1f39",
-      "store": "itch",
-      "title": "Smiley Dusty",
-      "claim_url": "https://isthereanydeal.com/giveaways/15746/",
-      "header_image": null,
-      "genres": [],
-      "blurb": "Smiley Dusty",
-      "ends_at": null,
-      "source": "itad"
-    },
-    {
-      "id": "itad-1b0433806065",
-      "store": "indiegala",
-      "title": "Die Young: Prologue",
-      "claim_url": "https://isthereanydeal.com/giveaways/7433/",
-      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/973000/header.jpg?t=1669757014",
-      "genres": [],
-      "blurb": "Die Young: Prologue",
-      "ends_at": null,
-      "steam_appid": 973000,
-      "review_percent": 78,
       "source": "itad"
     }
   ],

--- a/curated/sponsors.json
+++ b/curated/sponsors.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generated_at": null,
+  "generated_at": "2026-06-11T22:51:53.976Z",
   "ads": {
     "ad-spotlight-hero-emberfall": {
       "kind": "sponsor",
@@ -44,7 +44,6 @@
       "tagline": "Steam, Epic, GOG and more — deduped into one honest list. Free and local-first.",
       "cta": "Start free",
       "url": "https://baklog.app/",
-      "dismissible": true,
       "enabled": true
     },
     "ad-dash-picks-dawnbanner": {

--- a/landing/free-claims.json
+++ b/landing/free-claims.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-10T02:28:16.129220+00:00",
+  "generated_at": "2026-06-11T23:08:29.203734+00:00",
   "items": [
     {
       "id": "itad-9dcfdf2b0b35",
@@ -19,17 +19,169 @@
       "source": "itad"
     },
     {
+      "id": "epic-warhammer-40k-speed-freeks-12879c",
+      "store": "epic",
+      "title": "Warhammer 40K Speed Freeks",
+      "claim_url": "https://store.epicgames.com/en-US/p/warhammer-40k-speed-freeks-12879c",
+      "header_image": "https://cdn1.epicgames.com/spt-assets/a1af14251fb748fc9bda63bfc260f933/warhammer-40k-speed-freeks-1k4pq.jpg",
+      "genres": [],
+      "blurb": null,
+      "ends_at": "2026-06-18T15:00:00Z",
+      "source": "epic",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "gamerpower-3684",
+      "store": "steam",
+      "title": "Eets",
+      "claim_url": "https://www.gamerpower.com/open/eets-steam-giveaway",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/6100/b97e6e9de18d08941c872fc73abae7c2dc91ccfe/header.jpg?t=1781207036",
+      "genres": [
+        "Casual",
+        "Indie",
+        "Strategy"
+      ],
+      "blurb": "Claim Eets for free on Steam until June 15! Eets is a 2D puzzle game, something like Lemmings meets The Incredible Machine.",
+      "ends_at": "2026-06-15T23:59:00Z",
+      "steam_appid": 6100,
+      "review_percent": 59,
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "gamerpower-3682",
+      "store": "steam",
+      "title": "The Red Lantern",
+      "claim_url": "https://www.gamerpower.com/open/the-red-lantern-steam-giveaway",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/1053710/library_600x900_2x.jpg",
+      "genres": [
+        "Adventure",
+        "Casual",
+        "Indie",
+        "RPG"
+      ],
+      "blurb": "This giveaway is for the dog lovers! Grab The Red Lantern for free on Steam until June 18! The Red Lantern is a 3d first person dog sledding game with very positive reviews. Don´t miss it!",
+      "ends_at": "2026-06-18T23:59:00Z",
+      "steam_appid": 1053710,
+      "review_percent": 82,
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "gamerpower-3680",
+      "store": "epic",
+      "title": "The Ouroboros King",
+      "claim_url": "https://www.gamerpower.com/open/the-ouroboros-king-epic-games-giveaway",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2096510/library_600x900_2x.jpg",
+      "genres": [],
+      "blurb": "Checkmate your boredom! Download The Ouroboros King without any cost via Epic Games Store! The Ouroboros King combines chess with the replayability of roguelikes. Check it out!",
+      "ends_at": "2026-06-18T23:59:00Z",
+      "steam_appid": 2096510,
+      "review_percent": 81,
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "gamerpower-3679",
+      "store": "steam",
+      "title": "Happy's Humble Burger Farm",
+      "claim_url": "https://www.gamerpower.com/open/happy-s-humble-burger-farm-steam-giveaway",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/1433340/library_600x900_2x.jpg",
+      "genres": [
+        "Action",
+        "Adventure",
+        "Indie",
+        "Simulation"
+      ],
+      "blurb": "Start grilling patties today with this giveaway! Grab Happy’s Humble Burger Farm for free on Steam until June 15. Happy’s Humble Burger Farm is a first-person sim game about serving customers and maintaining a restaurant. Don´t miss it!",
+      "ends_at": "2026-06-15T23:59:00Z",
+      "steam_appid": 1433340,
+      "review_percent": 92,
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "gamerpower-3678",
+      "store": "itch",
+      "title": "MicroCrawl",
+      "claim_url": "https://www.gamerpower.com/open/microcrawl-itch-io-giveaway",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2250400/library_600x900_2x.jpg",
+      "genres": [],
+      "blurb": "80s Nostalgia! Get MicroCrawl for free on itch.io! MicroCrawl is a small 2D point-and-click adventure game with a first-person perspective that evokes memories of old-school dungeon crawlers from the 80s.",
+      "ends_at": "2026-06-13T23:59:00Z",
+      "steam_appid": 2250400,
+      "review_percent": 91,
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "gamerpower-3677",
+      "store": "itch",
+      "title": "Not A Customer",
+      "claim_url": "https://www.gamerpower.com/open/not-a-customer-itch-io-giveaway",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4747110/f8247728e4974286b897788cecda406069ab2068/header.jpg?t=1781116480",
+      "genres": [],
+      "blurb": "Download Not A Customer for free on itch.io. Not A Customer is a 3d first person grocery store sim game with old school Playstation 1 graphics. Check it out!",
+      "ends_at": "2026-06-14T23:59:00Z",
+      "steam_appid": 4747110,
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "gamerpower-3548",
+      "store": "itch",
+      "title": "Static Voice",
+      "claim_url": "https://www.gamerpower.com/open/static-voice-itch-io-giveaway",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4207170/5b734a735246cf374806d41ec31076c84772566a/header.jpg?t=1776267157",
+      "genres": [],
+      "blurb": "Claim Static Voice for free on Itch.io! Static Voice is a first-person survival game where you play as a resident of an old Soviet apartment block.",
+      "ends_at": "2026-06-19T23:59:00Z",
+      "steam_appid": 4207170,
+      "review_percent": 93,
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "gamerpower-3553",
+      "store": "itch",
+      "title": "Sleep Demon",
+      "claim_url": "https://www.gamerpower.com/open/sleep-demon-itchio-giveaway",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4465030/d04ad74487b126388fee536474bcb258c642239c/header.jpg?t=1773513774",
+      "genres": [],
+      "blurb": "Download Sleep Demon for free on Itch.io until June 14, a indie single player walking simulator game about sleep paralysis.",
+      "ends_at": "2026-06-14T23:59:00Z",
+      "steam_appid": 4465030,
+      "review_percent": 83,
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "gamerpower-3477",
+      "store": "itch",
+      "title": "CALLUS",
+      "claim_url": "https://www.gamerpower.com/open/callus-itch-io-giveaway",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4258330/6bdf7e7240b40e22c54c407ebe860b7397c53fd8/header.jpg?t=1781111625",
+      "genres": [],
+      "blurb": "Want to go for a walk? Grab CALLUS for free on itch.io! Callus is a small indie psychological walking simulator with realistic gameplay.",
+      "ends_at": "2026-06-15T23:59:00Z",
+      "steam_appid": 4258330,
+      "review_percent": 76,
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
       "id": "gamerpower-3676",
       "store": "itch",
       "title": "Dire Echo",
       "claim_url": "https://www.gamerpower.com/open/dire-echo-itchio-giveaway",
-      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/3743180/05c22cf5ef7893b5dd61c756ce94e5d5ebfb3d53/header.jpg?t=1780936347",
+      "header_image": "https://www.gamerpower.com/offers/1b/6a27eafa35794.jpg",
       "genres": [],
       "blurb": "Explore deep space with this giveaway. Get Dire Echo for free on itch.io, a 3d sci-fi first-person exploration game featuring impressive visuals.",
       "ends_at": "2026-06-11T23:59:00Z",
       "steam_appid": 3743180,
       "review_percent": 75,
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-3671",
@@ -40,7 +192,8 @@
       "genres": [],
       "blurb": "Flufftopia is free on itch.io until June 14th 2026. Flufftopia is a small clicker game with a story. Check it out!",
       "ends_at": "2026-06-14T23:59:00Z",
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-2386",
@@ -56,7 +209,8 @@
       "ends_at": "2026-07-01T23:59:59Z",
       "steam_appid": 1180660,
       "review_percent": 82,
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-3665",
@@ -72,7 +226,8 @@
       "ends_at": "2026-06-14T23:59:00Z",
       "steam_appid": 858710,
       "review_percent": 92,
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-3266",
@@ -85,7 +240,8 @@
       "ends_at": null,
       "steam_appid": 2081930,
       "review_percent": 85,
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-3096",
@@ -98,7 +254,8 @@
       "ends_at": "2026-08-01T23:59:59Z",
       "steam_appid": 3102000,
       "review_percent": 76,
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-3446",
@@ -111,7 +268,8 @@
       "ends_at": null,
       "steam_appid": 1546400,
       "review_percent": 94,
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-2204",
@@ -124,7 +282,8 @@
       "ends_at": null,
       "steam_appid": 2299730,
       "review_percent": 86,
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "gamerpower-1604",
@@ -135,7 +294,22 @@
       "genres": [],
       "blurb": "Grab Dora Diginoid for free on itch.io! Dora Diginoid is an indie Metroidvania sci-fi adventure game where you explore the base 17.",
       "ends_at": null,
-      "source": "gamerpower"
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "itad-330faa9821bf",
+      "store": "epic",
+      "title": "Guild of Dungeoneering Ultimate Edition",
+      "claim_url": "https://isthereanydeal.com/giveaways/16262/",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/317820/library_600x900_2x.jpg",
+      "genres": [],
+      "blurb": "Guild of Dungeoneering Ultimate Edition",
+      "ends_at": null,
+      "steam_appid": 317820,
+      "review_percent": 77,
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "itad-f0cffe659c19",
@@ -148,7 +322,8 @@
       "ends_at": null,
       "steam_appid": 2800500,
       "review_percent": 82,
-      "source": "itad"
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "itad-6d00ffeb0fdc",
@@ -161,7 +336,8 @@
       "ends_at": null,
       "steam_appid": 3445980,
       "review_percent": 50,
-      "source": "itad"
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
       "id": "itad-7a69412dd110",
@@ -174,6 +350,74 @@
       "ends_at": null,
       "steam_appid": 2965380,
       "review_percent": 89,
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "itad-0d4598c53ffe",
+      "store": "indiegala",
+      "title": "Mr.Brocco & Co",
+      "claim_url": "https://isthereanydeal.com/giveaways/16196/",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2074560/library_600x900_2x.jpg",
+      "genres": [],
+      "blurb": "Mr.Brocco & Co",
+      "ends_at": null,
+      "steam_appid": 2074560,
+      "review_percent": 83,
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "itad-dd5b5b16e035",
+      "store": "indiegala",
+      "title": "The Brave Little Cloud",
+      "claim_url": "https://isthereanydeal.com/giveaways/16143/",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2635070/library_600x900_2x.jpg",
+      "genres": [],
+      "blurb": "The Brave Little Cloud",
+      "ends_at": null,
+      "steam_appid": 2635070,
+      "review_percent": 97,
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "itad-de23882e1f39",
+      "store": "itch",
+      "title": "Smiley Dusty",
+      "claim_url": "https://isthereanydeal.com/giveaways/15746/",
+      "header_image": null,
+      "genres": [],
+      "blurb": "Smiley Dusty",
+      "ends_at": null,
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "itad-1b0433806065",
+      "store": "indiegala",
+      "title": "Die Young: Prologue",
+      "claim_url": "https://isthereanydeal.com/giveaways/7433/",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/973000/header.jpg?t=1669757014",
+      "genres": [],
+      "blurb": "Die Young: Prologue",
+      "ends_at": null,
+      "steam_appid": 973000,
+      "review_percent": 78,
+      "source": "itad",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "itad-0c69ed1f1bd8",
+      "store": "epic",
+      "title": "Rogue Waters",
+      "claim_url": "https://isthereanydeal.com/giveaways/16240/",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/1691190/library_600x900_2x.jpg",
+      "genres": [],
+      "blurb": "Rogue Waters",
+      "ends_at": null,
+      "steam_appid": 1691190,
+      "review_percent": 76,
       "source": "itad"
     },
     {
@@ -200,69 +444,6 @@
       "ends_at": null,
       "steam_appid": 867210,
       "review_percent": 86,
-      "source": "itad"
-    },
-    {
-      "id": "itad-0c69ed1f1bd8",
-      "store": "epic",
-      "title": "Rogue Waters",
-      "claim_url": "https://isthereanydeal.com/giveaways/16240/",
-      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/1691190/library_600x900_2x.jpg",
-      "genres": [],
-      "blurb": "Rogue Waters",
-      "ends_at": null,
-      "steam_appid": 1691190,
-      "review_percent": 76,
-      "source": "itad"
-    },
-    {
-      "id": "itad-0d4598c53ffe",
-      "store": "indiegala",
-      "title": "Mr.Brocco & Co",
-      "claim_url": "https://isthereanydeal.com/giveaways/16196/",
-      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2074560/library_600x900_2x.jpg",
-      "genres": [],
-      "blurb": "Mr.Brocco & Co",
-      "ends_at": null,
-      "steam_appid": 2074560,
-      "review_percent": 83,
-      "source": "itad"
-    },
-    {
-      "id": "itad-dd5b5b16e035",
-      "store": "indiegala",
-      "title": "The Brave Little Cloud",
-      "claim_url": "https://isthereanydeal.com/giveaways/16143/",
-      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2635070/library_600x900_2x.jpg",
-      "genres": [],
-      "blurb": "The Brave Little Cloud",
-      "ends_at": null,
-      "steam_appid": 2635070,
-      "review_percent": 97,
-      "source": "itad"
-    },
-    {
-      "id": "itad-de23882e1f39",
-      "store": "itch",
-      "title": "Smiley Dusty",
-      "claim_url": "https://isthereanydeal.com/giveaways/15746/",
-      "header_image": null,
-      "genres": [],
-      "blurb": "Smiley Dusty",
-      "ends_at": null,
-      "source": "itad"
-    },
-    {
-      "id": "itad-1b0433806065",
-      "store": "indiegala",
-      "title": "Die Young: Prologue",
-      "claim_url": "https://isthereanydeal.com/giveaways/7433/",
-      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/973000/header.jpg?t=1669757014",
-      "genres": [],
-      "blurb": "Die Young: Prologue",
-      "ends_at": null,
-      "steam_appid": 973000,
-      "review_percent": 78,
       "source": "itad"
     }
   ],


### PR DESCRIPTION
## Summary
- Refresh curated free_claims auto/fallback/approved feeds
- Update landing/free-claims.json and sponsors.json

## Test plan
- [ ] Claims surfaces load without JSON errors

Made with [Cursor](https://cursor.com)