### PR TITLE
chore: sync closeout free-claims and sponsor feeds

### DIFF
--- a/curated/free_claims.fallback.json
+++ b/curated/free_claims.fallback.json
@@ -1,23 +1,6 @@
 {
-  "generated_at": "2026-06-12T17:28:43.068342+00:00",
+  "generated_at": "2026-06-11T23:08:29.203734+00:00",
   "items": [
-    {
-      "id": "steam-wild-terra-2-new-lands",
-      "store": "steam",
-      "title": "Wild Terra 2: New Lands",
-      "claim_url": "https://store.steampowered.com/app/1134700/Wild_Terra_2_New_Lands/",
-      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/1134700/library_600x900_2x.jpg",
-      "genres": [
-        "Action",
-        "Indie",
-        "Massively Multiplayer",
-        "RPG"
-      ],
-      "blurb": null,
-      "ends_at": "2026-06-15T17:00:00Z",
-      "steam_appid": 1134700,
-      "review_percent": 52
-    },
     {
       "id": "itad-9dcfdf2b0b35",
       "store": "steam",
@@ -52,7 +35,7 @@
       "store": "steam",
       "title": "Eets",
       "claim_url": "https://www.gamerpower.com/open/eets-steam-giveaway",
-      "header_image": "https://www.gamerpower.com/offers/1b/6a2aebf9e069c.jpg",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/6100/b97e6e9de18d08941c872fc73abae7c2dc91ccfe/header.jpg?t=1781207036",
       "genres": [
         "Casual",
         "Indie",
@@ -149,7 +132,7 @@
       "store": "itch",
       "title": "Static Voice",
       "claim_url": "https://www.gamerpower.com/open/static-voice-itch-io-giveaway",
-      "header_image": "https://www.gamerpower.com/offers/1b/69c5a81a64b29.jpg",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4207170/5b734a735246cf374806d41ec31076c84772566a/header.jpg?t=1776267157",
       "genres": [],
       "blurb": "Claim Static Voice for free on Itch.io! Static Voice is a first-person survival game where you play as a resident of an old Soviet apartment block.",
       "ends_at": "2026-06-19T23:59:00Z",
@@ -163,7 +146,7 @@
       "store": "itch",
       "title": "Sleep Demon",
       "claim_url": "https://www.gamerpower.com/open/sleep-demon-itchio-giveaway",
-      "header_image": "https://www.gamerpower.com/offers/1b/69ca788f5d0d4.jpg",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4465030/d04ad74487b126388fee536474bcb258c642239c/header.jpg?t=1773513774",
       "genres": [],
       "blurb": "Download Sleep Demon for free on Itch.io until June 14, a indie single player walking simulator game about sleep paralysis.",
       "ends_at": "2026-06-14T23:59:00Z",
@@ -177,12 +160,26 @@
       "store": "itch",
       "title": "CALLUS",
       "claim_url": "https://www.gamerpower.com/open/callus-itch-io-giveaway",
-      "header_image": "https://www.gamerpower.com/offers/1b/697cea97b5a63.jpg",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4258330/6bdf7e7240b40e22c54c407ebe860b7397c53fd8/header.jpg?t=1781111625",
       "genres": [],
       "blurb": "Want to go for a walk? Grab CALLUS for free on itch.io! Callus is a small indie psychological walking simulator with realistic gameplay.",
       "ends_at": "2026-06-15T23:59:00Z",
       "steam_appid": 4258330,
       "review_percent": 76,
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "gamerpower-3676",
+      "store": "itch",
+      "title": "Dire Echo",
+      "claim_url": "https://www.gamerpower.com/open/dire-echo-itchio-giveaway",
+      "header_image": "https://www.gamerpower.com/offers/1b/6a27eafa35794.jpg",
+      "genres": [],
+      "blurb": "Explore deep space with this giveaway. Get Dire Echo for free on itch.io, a 3d sci-fi first-person exploration game featuring impressive visuals.",
+      "ends_at": "2026-06-11T23:59:00Z",
+      "steam_appid": 3743180,
+      "review_percent": 75,
       "source": "gamerpower",
       "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
@@ -240,7 +237,7 @@
       "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2081930/library_600x900_2x.jpg",
       "genres": [],
       "blurb": "Become the Taco! Finally, a free game made for taco fans! Download Carlos the Taco for free on IndieGala. Carlos the Taco is a 2D platformer set in Mexico where you play as a taco!",
-      "ends_at": "2026-06-25T22:48:59Z",
+      "ends_at": null,
       "steam_appid": 2081930,
       "review_percent": 85,
       "source": "gamerpower",
@@ -268,7 +265,7 @@
       "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/1546400/library_600x900_2x.jpg",
       "genres": [],
       "blurb": "Score GigaBash for free via Stove and claim your place as king among Titans! GigaBash is a multiplayer arena brawler with gigantic film-inspired kaiju and fully destructible environments.",
-      "ends_at": "2026-06-25T22:48:59Z",
+      "ends_at": null,
       "steam_appid": 1546400,
       "review_percent": 94,
       "source": "gamerpower",
@@ -282,7 +279,7 @@
       "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2299730/library_600x900_2x.jpg",
       "genres": [],
       "blurb": "Grab Dual Chroma: Academy Carols for free on itch.io! Dual Chroma: Academy Carols is a slice-of-life Visual Novel. Check it out, If you are a fan of this type of game!",
-      "ends_at": "2026-06-25T22:48:59Z",
+      "ends_at": null,
       "steam_appid": 2299730,
       "review_percent": 86,
       "source": "gamerpower",
@@ -296,7 +293,7 @@
       "header_image": "https://www.gamerpower.com/offers/1b/62dec9fa9312b.jpg",
       "genres": [],
       "blurb": "Grab Dora Diginoid for free on itch.io! Dora Diginoid is an indie Metroidvania sci-fi adventure game where you explore the base 17.",
-      "ends_at": "2026-06-25T22:48:59Z",
+      "ends_at": null,
       "source": "gamerpower",
       "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
@@ -411,6 +408,19 @@
       "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
+      "id": "itad-0c69ed1f1bd8",
+      "store": "epic",
+      "title": "Rogue Waters",
+      "claim_url": "https://isthereanydeal.com/giveaways/16240/",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/1691190/library_600x900_2x.jpg",
+      "genres": [],
+      "blurb": "Rogue Waters",
+      "ends_at": null,
+      "steam_appid": 1691190,
+      "review_percent": 76,
+      "source": "itad"
+    },
+    {
       "id": "itad-b07aac9ebd26",
       "store": "epic",
       "title": "Wytchwood",
@@ -434,19 +444,6 @@
       "ends_at": null,
       "steam_appid": 867210,
       "review_percent": 86,
-      "source": "itad"
-    },
-    {
-      "id": "itad-0c69ed1f1bd8",
-      "store": "epic",
-      "title": "Rogue Waters",
-      "claim_url": "https://isthereanydeal.com/giveaways/16240/",
-      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/1691190/library_600x900_2x.jpg",
-      "genres": [],
-      "blurb": "Rogue Waters",
-      "ends_at": null,
-      "steam_appid": 1691190,
-      "review_percent": 76,
       "source": "itad"
     }
   ],

--- a/curated/sponsors.json
+++ b/curated/sponsors.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generated_at": "2026-06-12T17:41:06.036Z",
+  "generated_at": "2026-06-11T22:51:53.976Z",
   "ads": {
     "ad-spotlight-hero-emberfall": {
       "kind": "sponsor",
@@ -23,7 +23,7 @@
     "ad-picks-ironveil": {
       "kind": "sponsor",
       "title": "Ironveil",
-      "tagline": "On sale now - 80% off",
+      "tagline": "On sale now — 80% off",
       "cta": "Grab it",
       "url": "https://baklog.app/#waitlist",
       "cover": "/assets/ads-sample/cover-ironveil.webp",
@@ -32,7 +32,7 @@
     "ad-table-encore": {
       "kind": "sponsor",
       "title": "Encore",
-      "tagline": "Replay-worthy roguelike - weekend-sized",
+      "tagline": "Replay-worthy roguelike — weekend-sized",
       "cta": "Learn more",
       "url": "https://baklog.app/#waitlist",
       "cover": "/assets/ads-sample/cover-encore.webp",
@@ -41,7 +41,7 @@
     "house-table-every-store": {
       "kind": "house",
       "title": "Every store, one backlog",
-      "tagline": "Steam, Epic, GOG and more - deduped into one honest list. Free and local-first.",
+      "tagline": "Steam, Epic, GOG and more — deduped into one honest list. Free and local-first.",
       "cta": "Start free",
       "url": "https://baklog.app/",
       "enabled": true
@@ -53,7 +53,7 @@
       "cta": "View the deal",
       "url": "https://baklog.app/#waitlist",
       "cover": "/assets/ads-sample/hero-dawnbanner.webp",
-      "enabled": false,
+      "enabled": true,
       "network": "Lantern Forge Studios",
       "genres": [
         "Tactical RPG",
@@ -65,29 +65,6 @@
       "release_year": 2025,
       "discount": 35,
       "price_base": 29.99
-    },
-    "ad-dash-picks-itch-pride": {
-      "kind": "sponsor",
-      "title": "The Power of Pride Bundle 2026",
-      "tagline": "396 indie games, zines, and more from 284 queer creators. Mutual aid bundle - every purchase supports artists directly.",
-      "cta": "Grab the bundle",
-      "url": "https://itch.io/b/3682/the-power-of-pride-bundle-2026-60-edition",
-      "cover": "/assets/ads/itch-pride-bundle.webp",
-      "enabled": true,
-      "network": "itch.io",
-      "discount": 94,
-      "price_base": 1087,
-      "price_sale": 60,
-      "bundle_items": 396,
-      "bundle_creators": 284,
-      "featured_titles": [
-        "Where Winter Crows Go",
-        "Syrup 2: Candy Alchemy RPG",
-        "A TAVERN FOR TEA",
-        "Cuscuta: A Prayer for Endless Winter",
-        "Detective Beebo: Night at the Mansion"
-      ],
-      "ends": "2026-07-06"
     },
     "ad-feature-banner-emberfall": {
       "kind": "sponsor",
@@ -116,7 +93,7 @@
       "cta": "View deal",
       "url": "https://baklog.app/#waitlist",
       "cover": "/assets/ads-sample/hero-dawnbanner.webp",
-      "enabled": false,
+      "enabled": true,
       "steam_review_percent": 94
     },
     "ad-dash-versus-zephyr": {
@@ -173,7 +150,7 @@
     "ad-claimable-apex-velocity": {
       "kind": "sponsor",
       "title": "Apex Velocity",
-      "tagline": "Blistering arcade racer - drift through neon cities",
+      "tagline": "Blistering arcade racer — drift through neon cities",
       "cta": "View deal",
       "url": "https://baklog.app/#waitlist",
       "cover": "/assets/ads-sample/cover-apex-velocity.webp",
@@ -213,18 +190,19 @@
     },
     "house-support-baklog": {
       "kind": "house",
-      "title": "Level up to BAKLOG Pro",
-      "tagline": "Queue every stale store, sync across machines, and drop sponsored cards - $5/mo.",
-      "cta": "Get Pro - $5/mo",
-      "url": "https://buy.polar.sh/polar_cl_1BV0qvxl87f2YEGmZo36HvXdmTf4GHthbIjh92P2yNw",
+      "title": "Back BAKLOG",
+      "tagline": "Local-first, no server to breach. Help fund development.",
+      "cta": "Join the waitlist",
+      "url": "https://baklog.app/#waitlist",
       "cover": "",
+      "dismissible": true,
       "enabled": true
     },
     "house-pro-promo": {
       "kind": "house",
       "title": "Move faster. Cut the noise.",
       "tagline": "Queue every stale store, sync across machines, and drop sponsored deal cards. Nothing you use today moves behind paywall.",
-      "cta": "Get Pro - $5/mo",
+      "cta": "Get Pro — $5/mo",
       "url": "https://buy.polar.sh/polar_cl_1BV0qvxl87f2YEGmZo36HvXdmTf4GHthbIjh92P2yNw",
       "cover": "",
       "enabled": true
@@ -233,17 +211,18 @@
       "kind": "house",
       "title": "You own 600 games. You've played 40.",
       "tagline": "One honest backlog across every store. Private, Steam-ready.",
-      "cta": "Get Pro - $5/mo",
+      "cta": "Get Pro — $5/mo",
       "url": "https://buy.polar.sh/polar_cl_1BV0qvxl87f2YEGmZo36HvXdmTf4GHthbIjh92P2yNw",
       "cover": "",
+      "dismissible": true,
       "enabled": true
     },
     "house-itch-privacy": {
       "kind": "house",
-      "title": "Level up to BAKLOG Pro",
-      "tagline": "Queue every stale store, sync across machines, and drop sponsored cards - $5/mo.",
-      "cta": "Get Pro - $5/mo",
-      "url": "https://buy.polar.sh/polar_cl_1BV0qvxl87f2YEGmZo36HvXdmTf4GHthbIjh92P2yNw",
+      "title": "Every store, one list",
+      "tagline": "There is no BAKLOG server to breach. Your libraries stay on your machine.",
+      "cta": "Learn more",
+      "url": "https://baklog.app/",
       "cover": "",
       "dismissible": true,
       "enabled": true
@@ -252,7 +231,7 @@
       "kind": "house",
       "title": "BAKLOG Pro",
       "slogan": "One honest backlog across every store.",
-      "tagline": "Leveled up with bulk refresh, cloud sync, and no ads - $5/mo.",
+      "tagline": "One honest backlog, leveled up. Bulk refresh, cloud sync, no ads — $5/mo.",
       "cta": "Get Pro",
       "url": "https://buy.polar.sh/polar_cl_1BV0qvxl87f2YEGmZo36HvXdmTf4GHthbIjh92P2yNw",
       "cover": "",
@@ -263,9 +242,9 @@
     "house-spotlight-pro-sync": {
       "kind": "house",
       "title": "Sync every machine",
-      "slogan": "Keep your library and personal data aligned across machines - no manual exports.",
-      "tagline": "Cloud sync for library JSON and personal prefs.",
-      "cta": "Get Pro - $5/mo",
+      "slogan": "Keep your library and personal data aligned across machines — no manual exports.",
+      "tagline": "BAKLOG Pro keeps your library and personal data aligned across machines — no manual exports.",
+      "cta": "Get Pro — $5/mo",
       "url": "https://buy.polar.sh/polar_cl_1BV0qvxl87f2YEGmZo36HvXdmTf4GHthbIjh92P2yNw",
       "cover": "",
       "art_mode": "logo",
@@ -276,8 +255,8 @@
       "kind": "house",
       "title": "Fewer distractions",
       "slogan": "Paid tier drops sponsored deal slots so your deal radar stays yours.",
-      "tagline": "$5/mo - nothing you use today moves behind paywall.",
-      "cta": "Get Pro - $5/mo",
+      "tagline": "BAKLOG Pro drops sponsored slots so your deal radar stays yours. $5/mo.",
+      "cta": "Get Pro — $5/mo",
       "url": "https://buy.polar.sh/polar_cl_1BV0qvxl87f2YEGmZo36HvXdmTf4GHthbIjh92P2yNw",
       "cover": "",
       "art_mode": "logo",
@@ -289,7 +268,7 @@
       "title": "It's just your library",
       "slogan": "It's not a godsend, it's just your library.",
       "tagline": "Every game you already own, deduped across every store into one honest backlog. Local-first.",
-      "cta": "Get Pro - $5/mo",
+      "cta": "Get Pro — $5/mo",
       "url": "https://buy.polar.sh/polar_cl_1BV0qvxl87f2YEGmZo36HvXdmTf4GHthbIjh92P2yNw",
       "cover": "",
       "art_mode": "logo",
@@ -311,12 +290,14 @@
     "dash-coop-couch": [
       "ad-coop-couch-ironveil"
     ],
-    "dash-versus-rated": [],
+    "dash-versus-rated": [
+      "ad-dash-versus-dawnbanner"
+    ],
     "dash-versus-fast": [
       "ad-dash-versus-zephyr"
     ],
     "dash-pick": [
-      "ad-dash-picks-itch-pride"
+      "ad-dash-picks-dawnbanner"
     ],
     "dash-house": [
       "house-pro-promo"

--- a/landing/free-claims.json
+++ b/landing/free-claims.json
@@ -1,23 +1,6 @@
 {
-  "generated_at": "2026-06-12T17:28:43.068342+00:00",
+  "generated_at": "2026-06-11T23:08:29.203734+00:00",
   "items": [
-    {
-      "id": "steam-wild-terra-2-new-lands",
-      "store": "steam",
-      "title": "Wild Terra 2: New Lands",
-      "claim_url": "https://store.steampowered.com/app/1134700/Wild_Terra_2_New_Lands/",
-      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/1134700/library_600x900_2x.jpg",
-      "genres": [
-        "Action",
-        "Indie",
-        "Massively Multiplayer",
-        "RPG"
-      ],
-      "blurb": null,
-      "ends_at": "2026-06-15T17:00:00Z",
-      "steam_appid": 1134700,
-      "review_percent": 52
-    },
     {
       "id": "itad-9dcfdf2b0b35",
       "store": "steam",
@@ -52,7 +35,7 @@
       "store": "steam",
       "title": "Eets",
       "claim_url": "https://www.gamerpower.com/open/eets-steam-giveaway",
-      "header_image": "https://www.gamerpower.com/offers/1b/6a2aebf9e069c.jpg",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/6100/b97e6e9de18d08941c872fc73abae7c2dc91ccfe/header.jpg?t=1781207036",
       "genres": [
         "Casual",
         "Indie",
@@ -149,7 +132,7 @@
       "store": "itch",
       "title": "Static Voice",
       "claim_url": "https://www.gamerpower.com/open/static-voice-itch-io-giveaway",
-      "header_image": "https://www.gamerpower.com/offers/1b/69c5a81a64b29.jpg",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4207170/5b734a735246cf374806d41ec31076c84772566a/header.jpg?t=1776267157",
       "genres": [],
       "blurb": "Claim Static Voice for free on Itch.io! Static Voice is a first-person survival game where you play as a resident of an old Soviet apartment block.",
       "ends_at": "2026-06-19T23:59:00Z",
@@ -163,7 +146,7 @@
       "store": "itch",
       "title": "Sleep Demon",
       "claim_url": "https://www.gamerpower.com/open/sleep-demon-itchio-giveaway",
-      "header_image": "https://www.gamerpower.com/offers/1b/69ca788f5d0d4.jpg",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4465030/d04ad74487b126388fee536474bcb258c642239c/header.jpg?t=1773513774",
       "genres": [],
       "blurb": "Download Sleep Demon for free on Itch.io until June 14, a indie single player walking simulator game about sleep paralysis.",
       "ends_at": "2026-06-14T23:59:00Z",
@@ -177,12 +160,26 @@
       "store": "itch",
       "title": "CALLUS",
       "claim_url": "https://www.gamerpower.com/open/callus-itch-io-giveaway",
-      "header_image": "https://www.gamerpower.com/offers/1b/697cea97b5a63.jpg",
+      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4258330/6bdf7e7240b40e22c54c407ebe860b7397c53fd8/header.jpg?t=1781111625",
       "genres": [],
       "blurb": "Want to go for a walk? Grab CALLUS for free on itch.io! Callus is a small indie psychological walking simulator with realistic gameplay.",
       "ends_at": "2026-06-15T23:59:00Z",
       "steam_appid": 4258330,
       "review_percent": 76,
+      "source": "gamerpower",
+      "first_seen": "2026-06-11T22:48:59.387102+00:00"
+    },
+    {
+      "id": "gamerpower-3676",
+      "store": "itch",
+      "title": "Dire Echo",
+      "claim_url": "https://www.gamerpower.com/open/dire-echo-itchio-giveaway",
+      "header_image": "https://www.gamerpower.com/offers/1b/6a27eafa35794.jpg",
+      "genres": [],
+      "blurb": "Explore deep space with this giveaway. Get Dire Echo for free on itch.io, a 3d sci-fi first-person exploration game featuring impressive visuals.",
+      "ends_at": "2026-06-11T23:59:00Z",
+      "steam_appid": 3743180,
+      "review_percent": 75,
       "source": "gamerpower",
       "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
@@ -240,7 +237,7 @@
       "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2081930/library_600x900_2x.jpg",
       "genres": [],
       "blurb": "Become the Taco! Finally, a free game made for taco fans! Download Carlos the Taco for free on IndieGala. Carlos the Taco is a 2D platformer set in Mexico where you play as a taco!",
-      "ends_at": "2026-06-25T22:48:59Z",
+      "ends_at": null,
       "steam_appid": 2081930,
       "review_percent": 85,
       "source": "gamerpower",
@@ -268,7 +265,7 @@
       "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/1546400/library_600x900_2x.jpg",
       "genres": [],
       "blurb": "Score GigaBash for free via Stove and claim your place as king among Titans! GigaBash is a multiplayer arena brawler with gigantic film-inspired kaiju and fully destructible environments.",
-      "ends_at": "2026-06-25T22:48:59Z",
+      "ends_at": null,
       "steam_appid": 1546400,
       "review_percent": 94,
       "source": "gamerpower",
@@ -282,7 +279,7 @@
       "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/2299730/library_600x900_2x.jpg",
       "genres": [],
       "blurb": "Grab Dual Chroma: Academy Carols for free on itch.io! Dual Chroma: Academy Carols is a slice-of-life Visual Novel. Check it out, If you are a fan of this type of game!",
-      "ends_at": "2026-06-25T22:48:59Z",
+      "ends_at": null,
       "steam_appid": 2299730,
       "review_percent": 86,
       "source": "gamerpower",
@@ -296,7 +293,7 @@
       "header_image": "https://www.gamerpower.com/offers/1b/62dec9fa9312b.jpg",
       "genres": [],
       "blurb": "Grab Dora Diginoid for free on itch.io! Dora Diginoid is an indie Metroidvania sci-fi adventure game where you explore the base 17.",
-      "ends_at": "2026-06-25T22:48:59Z",
+      "ends_at": null,
       "source": "gamerpower",
       "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
@@ -411,6 +408,19 @@
       "first_seen": "2026-06-11T22:48:59.387102+00:00"
     },
     {
+      "id": "itad-0c69ed1f1bd8",
+      "store": "epic",
+      "title": "Rogue Waters",
+      "claim_url": "https://isthereanydeal.com/giveaways/16240/",
+      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/1691190/library_600x900_2x.jpg",
+      "genres": [],
+      "blurb": "Rogue Waters",
+      "ends_at": null,
+      "steam_appid": 1691190,
+      "review_percent": 76,
+      "source": "itad"
+    },
+    {
       "id": "itad-b07aac9ebd26",
       "store": "epic",
       "title": "Wytchwood",
@@ -434,19 +444,6 @@
       "ends_at": null,
       "steam_appid": 867210,
       "review_percent": 86,
-      "source": "itad"
-    },
-    {
-      "id": "itad-0c69ed1f1bd8",
-      "store": "epic",
-      "title": "Rogue Waters",
-      "claim_url": "https://isthereanydeal.com/giveaways/16240/",
-      "header_image": "https://cdn.akamai.steamstatic.com/steam/apps/1691190/library_600x900_2x.jpg",
-      "genres": [],
-      "blurb": "Rogue Waters",
-      "ends_at": null,
-      "steam_appid": 1691190,
-      "review_percent": 76,
       "source": "itad"
     }
   ],


### PR DESCRIPTION
## Summary
Rebased closeout-staging onto main (#52). After cherry-pick, only feed sync remains:
- curated/free_claims.fallback.json
- curated/sponsors.json
- landing/free-claims.json

All other closeout instrumentation purge changes were already absorbed by main or #52.

Supersedes closed #53. Original backed up as backup/chore-closeout-staging-2026-06-12.

Made with [Cursor](https://cursor.com)