### PR TITLE
fix: strip exported credential lines during legacy .env migration

### DIFF
--- a/shared/legacy_env.py
+++ b/shared/legacy_env.py
@@ -21,11 +21,18 @@ def remediate_env_imported_archive(root: Path) -> bool:
 
 
 def _split_env_line(line: str) -> str | None:
-    """Return the assignment key for a ``KEY=value`` line, else None (blank/comment)."""
+    """Return the assignment key for a ``KEY=value`` line, else None (blank/comment).
+
+    Honors python-dotenv's ``export KEY=value`` form so an exported credential is
+    matched (and stripped) the same as a bare assignment.
+    """
     stripped = line.strip()
     if not stripped or stripped.startswith("#") or "=" not in stripped:
         return None
-    return stripped.split("=", 1)[0].strip()
+    key = stripped.split("=", 1)[0].strip()
+    if key.startswith("export ") or key.startswith("export\t"):
+        key = key[len("export"):].strip()
+    return key or None
 
 
 def _strip_credential_lines(text: str, cred_keys: set[str]) -> tuple[str, bool]:

--- a/tests/test_env_import.py
+++ b/tests/test_env_import.py
@@ -155,6 +155,31 @@ def test_maybe_import_legacy_env_preserves_non_credential_config(
     assert _read_default_blob("itch")["ITCH_API_KEY"] == "from-dotenv"
 
 
+def test_maybe_import_legacy_env_strips_exported_credential_lines(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """python-dotenv honors `export KEY=value`; the stripper must too."""
+    from shared.legacy_env import maybe_import_legacy_env
+
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "export ITCH_API_KEY=from-dotenv\n"
+        "BAKLOG_ADMIN=1\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ITCH_API_KEY", "from-dotenv")
+
+    count, err = maybe_import_legacy_env(tmp_path)
+
+    assert err is None
+    assert count == 1
+    surviving = env_path.read_text(encoding="utf-8")
+    # Exported credential line removed; non-credential config preserved.
+    assert "ITCH_API_KEY" not in surviving
+    assert "BAKLOG_ADMIN=1" in surviving
+    assert _read_default_blob("itch")["ITCH_API_KEY"] == "from-dotenv"
+
+
 def test_remediates_existing_env_imported_archive(tmp_path: Path):
     from shared.legacy_env import maybe_import_legacy_env, remediate_env_imported_archive
 


### PR DESCRIPTION
## Summary
- The legacy .env migration imports store credentials then strips the plaintext lines. python-dotenv also honors the export KEY=value form, but the stripper only matched bare KEY=value, so an exported credential would be imported yet left behind in plaintext - defeating the security fix for that case.
- _split_env_line now strips an optional export  prefix so exported credentials are matched and removed.

## Test plan
- [x] New regression test 	est_maybe_import_legacy_env_strips_exported_credential_lines`n- [x] pytest tests/test_env_import.py (8/8)
- [x] ruff clean

Made with [Cursor](https://cursor.com)