### PR TITLE
feat: default 2-week claimable expiry

### DIFF
--- a/build_free_claims.py
+++ b/build_free_claims.py
@@ -8,7 +8,7 @@ import json
 import os
 import re
 import time
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import requests
@@ -311,10 +311,16 @@ def _infer_store_from_text(store: str, title: str, blurb: object, claim_url: str
     return store or "other"
 
 
+DEFAULT_EXPIRY_SOURCES = frozenset({"epic", "gamerpower"})
+DEFAULT_EXPIRY_DAYS = 14
+
+
 def _enrich_item(
     raw: dict,
     last_call: list[float],
     cover_lookup: dict[str, str] | None = None,
+    *,
+    now: datetime | None = None,
 ) -> dict:
     claim_url = str(raw.get("claim_url") or "").strip()
     title = (raw.get("title") or "").strip()
@@ -397,7 +403,7 @@ def _enrich_item(
         "header_image": header,
         "genres": genres[:6] if isinstance(genres, list) else [],
         "blurb": _clean_blurb(raw.get("blurb")),
-        "ends_at": _normalize_ends_at(raw.get("ends_at")),
+        "ends_at": _resolve_ends_at(raw, now=now),
     }
     if appid:
         out["steam_appid"] = appid
@@ -837,6 +843,22 @@ def _normalize_ends_at(ends_at: object) -> str | None:
     return parsed.astimezone(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def _resolve_ends_at(raw: dict, *, now: datetime | None = None) -> str | None:
+    """Normalize ends_at or assign a 2-week default for dated giveaway sources."""
+    raw_val = raw.get("ends_at")
+    if raw_val is not None and str(raw_val).strip():
+        return _normalize_ends_at(raw_val)
+    source = (raw.get("source") or "").strip().lower()
+    if source not in DEFAULT_EXPIRY_SOURCES:
+        return None
+    clock = now or datetime.now(UTC)
+    if clock.tzinfo is None:
+        clock = clock.replace(tzinfo=UTC)
+    anchor = _parse_ends_at(raw.get("first_seen")) or clock
+    default_end = anchor + timedelta(days=DEFAULT_EXPIRY_DAYS)
+    return default_end.astimezone(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
 def _is_expired(ends_at: object, now: datetime) -> bool:
     parsed = _parse_ends_at(ends_at)
     if parsed is None:
@@ -860,6 +882,8 @@ def _enrich_item_light(
     cover_lookup: dict[str, str] | None = None,
     live_item: dict | None = None,
     review_lookup: dict[str, int] | None = None,
+    *,
+    now: datetime | None = None,
 ) -> dict:
     """Fast enrich for admin preview — no Steam/network calls."""
     claim_url = str(raw.get("claim_url") or "").strip()
@@ -909,7 +933,7 @@ def _enrich_item_light(
         "header_image": header,
         "genres": genres[:6] if isinstance(genres, list) else [],
         "blurb": _clean_blurb(raw.get("blurb")),
-        "ends_at": _normalize_ends_at(raw.get("ends_at")),
+        "ends_at": _resolve_ends_at(raw, now=now),
     }
     if appid:
         out["steam_appid"] = appid
@@ -982,7 +1006,7 @@ def preview_publish_items(
             continue
         if not raw.get("claim_url") or not raw.get("store"):
             continue
-        if _is_expired(raw.get("ends_at"), now):
+        if _is_expired(_resolve_ends_at(raw, now=now), now):
             continue
         item_id = str(raw.get("id") or "").strip()
         items.append(
@@ -991,6 +1015,7 @@ def preview_publish_items(
                 cover_lookup,
                 live_by_id.get(item_id),
                 review_lookup=review_lookup,
+                now=now,
             )
         )
     # Mirror the build's carry-forward: an approved claim that momentarily falls
@@ -1399,10 +1424,10 @@ def main() -> int:
         if not raw.get("claim_url") or not raw.get("store"):
             stats.warn(f"skipped item missing store/claim_url: {raw!r}")
             continue
-        if _is_expired(raw.get("ends_at"), now):
+        if _is_expired(_resolve_ends_at(raw, now=now), now):
             stats.warn(f"skipped expired item: {raw.get('id')!r}")
             continue
-        items.append(_enrich_item(raw, last_call, cover_lookup))
+        items.append(_enrich_item(raw, last_call, cover_lookup, now=now))
 
     carried = _carry_forward_missing_approved(
         items,

--- a/tests/test_build_free_claims_approved.py
+++ b/tests/test_build_free_claims_approved.py
@@ -149,6 +149,51 @@ def test_enrich_item_normalizes_ends_at() -> None:
     assert out["ends_at"] == "2026-06-11T22:00:00Z"
 
 
+def test_resolve_ends_at_defaults_epic_from_first_seen() -> None:
+    from datetime import UTC, datetime
+
+    now = datetime(2026, 6, 11, 12, 0, 0, tzinfo=UTC)
+    raw = {
+        "source": "epic",
+        "first_seen": "2026-06-01T00:00:00Z",
+    }
+    assert bfc._resolve_ends_at(raw, now=now) == "2026-06-15T00:00:00Z"
+
+
+def test_resolve_ends_at_leaves_itad_without_date() -> None:
+    from datetime import UTC, datetime
+
+    now = datetime(2026, 6, 11, 12, 0, 0, tzinfo=UTC)
+    assert bfc._resolve_ends_at({"source": "itad"}, now=now) is None
+
+
+def test_resolve_ends_at_keeps_existing_longer_date() -> None:
+    raw = {
+        "source": "epic",
+        "ends_at": "2026-08-01T00:00:00Z",
+    }
+    assert bfc._resolve_ends_at(raw) == "2026-08-01T00:00:00Z"
+
+
+def test_enrich_item_defaults_epic_ends_at_without_upstream_date() -> None:
+    from datetime import UTC, datetime
+
+    now = datetime(2026, 6, 11, 12, 0, 0, tzinfo=UTC)
+    out = bfc._enrich_item(
+        {
+            "id": "epic-bar",
+            "store": "epic",
+            "title": "Bar",
+            "claim_url": "https://store.epicgames.com/en-US/p/bar",
+            "source": "epic",
+            "first_seen": "2026-06-01T00:00:00Z",
+        },
+        [0.0],
+        now=now,
+    )
+    assert out["ends_at"] == "2026-06-15T00:00:00Z"
+
+
 def test_build_publishes_only_approved_auto_items(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -207,7 +252,7 @@ def test_build_publishes_only_approved_auto_items(
     monkeypatch.setattr(
         bfc,
         "_enrich_item",
-        lambda raw, last_call, cover_lookup=None: {
+        lambda raw, last_call, cover_lookup=None, **kwargs: {
             "id": raw["id"],
             "store": raw["store"],
             "title": raw["title"],
@@ -272,7 +317,7 @@ def test_build_without_approved_file_publishes_manual_only(
     monkeypatch.setattr(
         bfc,
         "_enrich_item",
-        lambda raw, last_call, cover_lookup=None: {
+        lambda raw, last_call, cover_lookup=None, **kwargs: {
             "id": raw["id"],
             "store": raw["store"],
             "title": raw["title"],
@@ -338,7 +383,7 @@ def test_build_applies_field_overrides(
     monkeypatch.setattr(
         bfc,
         "_enrich_item",
-        lambda raw, last_call, cover_lookup=None: {
+        lambda raw, last_call, cover_lookup=None, **kwargs: {
             "id": raw["id"],
             "store": raw["store"],
             "title": raw["title"],
@@ -405,7 +450,7 @@ def test_field_override_extends_ends_at_before_expiry_prune(
     monkeypatch.setattr(
         bfc,
         "_enrich_item",
-        lambda raw, last_call, cover_lookup=None: {
+        lambda raw, last_call, cover_lookup=None, **kwargs: {
             "id": raw["id"],
             "store": raw["store"],
             "title": raw["title"],
@@ -524,7 +569,7 @@ def test_build_prunes_expired_approved_and_manual_items(
     monkeypatch.setattr(
         bfc,
         "_enrich_item",
-        lambda raw, last_call, cover_lookup=None: {
+        lambda raw, last_call, cover_lookup=None, **kwargs: {
             "id": raw["id"],
             "store": raw["store"],
             "title": raw["title"],
@@ -1139,7 +1184,7 @@ def test_build_publishes_key_matched_row_when_approved_id_flipped(
     monkeypatch.setattr(
         bfc,
         "_enrich_item",
-        lambda raw, last_call, cover_lookup=None: {
+        lambda raw, last_call, cover_lookup=None, **kwargs: {
             "id": raw["id"],
             "store": raw["store"],
             "title": raw["title"],
@@ -1203,7 +1248,7 @@ def test_build_key_matched_row_inherits_store_and_field_overrides(
     monkeypatch.setattr(
         bfc,
         "_enrich_item",
-        lambda raw, last_call, cover_lookup=None: {
+        lambda raw, last_call, cover_lookup=None, **kwargs: {
             "id": raw["id"],
             "store": raw["store"],
             "title": raw["title"],
@@ -1259,7 +1304,7 @@ def test_build_absent_approved_id_without_override_title_stays_id_only(
     monkeypatch.setattr(
         bfc,
         "_enrich_item",
-        lambda raw, last_call, cover_lookup=None: {
+        lambda raw, last_call, cover_lookup=None, **kwargs: {
             "id": raw["id"],
             "store": raw["store"],
             "title": raw["title"],
@@ -1369,7 +1414,7 @@ def test_build_excludes_dismissed_key_matched_duplicate(
     monkeypatch.setattr(
         bfc,
         "_enrich_item",
-        lambda raw, last_call, cover_lookup=None: {
+        lambda raw, last_call, cover_lookup=None, **kwargs: {
             "id": raw["id"],
             "store": raw["store"],
             "title": raw["title"],


### PR DESCRIPTION
Assign first_seen + 14 days when Epic/GamerPower claims lack ends_at; keep ITAD/F2P evergreen claims without expiry.

Made with [Cursor](https://cursor.com)