### PR TITLE
test: mock image_url_ok in enrich integration tests

### DIFF
--- a/tests/test_enrich_cross_store_images.py
+++ b/tests/test_enrich_cross_store_images.py
@@ -109,6 +109,7 @@ def test_enriches_armatus_wishlist_row(tmp_path: Path, monkeypatch: pytest.Monke
     )
     monkeypatch.setattr(enrich, "meta_file", lambda: meta_path)
     monkeypatch.setattr(enrich, "steam_search_appid", lambda name: 3660710 if name == "Armatus" else None)
+    monkeypatch.setattr(enrich, "image_url_ok", lambda _url: True)
     monkeypatch.setattr(enrich.time, "sleep", lambda _: None)
     monkeypatch.setattr(sys, "argv", ["enrich_cross_store_images.py"])
 
@@ -168,6 +169,7 @@ def test_itch_non_game_skipped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     )
     monkeypatch.setattr(enrich, "meta_file", lambda: meta_path)
     monkeypatch.setattr(enrich, "steam_search_appid", fake_search)
+    monkeypatch.setattr(enrich, "image_url_ok", lambda _url: True)
     monkeypatch.setattr(enrich.time, "sleep", lambda _: None)
     monkeypatch.setattr(sys, "argv", ["enrich_cross_store_images.py"])
 
@@ -228,6 +230,7 @@ def test_upgrade_lowres_replaces_native_art(tmp_path: Path, monkeypatch: pytest.
     monkeypatch.setattr(enrich, "write_catalog_text", lambda rel, text: xbox_path.write_text(text, encoding="utf-8"))
     monkeypatch.setattr(enrich, "meta_file", lambda: meta_path)
     monkeypatch.setattr(enrich, "steam_search_appid", lambda name: 4242 if name == "Native Capsule Game" else None)
+    monkeypatch.setattr(enrich, "image_url_ok", lambda _url: True)
     monkeypatch.setattr(enrich.time, "sleep", lambda _: None)
     monkeypatch.setattr(sys, "argv", ["enrich_cross_store_images.py", "--upgrade-lowres"])
 


### PR DESCRIPTION
## Summary
PR #40 added image_url_ok HTTP validation; integration tests that call enrich.main() need to mock it.

## Test plan
- [x] pytest tests/test_enrich_cross_store_images.py (14/14)

Made with [Cursor](https://cursor.com)