### PR TITLE
fix: sync banner margin and recommended note

### DIFF
--- a/app.css
+++ b/app.css
@@ -3622,6 +3622,13 @@ html[data-theme="ember"] .brand-logo-pills { fill: url(#brandMarkGrad); }
   font-size: 0.85rem;
 }
 .migration-banner.hidden { display: none; }
+#migrationBanner { margin-top: 0.75rem; }
+.migration-banner-recommended {
+  display: block;
+  margin-top: 0.35rem;
+  color: var(--text-mute);
+  font-size: 0.8rem;
+}
 .migration-banner-body {
   display: flex; align-items: center; justify-content: space-between;
   gap: 0.75rem; flex-wrap: wrap;

--- a/js/personal-store.js
+++ b/js/personal-store.js
@@ -429,6 +429,7 @@ export function showMigrationBanner(snap, { escapeHtml, onUploaded }) {
         <strong>Server file is empty.</strong>
         Found ${escapeHtml(summary)} in this browser that isn't on the server yet.
         Upload to <code class="bg-slate-700 px-1 rounded">data/personal.json</code>?
+        <span class="migration-banner-recommended">Recommended: syncing keeps your edits safe across browser refreshes and reinstalls.</span>
       </div>
       <div class="migration-banner-actions">
         <button type="button" id="migrationUpload" class="bg-emerald-700 hover:bg-emerald-600 px-3 py-1.5 rounded text-sm">Upload to server</button>


### PR DESCRIPTION
Add top margin to the localStorage migration banner and note that uploading to the server is recommended.

Made with [Cursor](https://cursor.com)