### PR TITLE
fix: remove cover pick tip

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,7 +242,6 @@
           "Use the A-Z rail on the right edge to jump through a long library.",
           "Long backlog? The alphabet rail on the right jumps you to any letter.",
           "Click a game's cover to browse alternate cover and landscape art.",
-          "Don't love a cover? Click it to pick from other art.",
           "Open Columns to reveal hidden stats like Score and Metacritic.",
           "Missing a column? The Columns button shows Score, Metacritic, and more.",
           "Can't decide? Hit Pick for me for a random game from your backlog.",

--- a/js/tips.js
+++ b/js/tips.js
@@ -82,7 +82,6 @@ export const TIP_GROUPS = [
   ],
   [
     "Click a game's cover to browse alternate cover and landscape art.",
-    "Don't love a cover? Click it to pick from other art.",
   ],
   [
     "Open Columns to reveal hidden stats like Score and Metacritic.",


### PR DESCRIPTION
Remove the boot tip that claims you can pick/save alternate covers; browsing art is still documented.

Made with [Cursor](https://cursor.com)