### PR TITLE
feat: enable Epic Support-A-Creator code BAKLOG

### DIFF
--- a/js/affiliate.js
+++ b/js/affiliate.js
@@ -34,7 +34,7 @@ export const AFFILIATE_CREDENTIALS = {
   //   e.g. 'https://go.adt231.net/c/<AID>/<CID>/<MID>?url={url}'
   gog: '',
   // Epic Games Store (param): your Support-A-Creator creator id.  e.g. 'baklog'
-  epic: '',
+  epic: 'BAKLOG',
   // Humble Store (deeplink): Impact template with {url}.
   //   e.g. 'https://humblebundle.pxf.io/c/<AID>/<CID>/<MID>?u={url}'
   humble: '',

--- a/landing/index.html
+++ b/landing/index.html
@@ -542,7 +542,8 @@
     .foot-col h4 { margin: 0 0 0.65rem; font-size: 0.72rem; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-mute); }
     .foot-col a { display: block; font-size: 0.9rem; line-height: 1.45; font-weight: 600; padding: 0.15rem 0; }
     .foot-bottom { display: flex; flex-wrap: wrap; justify-content: space-between; align-items: center; gap: 0.75rem 1.5rem; margin-top: 2.5rem; padding-top: 1.5rem; border-top: 1px solid var(--border-subtle); font-size: 0.8rem; color: var(--text-mute); }
-    .foot-legal, .foot-trademark { margin: 0; }
+    .foot-legal, .foot-trademark, .foot-affiliate { margin: 0; }
+    .foot-affiliate { flex: 1 1 100%; font-size: 0.75rem; line-height: 1.45; color: var(--text-mute); margin-top: 0.35rem; }
 
     @keyframes rise { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: translateY(0); } }
 
@@ -1110,6 +1111,7 @@
       </div>
       <div class="foot-bottom">
         <p class="foot-legal">Local-first &middot; No telemetry &middot; <a href="https://github.com/Ogrods/BAKLOG" target="_blank" rel="noopener noreferrer">Open source (MIT)</a> &middot; &copy; <span id="year"></span> BAKLOG</p>
+        <p class="foot-affiliate">BAKLOG is an Epic Games Store Support-A-Creator affiliate and an itch.io Partner affiliate. Store links in the app may include our creator codes.</p>
         <p class="foot-trademark">BAKLOG&trade; is a trademark of its owner</p>
       </div>
     </div>

--- a/tests/affiliate.test.js
+++ b/tests/affiliate.test.js
@@ -32,12 +32,13 @@ describe('affiliateUrl', () => {
     restoreCreds(baseline);
   });
 
-  it('ships with every program disabled', () => {
-    for (const value of Object.values(AFFILIATE_CREDENTIALS)) {
-      expect(value).toBe('');
+  it('ships with Epic Support-A-Creator live and other programs disabled', () => {
+    expect(AFFILIATE_CREDENTIALS.epic).toBe('BAKLOG');
+    for (const [key, value] of Object.entries(AFFILIATE_CREDENTIALS)) {
+      if (key !== 'epic') expect(value).toBe('');
     }
-    expect(hasLiveAffiliates()).toBe(false);
-    expect(liveAffiliateShops()).toEqual([]);
+    expect(hasLiveAffiliates()).toBe(true);
+    expect(liveAffiliateShops()).toContain('Epic Games Store');
   });
 
   it('passes through Steam URLs (no program)', () => {
@@ -111,7 +112,8 @@ describe('affiliateUrl', () => {
     AFFILIATE_CREDENTIALS.gog = 'https://track.example.com/no-placeholder';
     const url = 'https://www.gog.com/en/game/bar';
     expect(affiliateUrl(url)).toBe(url);
-    expect(hasLiveAffiliates()).toBe(false);
+    expect(hasLiveAffiliates()).toBe(true);
+    expect(liveAffiliateShops()).not.toContain('GOG');
   });
 
   it('treats whitespace-only credentials as unset', () => {
@@ -119,6 +121,7 @@ describe('affiliateUrl', () => {
     const url = 'https://store.epicgames.com/en-US/p/foo';
     expect(affiliateUrl(url)).toBe(url);
     expect(hasLiveAffiliates()).toBe(false);
+    AFFILIATE_CREDENTIALS.epic = 'BAKLOG';
   });
 
   it('is idempotent for deeplink rules', () => {


### PR DESCRIPTION
Enable epic_creator_id=BAKLOG on Epic store outbound links and add landing footer affiliate disclosure for Epic and itch.io Partner status.

Made with [Cursor](https://cursor.com)