### PR TITLE
fix: hide hidden gem badge on wishlist

### DIFF
--- a/js/table-ui.js
+++ b/js/table-ui.js
@@ -1218,7 +1218,7 @@ function timeSyncCoverFits(tbody) {
 function tableRowHtml(g, idx, { isWish }) {
   const p = getPersonal(g);
   const lowConf = g.hltb_match_confidence != null && g.hltb_match_confidence < 0.75;
-  const hiddenGem = isHiddenGem(g);
+  const hiddenGem = state.activeView !== "wishlist" && isHiddenGem(g);
   const key = gameKey(g);
   const headerFallback = coverFallbackFor(g);
   const cover = libraryCoverFor(g);


### PR DESCRIPTION
Keep the hidden gem indicator on library and itch rows only.

Made with [Cursor](https://cursor.com)