### PR TITLE
Require PIN to delete locked profiles, fix drill scroll, add Discord claims

### DIFF
--- a/js/dashboard-drilldown.js
+++ b/js/dashboard-drilldown.js
@@ -5,7 +5,15 @@ import { state } from './state.js';
 import { savePrefs, setCoopFilterMode, syncFilterDomFromState } from './prefs.js';
 import { refreshFilterUI, renderGenreChips, renderStoreChips, switchView } from './filters-ui.js';
 import { invalidateTableCache, setPendingScrollTarget } from './table-ui.js';
+import { applyPicksCollapsedState } from './picks-ui.js';
 import { HLTB_BUCKETS } from './dashboard-shared.js';
+
+/** Collapse picks on category drill so filtered rows stay in view after toolbar scroll. */
+function collapsePicksForDrill() {
+  if (state.prefs.picksCollapsed === true) return;
+  state.prefs.picksCollapsed = true;
+  applyPicksCollapsedState();
+}
 
 export /** Reset every active library filter except cross-store dedup before drilling. */
 function dashResetLibraryFiltersExceptDedup() {
@@ -29,6 +37,7 @@ function dashResetLibraryFiltersExceptDedup() {
 export function dashDrillStore(store) {
   dashResetLibraryFiltersExceptDedup();
   state.prefs.storeFilter = store || "";
+  collapsePicksForDrill();
   savePrefs();
   setPendingScrollTarget({ kind: "toolbar" });
   switchView("library");
@@ -39,6 +48,7 @@ export function dashDrillStatus(status) {
   dashResetLibraryFiltersExceptDedup();
   state.sessionPrefs.statusFilter = status || "";
   syncFilterDomFromState();
+  collapsePicksForDrill();
   savePrefs();
   setPendingScrollTarget({ kind: "toolbar" });
   switchView("library");
@@ -50,6 +60,7 @@ export function dashDrillStoreStatus(store, status) {
   state.prefs.storeFilter = store || "";
   state.sessionPrefs.statusFilter = status || "";
   syncFilterDomFromState();
+  collapsePicksForDrill();
   savePrefs();
   setPendingScrollTarget({ kind: "toolbar" });
   switchView("library");
@@ -57,6 +68,7 @@ export function dashDrillStoreStatus(store, status) {
 }
 
 export function dashFinishDrillToLibrary() {
+  collapsePicksForDrill();
   savePrefs();
   setPendingScrollTarget({ kind: "toolbar" });
   switchView("library");
@@ -89,6 +101,7 @@ export function dashDrillMinRating(minRating) {
 export function dashDrillGenre(genre) {
   dashResetLibraryFiltersExceptDedup();
   state.prefs.genreFilters = [genre];
+  collapsePicksForDrill();
   savePrefs();
   setPendingScrollTarget({ kind: "toolbar" });
   switchView("library");
@@ -98,6 +111,7 @@ export function dashDrillGenre(genre) {
 export function dashDrillItchGenre(genre) {
   dashResetLibraryFiltersExceptDedup();
   state.prefs.genreFilters = [genre];
+  collapsePicksForDrill();
   savePrefs();
   setPendingScrollTarget({ kind: "toolbar" });
   switchView("itch");
@@ -114,6 +128,7 @@ export function dashDrillCoop({ online = false, local = false, any = false } = {
   state.sessionPrefs.statusFilter = "";
   syncFilterDomFromState();
   state.prefs.storeFilter = "";
+  collapsePicksForDrill();
   savePrefs();
   invalidateTableCache();
   setPendingScrollTarget({ kind: "toolbar" });

--- a/js/filters-ui.js
+++ b/js/filters-ui.js
@@ -56,7 +56,7 @@ import {
   prewarmTableQueryForView,
   syncRowCountLabel,
 } from './table-ui.js';
-import { renderPicks } from './picks-ui.js';
+import { renderPicks, updatePicksChrome, renderViewHouseSlot } from './picks-ui.js';
 import { showViewOverlay, hideViewOverlay } from './loading-curtain.js';
 import { ensureChartJs } from './chart-loader.js';
 
@@ -477,12 +477,10 @@ export function updateViewChrome(options) {
   applyItchTabVisibility();
   updateWishlistDrawerVisibility();
   updatePickTabsVisibility();
-  // Quick-Wins slider visibility (only shown on the Quick Wins tab) lives in
-  // picks-ui via updatePicksChrome; import lazily to avoid a top-level cycle.
-  void import('./picks-ui.js').then(m => {
-    m.updatePicksChrome();
-    m.renderViewHouseSlot?.();
-  });
+  // Picks chrome is synchronous here — async renderViewHouseSlot raced category
+  // drill-ins and re-painted the house stripe after toolbar scroll (68px jump).
+  updatePicksChrome();
+  if (isDash || !hideTableUi) renderViewHouseSlot();
   document.getElementById("picksSection")?.classList.toggle("hidden", hideTableUi);
   document.getElementById("toolbarSection")?.classList.toggle("hidden", hideTableUi);
   document.getElementById("tableShell")?.classList.toggle("hidden", hideTableUi);

--- a/js/profiles.js
+++ b/js/profiles.js
@@ -375,6 +375,7 @@ export function friendlyPinError(msg) {
 
 let _pinPromptTarget = null;
 let _pinPromptRelease = null;
+let _pinPromptOnSubmit = null;
 
 function setPinPromptError(msg) {
   const errEl = el('profilePinPromptError');
@@ -388,20 +389,30 @@ function setPinPromptError(msg) {
   }
 }
 
-function openPinPrompt(id) {
+/**
+ * Open the masked PIN dialog. Defaults to switching into `id`; pass
+ * `opts.onSubmit(id, pin)` (and optional note/submitLabel) to reuse the dialog
+ * for other locked actions such as deleting a PIN-protected profile.
+ */
+function openPinPrompt(id, opts = {}) {
   closeMenu();
   _pinPromptTarget = id;
+  _pinPromptOnSubmit = typeof opts.onSubmit === 'function'
+    ? opts.onSubmit
+    : (pid, pin) => switchProfile(pid, pin);
   const modal = el('profilePinModal');
   if (!modal) return;
   const dialog = modal.querySelector('[role="dialog"]') || modal;
   const input = el('profilePinPromptInput');
   const note = el('profilePinPromptNote');
+  const submitBtn = el('profilePinPromptSubmit');
   const profiles = _status?.profiles || [];
   const target = profiles.find((p) => p.id === id);
+  const name = target ? profileDisplayLabel(target, profiles) : id;
   if (note) {
-    const name = target ? profileDisplayLabel(target, profiles) : id;
-    note.textContent = `“${name}” is locked. Enter its PIN to switch in.`;
+    note.textContent = opts.note || `“${name}” is locked. Enter its PIN to switch in.`;
   }
+  if (submitBtn) submitBtn.textContent = opts.submitLabel || 'Switch';
   if (input) input.value = '';
   setPinPromptError('');
   modal.classList.remove('hidden');
@@ -418,12 +429,14 @@ function closePinPrompt() {
   _pinPromptRelease?.();
   _pinPromptRelease = null;
   _pinPromptTarget = null;
+  _pinPromptOnSubmit = null;
   el('profileMenuTrigger')?.focus();
 }
 
 async function submitPinPrompt() {
   const id = _pinPromptTarget;
-  if (!id) return;
+  const onSubmit = _pinPromptOnSubmit;
+  if (!id || !onSubmit) return;
   const pin = (el('profilePinPromptInput')?.value || '').trim();
   if (!pin) {
     setPinPromptError('Enter the PIN for this profile.');
@@ -432,7 +445,8 @@ async function submitPinPrompt() {
   const submitBtn = el('profilePinPromptSubmit');
   if (submitBtn) submitBtn.disabled = true;
   try {
-    await switchProfile(id, pin);
+    await onSubmit(id, pin);
+    closePinPrompt();
   } catch (err) {
     setPinPromptError(friendlyPinError(err.message));
     const input = el('profilePinPromptInput');
@@ -543,6 +557,16 @@ async function renameActiveProfile() {
   }
 }
 
+async function performProfileDelete(id, pin, label) {
+  await api('DELETE', `/api/profiles/${encodeURIComponent(id)}`, pin ? { currentPin: pin } : undefined);
+  resetProfileClientCache(id);
+  await fetchProfilesStatus();
+  populateDeleteSelect();
+  const sel = el('profileDeleteSelect');
+  if (sel) sel.value = '';
+  setManageStatus(`Deleted “${label}”.`);
+}
+
 async function deleteSelectedProfile() {
   const sel = el('profileDeleteSelect');
   const id = sel?.value;
@@ -555,13 +579,18 @@ async function deleteSelectedProfile() {
   if (!confirm(`Delete profile "${label}"? This removes its games and connections under profiles/${id}/. Root backup files are not deleted.`)) {
     return;
   }
+  // A PIN-locked profile requires its PIN to delete, mirroring switch-in.
+  const target = (_status?.profiles || []).find((p) => p.id === id);
+  if (target?.hasPin) {
+    openPinPrompt(id, {
+      note: `“${label}” is locked. Enter its PIN to delete it.`,
+      submitLabel: 'Delete',
+      onSubmit: (pid, pin) => performProfileDelete(pid, pin, label),
+    });
+    return;
+  }
   try {
-    await api('DELETE', `/api/profiles/${encodeURIComponent(id)}`);
-    resetProfileClientCache(id);
-    await fetchProfilesStatus();
-    populateDeleteSelect();
-    if (sel) sel.value = '';
-    setManageStatus(`Deleted “${label}”.`);
+    await performProfileDelete(id, '', label);
   } catch (e) {
     showManageError(e.message);
   }

--- a/js/table-ui.js
+++ b/js/table-ui.js
@@ -683,6 +683,8 @@ export function scheduleScrollAfterChromeSettled() {
   const picks = document.getElementById('picksSection');
   const toolbar = document.getElementById('toolbarSection');
   const summary = document.getElementById('summary');
+  const viewHouse = document.getElementById('viewHouseSlot');
+  const wishRadar = document.getElementById('wishlistDealRadar');
   if (!picks || !toolbar || typeof ResizeObserver !== 'function') {
     const run = () => scheduleScrollAfterLayoutSettled();
     if (typeof requestIdleCallback === 'function') requestIdleCallback(run, { timeout: 800 });
@@ -696,7 +698,23 @@ export function scheduleScrollAfterChromeSettled() {
   _chromeScrollObs.observe(picks);
   _chromeScrollObs.observe(toolbar);
   if (summary) _chromeScrollObs.observe(summary);
+  if (viewHouse) _chromeScrollObs.observe(viewHouse);
+  if (wishRadar) _chromeScrollObs.observe(wishRadar);
   requestAnimationFrame(() => requestAnimationFrame(tryConsume));
+}
+
+const CHROME_BAND_ABOVE_TOOLBAR = ['viewHouseSlot', 'wishlistDealRadar'];
+
+function isChromeBandAboveToolbarSettled(toolbarTop) {
+  for (const id of CHROME_BAND_ABOVE_TOOLBAR) {
+    const el = document.getElementById(id);
+    if (!el || el.classList.contains('hidden')) continue;
+    const hasContent = el.innerHTML.trim().length > 0;
+    if (hasContent && el.offsetHeight < 8) return false;
+    const bottom = el.offsetTop + el.offsetHeight;
+    if (bottom > 0 && toolbarTop > 0 && toolbarTop < bottom - 2) return false;
+  }
+  return true;
 }
 
 function scrollDeferredToRefreshFilterUI() {
@@ -720,6 +738,7 @@ function isToolbarScrollReady() {
   const toolbarTop = toolbar.offsetTop;
   if (picksTop > 0 && toolbarTop > 0) {
     if (toolbarTop < picksTop + picks.offsetHeight - 4) return false;
+    if (!isChromeBandAboveToolbarSettled(toolbarTop)) return false;
     const toolbarRectTop = toolbar.getBoundingClientRect().top;
     if (window.scrollY < 16 && toolbarRectTop < 80) return false;
   }

--- a/server.py
+++ b/server.py
@@ -2891,6 +2891,12 @@ class Handler(SimpleHTTPRequestHandler):
                 return
             server_internal_routes.handle_internal_free_claims_enrich(self)
             return
+        if path == "/api/internal/free-claims/discord":
+            if not ADMIN_ENABLED:
+                self.send_error(HTTPStatus.NOT_FOUND, "Not found")
+                return
+            server_internal_routes.handle_internal_free_claims_discord(self)
+            return
         if path == "/api/internal/free-claims/preview":
             if not ADMIN_ENABLED:
                 self.send_error(HTTPStatus.NOT_FOUND, "Not found")
@@ -3308,38 +3314,32 @@ class Handler(SimpleHTTPRequestHandler):
 
     def _handle_profiles_delete(self, profile_id: str) -> None:
         if _profile_admin_blocked():
-            _send_json(
-                self,
-                HTTPStatus.FORBIDDEN,
-                {"error": "profile management is disabled while account sign-in is enabled"},
-            )
+            _send_json(self, HTTPStatus.FORBIDDEN, {
+                "error": "profile management is disabled while account sign-in is enabled"})
             return
         if MANAGER.has_runs_for_profile(profile_id):
-            _send_json(
-                self,
-                HTTPStatus.CONFLICT,
-                {
-                    "error": (
-                        "This profile has a fetch running or queued. "
-                        "Cancel its runs or let them finish before deleting."
-                    ),
-                },
-            )
+            _send_json(self, HTTPStatus.CONFLICT, {"error": (
+                "This profile has a fetch running or queued. "
+                "Cancel its runs or let them finish before deleting."
+            )})
             return
+        current_pin: str | None = None
+        if int(self.headers.get("Content-Length") or 0) > 0:
+            payload, err = _read_json_body(self)
+            if err:
+                _send_json(self, HTTPStatus.BAD_REQUEST, {"error": err})
+                return
+            current_pin = str((payload or {}).get("currentPin") or (payload or {}).get("pin") or "").strip() or None
         try:
             from shared.profiles import delete_profile
 
-            delete_profile(profile_id)
+            delete_profile(profile_id, current_pin=current_pin)
             _refresh_personal_paths()
             _send_json(self, HTTPStatus.OK, {"ok": True})
         except ValueError as exc:
             _send_json(self, HTTPStatus.BAD_REQUEST, {"error": str(exc)})
         except OSError as exc:
-            _send_json(
-                self,
-                HTTPStatus.INTERNAL_SERVER_ERROR,
-                {"error": f"profile delete failed: {exc}"},
-            )
+            _send_json(self, HTTPStatus.INTERNAL_SERVER_ERROR, {"error": f"profile delete failed: {exc}"})
 
     def _handle_personal_get(self) -> None:
         try:
@@ -4214,8 +4214,8 @@ def main() -> None:
     atexit.register(_remove_pid_file)
     _maybe_import_legacy_env()
     try:
-        from shared.profiles import finalize_default_profile_migration
         from shared.profile_paths import reconcile_profile_store
+        from shared.profiles import finalize_default_profile_migration
 
         finalize_default_profile_migration()
         for note in reconcile_profile_store():

--- a/shared/discord_claims.py
+++ b/shared/discord_claims.py
@@ -1,0 +1,178 @@
+"""Post free-claim announcements to Discord via maintainer-configured webhooks."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime
+from typing import Any
+
+from shared.free_claims_sources import GAMERPOWER_ATTRIBUTION
+from shared.steam_match import strip_giveaway_decorations
+
+CLAIM_LINK = "https://baklog.app"
+
+_WEBHOOK_ENV = (
+    ("BAKLOG_DISCORD_CLAIMS_WEBHOOK_1", "Sacrificial Altar"),
+    ("BAKLOG_DISCORD_CLAIMS_WEBHOOK_2", "BAKLOG Discord"),
+)
+
+_MAX_POST_ATTEMPTS = 4
+_MAX_RETRY_SLEEP_S = 5.0
+_DISCORD_FIELD_VALUE_MAX = 1024
+
+
+def validate_claim_item_for_discord(item: dict[str, Any]) -> str | None:
+    if not isinstance(item, dict):
+        return "item must be an object"
+    for field in ("id", "store", "title"):
+        if not str(item.get(field) or "").strip():
+            return f"item missing {field}"
+    return None
+
+
+def _is_webhook_url(url: str) -> bool:
+    u = str(url or "").strip()
+    return u.startswith("http://") or u.startswith("https://")
+
+
+def load_webhooks() -> list[dict[str, str]]:
+    out: list[dict[str, str]] = []
+    for env_key, name in _WEBHOOK_ENV:
+        url = str(os.environ.get(env_key) or "").strip()
+        if url and _is_webhook_url(url):
+            out.append({"name": name, "url": url})
+    return out
+
+
+def _clamp_field_value(value: str) -> str:
+    return str(value or "")[:_DISCORD_FIELD_VALUE_MAX]
+
+
+def _format_ends_at(value: Any) -> str | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    try:
+        dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return raw
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC).strftime("%b %d, %Y")
+
+
+def _display_title(item: dict[str, Any]) -> str:
+    title = strip_giveaway_decorations(str(item.get("title") or "")).strip()
+    return title or str(item.get("id") or "Free game")
+
+
+def _display_store(item: dict[str, Any]) -> str:
+    store = str(item.get("store") or "").strip().lower()
+    if not store:
+        return "Unknown"
+    return store.replace("_", " ").title()
+
+
+def build_discord_payload(item: dict[str, Any]) -> dict[str, Any]:
+    """Build a Discord webhook JSON body for one claim."""
+    title = _display_title(item)
+    fields: list[dict[str, Any]] = [
+        {
+            "name": "Store",
+            "value": _clamp_field_value(_display_store(item)),
+            "inline": True,
+        },
+    ]
+    ends_label = _format_ends_at(item.get("ends_at"))
+    if ends_label:
+        fields.append(
+            {
+                "name": "Ends",
+                "value": _clamp_field_value(ends_label),
+                "inline": True,
+            }
+        )
+
+    embed: dict[str, Any] = {
+        "title": title[:256],
+        "url": CLAIM_LINK,
+        "fields": fields,
+    }
+    header_image = str(item.get("header_image") or "").strip()
+    if header_image.startswith("http://") or header_image.startswith("https://"):
+        embed["thumbnail"] = {"url": header_image[:2048]}
+
+    payload: dict[str, Any] = {
+        "content": f"Free game on BAKLOG: {CLAIM_LINK}",
+        "embeds": [embed],
+    }
+    if str(item.get("source") or "").strip().lower() == "gamerpower":
+        embed["footer"] = {"text": GAMERPOWER_ATTRIBUTION}
+    return payload
+
+
+def _post_webhook_once(
+    url: str, body: dict[str, Any]
+) -> tuple[int, str, float | None, bool]:
+    data = json.dumps(body, ensure_ascii=False).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "BAKLOG-claims-discord/1.0",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.status, resp.read().decode("utf-8", errors="replace"), None, False
+    except urllib.error.HTTPError as exc:
+        retry_after: float | None = None
+        rate_limit_global = False
+        detail = exc.read().decode("utf-8", errors="replace")
+        if exc.code == 429:
+            try:
+                parsed = json.loads(detail or "{}")
+                retry_after = float(parsed.get("retry_after") or 1.0)
+                rate_limit_global = bool(parsed.get("global"))
+            except (TypeError, ValueError, json.JSONDecodeError):
+                retry_after = 1.0
+        return exc.code, detail, retry_after, rate_limit_global
+    except (urllib.error.URLError, TimeoutError) as exc:
+        return 0, f"network error: {exc}", None, False
+
+
+def post_to_webhook(url: str, body: dict[str, Any]) -> dict[str, Any]:
+    last_error = "unknown error"
+    status = 0
+    for attempt in range(_MAX_POST_ATTEMPTS):
+        status, detail, retry_after, rate_limit_global = _post_webhook_once(url, body)
+        if 200 <= status < 300:
+            return {"ok": True, "status": status}
+        last_error = detail.strip() or f"HTTP {status}"
+        if (
+            status == 429
+            and retry_after is not None
+            and attempt + 1 < _MAX_POST_ATTEMPTS
+            and not rate_limit_global
+            and retry_after <= _MAX_RETRY_SLEEP_S
+        ):
+            time.sleep(min(max(retry_after, 0.5), _MAX_RETRY_SLEEP_S))
+            continue
+        break
+    return {"ok": False, "status": status, "error": last_error[:500]}
+
+
+def post_claim_to_discord(item: dict[str, Any]) -> list[dict[str, Any]]:
+    """Post one claim embed to every configured webhook."""
+    body = build_discord_payload(item)
+    results: list[dict[str, Any]] = []
+    for target in load_webhooks():
+        posted = post_to_webhook(target["url"], body)
+        results.append({"name": target["name"], **posted})
+    return results

--- a/shared/profiles.py
+++ b/shared/profiles.py
@@ -260,7 +260,7 @@ def rename_profile(profile_id: str, label: str) -> dict[str, Any]:
     return {"id": profile_id, "label": label}
 
 
-def delete_profile(profile_id: str) -> None:
+def delete_profile(profile_id: str, current_pin: str | None = None) -> None:
     profile_id = normalize_profile_id(profile_id)
     with mutate_index() as doc:
         profiles = [p for p in doc.get("profiles", []) if isinstance(p, dict)]
@@ -268,6 +268,13 @@ def delete_profile(profile_id: str) -> None:
             raise ValueError("cannot delete the last profile")
         if get_active_profile_id(doc=doc) == profile_id:
             raise ValueError("cannot delete the active profile — switch first")
+        if profile_has_pin(profile_id, doc):
+            limit_err = pin_rate_limit_error(profile_id)
+            if limit_err:
+                raise ValueError(limit_err)
+            if not current_pin or not verify_profile_pin(profile_id, current_pin, doc):
+                record_pin_failure(profile_id)
+                raise ValueError("current PIN is incorrect")
         remaining = [p for p in profiles if p.get("id") != profile_id]
         if len(remaining) == len(profiles):
             raise ValueError(f"unknown profile: {profile_id}")

--- a/shared/server_internal_routes.py
+++ b/shared/server_internal_routes.py
@@ -227,6 +227,65 @@ def handle_internal_free_claims_enrich(handler: SimpleHTTPRequestHandler) -> Non
     )
 
 
+def handle_internal_free_claims_discord(handler: SimpleHTTPRequestHandler) -> None:
+    s = _srv()
+    payload, err = s._read_json_body(handler)
+    if err:
+        s._send_json(handler, HTTPStatus.BAD_REQUEST, {"error": err})
+        return
+    assert payload is not None
+    item = payload.get("item")
+    if not isinstance(item, dict):
+        s._send_json(handler, HTTPStatus.BAD_REQUEST, {"error": "item must be an object"})
+        return
+
+    from shared.discord_claims import (
+        load_webhooks,
+        post_claim_to_discord,
+        validate_claim_item_for_discord,
+    )
+
+    validation_err = validate_claim_item_for_discord(item)
+    if validation_err:
+        s._send_json(handler, HTTPStatus.BAD_REQUEST, {"error": validation_err})
+        return
+
+    webhooks = load_webhooks()
+    if not webhooks:
+        s._send_json(
+            handler,
+            HTTPStatus.SERVICE_UNAVAILABLE,
+            {
+                "error": (
+                    "Discord webhooks not configured. Set "
+                    "BAKLOG_DISCORD_CLAIMS_WEBHOOK_1 and/or "
+                    "BAKLOG_DISCORD_CLAIMS_WEBHOOK_2 before posting."
+                ),
+            },
+        )
+        return
+
+    from build_free_claims import _build_cover_lookup, _enrich_item
+
+    to_post = dict(item)
+    try:
+        cover_lookup = _build_cover_lookup([item])
+        to_post = _enrich_item(dict(item), [0.0], cover_lookup, upgrade_covers=True)
+    except Exception:
+        to_post = dict(item)
+
+    posted = post_claim_to_discord(to_post)
+    if posted and all(not row.get("ok") for row in posted):
+        s._send_json(
+            handler,
+            HTTPStatus.BAD_GATEWAY,
+            {"error": "All Discord webhooks failed", "posted": posted},
+        )
+        return
+
+    s._send_json(handler, HTTPStatus.OK, {"posted": posted, "item_id": to_post.get("id")})
+
+
 def handle_internal_free_claims_preview(handler: SimpleHTTPRequestHandler) -> None:
     s = _srv()
     payload, err = s._read_json_body(handler)

--- a/tests/test_discord_claims.py
+++ b/tests/test_discord_claims.py
@@ -1,0 +1,251 @@
+"""Tests for Discord claim announcements (shared/discord_claims.py)."""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from unittest.mock import patch
+
+import pytest
+
+from shared.discord_claims import (
+    CLAIM_LINK,
+    _post_webhook_once,
+    build_discord_payload,
+    load_webhooks,
+    post_claim_to_discord,
+    post_to_webhook,
+    validate_claim_item_for_discord,
+)
+
+
+def test_validate_claim_item_for_discord_requires_core_fields() -> None:
+    assert validate_claim_item_for_discord({}) == "item missing id"
+    assert validate_claim_item_for_discord({"id": "x"}) == "item missing store"
+    assert validate_claim_item_for_discord({"id": "x", "store": "steam"}) == "item missing title"
+    assert validate_claim_item_for_discord(
+        {"id": "x", "store": "steam", "title": "Portal 2"}
+    ) is None
+
+
+def test_build_discord_payload_shape() -> None:
+    payload = build_discord_payload(
+        {
+            "id": "epic-1",
+            "store": "epic",
+            "title": "Portal 2",
+            "header_image": "https://cdn.example/cover.jpg",
+            "ends_at": "2026-06-18T15:00:00Z",
+            "source": "epic",
+        }
+    )
+    assert CLAIM_LINK in payload["content"]
+    embed = payload["embeds"][0]
+    assert embed["title"] == "Portal 2"
+    assert embed["url"] == CLAIM_LINK
+    assert embed["thumbnail"]["url"] == "https://cdn.example/cover.jpg"
+    field_names = {f["name"] for f in embed["fields"]}
+    assert field_names == {"Store", "Ends"}
+    assert "footer" not in embed
+
+
+def test_build_discord_payload_strips_giveaway_title() -> None:
+    payload = build_discord_payload(
+        {
+            "id": "gp-1",
+            "store": "steam",
+            "title": "Portal 2 (Steam) Giveaway",
+            "source": "gamerpower",
+        }
+    )
+    embed = payload["embeds"][0]
+    assert embed["title"] == "Portal 2"
+    assert embed["footer"]["text"] == "GamerPower.com"
+
+
+def test_build_discord_payload_omits_ends_when_missing() -> None:
+    payload = build_discord_payload(
+        {"id": "x", "store": "steam", "title": "Foo", "ends_at": None}
+    )
+    field_names = [f["name"] for f in payload["embeds"][0]["fields"]]
+    assert field_names == ["Store"]
+
+
+def test_load_webhooks_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BAKLOG_DISCORD_CLAIMS_WEBHOOK_1", "https://discord.example/one")
+    monkeypatch.setenv("BAKLOG_DISCORD_CLAIMS_WEBHOOK_2", "  ")
+    monkeypatch.delenv("BAKLOG_DISCORD_CLAIMS_WEBHOOK_2", raising=False)
+    hooks = load_webhooks()
+    assert hooks == [{"name": "Sacrificial Altar", "url": "https://discord.example/one"}]
+
+
+def test_post_claim_to_discord_posts_to_each_webhook(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BAKLOG_DISCORD_CLAIMS_WEBHOOK_1", "https://discord.example/one")
+    monkeypatch.setenv("BAKLOG_DISCORD_CLAIMS_WEBHOOK_2", "https://discord.example/two")
+    calls: list[str] = []
+
+    def fake_post(url: str, body: dict) -> dict:
+        calls.append(url)
+        return {"ok": True, "status": 204}
+
+    with patch("shared.discord_claims.post_to_webhook", side_effect=fake_post):
+        results = post_claim_to_discord(
+            {"id": "x", "store": "steam", "title": "Foo", "source": "epic"}
+        )
+    assert len(results) == 2
+    assert all(row["ok"] for row in results)
+    assert calls == ["https://discord.example/one", "https://discord.example/two"]
+
+
+def test_post_to_webhook_retries_on_429() -> None:
+    body = build_discord_payload({"id": "x", "store": "steam", "title": "Foo"})
+    rate_body = json.dumps({"retry_after": 0.01}).encode()
+    success_response = type(
+        "Resp",
+        (),
+        {
+            "status": 204,
+            "read": lambda self: b"",
+            "__enter__": lambda self: self,
+            "__exit__": lambda self, *args: None,
+        },
+    )()
+
+    def urlopen_side_effect(req, timeout=30):
+        if not hasattr(urlopen_side_effect, "calls"):
+            urlopen_side_effect.calls = 0
+        urlopen_side_effect.calls += 1
+        if urlopen_side_effect.calls == 1:
+            raise urllib.error.HTTPError(
+                req.full_url,
+                429,
+                "Too Many Requests",
+                hdrs={},
+                fp=io.BytesIO(rate_body),
+            )
+        return success_response
+
+    with patch("shared.discord_claims.time.sleep"), patch(
+        "urllib.request.urlopen", side_effect=urlopen_side_effect
+    ):
+        result = post_to_webhook("https://discord.example/hook", body)
+
+    assert result["ok"] is True
+    assert urlopen_side_effect.calls == 2
+
+
+def test_post_webhook_once_handles_urlerror() -> None:
+    body = build_discord_payload({"id": "x", "store": "steam", "title": "Foo"})
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.URLError("connection refused"),
+    ):
+        status, detail, retry_after, rate_limit_global = _post_webhook_once("https://discord.example/hook", body)
+    assert status == 0
+    assert "network error" in detail
+    assert retry_after is None
+    assert rate_limit_global is False
+
+
+def test_post_webhook_once_handles_timeout() -> None:
+    body = build_discord_payload({"id": "x", "store": "steam", "title": "Foo"})
+    with patch("urllib.request.urlopen", side_effect=TimeoutError("timed out")):
+        status, detail, retry_after, rate_limit_global = _post_webhook_once("https://discord.example/hook", body)
+    assert status == 0
+    assert "network error" in detail
+    assert retry_after is None
+    assert rate_limit_global is False
+
+
+def test_post_to_webhook_returns_failure_on_network_error() -> None:
+    body = build_discord_payload({"id": "x", "store": "steam", "title": "Foo"})
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.URLError("name not resolved"),
+    ):
+        result = post_to_webhook("https://discord.example/hook", body)
+    assert result["ok"] is False
+    assert result["status"] == 0
+    assert "network error" in result["error"]
+
+
+def test_post_claim_to_discord_structured_failure_on_network_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BAKLOG_DISCORD_CLAIMS_WEBHOOK_1", "https://discord.example/one")
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.URLError("connection refused"),
+    ):
+        results = post_claim_to_discord(
+            {"id": "x", "store": "steam", "title": "Foo", "source": "epic"}
+        )
+    assert len(results) == 1
+    assert results[0]["ok"] is False
+    assert results[0]["name"] == "Sacrificial Altar"
+    assert "network error" in results[0]["error"]
+
+
+def test_build_discord_payload_clamps_long_ends_field() -> None:
+    long_ends = "x" * 2000
+    payload = build_discord_payload(
+        {"id": "x", "store": "steam", "title": "Foo", "ends_at": long_ends}
+    )
+    ends_field = next(f for f in payload["embeds"][0]["fields"] if f["name"] == "Ends")
+    assert len(ends_field["value"]) == 1024
+
+
+def test_load_webhooks_skips_non_http_scheme(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BAKLOG_DISCORD_CLAIMS_WEBHOOK_1", "ftp://discord.example/bad")
+    monkeypatch.setenv("BAKLOG_DISCORD_CLAIMS_WEBHOOK_2", "https://discord.example/good")
+    hooks = load_webhooks()
+    assert hooks == [{"name": "BAKLOG Discord", "url": "https://discord.example/good"}]
+
+
+def test_post_to_webhook_stops_on_large_retry_after() -> None:
+    body = build_discord_payload({"id": "x", "store": "steam", "title": "Foo"})
+    rate_body = json.dumps({"retry_after": 60.0, "global": False}).encode()
+    sleeps: list[float] = []
+
+    def urlopen_side_effect(req, timeout=30):
+        raise urllib.error.HTTPError(
+            req.full_url,
+            429,
+            "Too Many Requests",
+            hdrs={},
+            fp=io.BytesIO(rate_body),
+        )
+
+    with patch("shared.discord_claims.time.sleep", side_effect=lambda s: sleeps.append(s)), patch(
+        "urllib.request.urlopen", side_effect=urlopen_side_effect
+    ):
+        result = post_to_webhook("https://discord.example/hook", body)
+
+    assert result["ok"] is False
+    assert result["status"] == 429
+    assert sleeps == []
+
+
+def test_post_to_webhook_stops_on_global_rate_limit() -> None:
+    body = build_discord_payload({"id": "x", "store": "steam", "title": "Foo"})
+    rate_body = json.dumps({"retry_after": 0.5, "global": True}).encode()
+    sleeps: list[float] = []
+
+    def urlopen_side_effect(req, timeout=30):
+        raise urllib.error.HTTPError(
+            req.full_url,
+            429,
+            "Too Many Requests",
+            hdrs={},
+            fp=io.BytesIO(rate_body),
+        )
+
+    with patch("shared.discord_claims.time.sleep", side_effect=lambda s: sleeps.append(s)), patch(
+        "urllib.request.urlopen", side_effect=urlopen_side_effect
+    ):
+        result = post_to_webhook("https://discord.example/hook", body)
+
+    assert result["ok"] is False
+    assert result["status"] == 429
+    assert sleeps == []

--- a/tests/test_profile_integrity.py
+++ b/tests/test_profile_integrity.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import shutil
 from pathlib import Path
 from unittest.mock import patch
@@ -21,6 +20,16 @@ def isolated_profiles(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr(profile_paths, "INDEX_FILE", prof_dir / "index.json")
     monkeypatch.delenv("BAKLOG_PROFILE", raising=False)
     return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _reset_pin_state() -> None:
+    """PIN failure/lockout dicts are module-level; isolate them per test."""
+    profiles._pin_failures.clear()
+    profiles._pin_lock_until.clear()
+    yield
+    profiles._pin_failures.clear()
+    profiles._pin_lock_until.clear()
 
 
 def test_reserved_profile_ids_rejected() -> None:
@@ -154,9 +163,52 @@ def test_delete_profile_clears_pin_lockout(isolated_profiles: Path) -> None:
     doc["active"] = "work"
     profile_paths.save_index(doc)
     profiles.set_profile_pin("play", "1234")
-    profiles.delete_profile("play")
+    profiles.delete_profile("play", current_pin="1234")
     profiles.create_profile("Play")
     assert profiles.pin_rate_limit_error("play") is None
+
+
+def test_delete_locked_profile_requires_pin(isolated_profiles: Path) -> None:
+    profiles.create_profile("Work")
+    profiles.create_profile("Play")
+    doc = profile_paths.load_index()
+    doc["active"] = "work"
+    profile_paths.save_index(doc)
+    profiles.set_profile_pin("play", "1234")
+    with pytest.raises(ValueError, match="current PIN is incorrect"):
+        profiles.delete_profile("play")
+    with pytest.raises(ValueError, match="current PIN is incorrect"):
+        profiles.delete_profile("play", current_pin="0000")
+    # Profile survives the failed attempts.
+    assert "play" in {p["id"] for p in profile_paths.load_index()["profiles"]}
+    profiles.delete_profile("play", current_pin="1234")
+    assert "play" not in {p["id"] for p in profile_paths.load_index()["profiles"]}
+
+
+def test_delete_unlocked_profile_ignores_pin_arg(isolated_profiles: Path) -> None:
+    profiles.create_profile("Work")
+    profiles.create_profile("Play")
+    doc = profile_paths.load_index()
+    doc["active"] = "work"
+    profile_paths.save_index(doc)
+    profiles.delete_profile("play")
+    assert "play" not in {p["id"] for p in profile_paths.load_index()["profiles"]}
+
+
+def test_delete_locked_profile_lockout_blocks(isolated_profiles: Path) -> None:
+    profiles.create_profile("Work")
+    profiles.create_profile("Play")
+    doc = profile_paths.load_index()
+    doc["active"] = "work"
+    profile_paths.save_index(doc)
+    profiles.set_profile_pin("play", "1234")
+    for _ in range(profiles._PIN_MAX_ATTEMPTS):
+        with pytest.raises(ValueError):
+            profiles.delete_profile("play", current_pin="0000")
+    # Now locked out: even the correct PIN is refused with the lockout message.
+    with pytest.raises(ValueError, match="too many PIN attempts"):
+        profiles.delete_profile("play", current_pin="1234")
+    assert "play" in {p["id"] for p in profile_paths.load_index()["profiles"]}
 
 
 def test_delete_profile_blocks_effective_active_via_env(


### PR DESCRIPTION
## Summary
- Require the profile PIN to delete a PIN-locked profile (client dialog + server validation with lockout parity).
- Fix dashboard category drill-ins: collapse picks, sync picks chrome, and wait for view-house/wishlist chrome before toolbar scroll.
- Add `shared/discord_claims.py` and `/api/internal/free-claims/discord` for admin posting enriched free claims to configured webhooks.

## Test plan
- [x] `pytest tests/test_profile_integrity.py tests/test_discord_claims.py`
- [ ] Delete a PIN-locked profile from Manage profiles (PIN prompt, wrong PIN rejected, correct PIN deletes).
- [ ] Dashboard card drill-in scrolls to toolbar without a late house-stripe jump.
- [ ] Admin free-claims Discord post with webhooks configured (optional env).

Made with [Cursor](https://cursor.com)