### PR TITLE
Harden profile isolation and fix admin SSE reconnect spam

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Watch your library appear
 
-From empty to 2,000+ games in about 90 seconds — three steps:
+From empty to 2,000+ games in about 90 seconds — three steps. That timing comes from real tests on an above-average Steam library; extremely large libraries take longer.
 
 1. **Connect** — link your stores once from the **Connections** tab. Credentials stay encrypted on your machine (OS keyring + AES-GCM fallback).
 2. **Auto-fetch on connect** — BAKLOG opens a channel to each store and brings everything you own back to one table. Fetcher chips light up as each library lands, and auto-refresh quietly updates stores older than 24h while the app is open.

--- a/guide/faq.md
+++ b/guide/faq.md
@@ -73,6 +73,10 @@ Stores pad your library with things that aren't games: DLC skins, soundtracks, w
 
 Separately, you can hide any game you don't want to see and restore it later from the **Hidden games** panel. See [Using the dashboard](using-the-dashboard.md#blacklist-vs-hidden-list).
 
+## How long does the first import take?
+
+Marketing copy uses ~90 seconds for 0 to 2,000+ games. That number comes from timing a real import on an above-average Steam library. Smaller libraries finish faster; extremely large ones take longer. Each store fetches independently - the fetcher log shows progress.
+
 ## Do I have to refresh manually?
 
 Not usually. When you connect a store, BAKLOG auto-fetches its library. While the app is open, auto-refresh for stores older than 24h is on by default (Connections). ITAD deal prices refresh on a schedule.

--- a/guide/getting-started.md
+++ b/guide/getting-started.md
@@ -21,7 +21,9 @@ If you received a beta invite:
 3. Launch **BAKLOG** from the Start Menu. A tray icon appears and your browser opens.
 4. Open the **Connections** tab and connect each store you use (Chrome or Edge required).
 
-Portable zip builds work too: unzip to a normal folder, then run `Start BAKLOG.bat` or `BAKLOG Tray.exe`. See `BETA-README.txt` in the bundle.
+Your library data (profiles, games, connections) lives in `%LOCALAPPDATA%\BAKLOG-Data`, separate from the app folder. Uninstalling BAKLOG removes only the app; your data stays until you delete that folder.
+
+Portable zip builds work too: unzip to a normal folder, then run `Start BAKLOG.bat` or `BAKLOG Tray.exe`. Add an empty `portable.txt` beside `BAKLOG.exe` only if you want all data in the unzip folder (thumb drives). See `BETA-README.txt` in the bundle.
 
 ## Install (from source)
 
@@ -60,7 +62,7 @@ Then open **http://localhost:8765** in your browser.
 
 1. Open the **Connections** tab and click **Connect** for each store you use. A headed browser window opens for cookie or OAuth sign-in. Credentials stay encrypted on your machine (OS keyring + AES-GCM fallback). See [Connecting stores](connecting-stores.md) for per-store steps.
 
-2. After connecting, BAKLOG **auto-fetches** each store by default and opens the fetcher log. Fetcher chips in the **Fetcher health** row light up as each library lands.
+2. After connecting, BAKLOG **auto-fetches** each store by default and opens the fetcher log. Fetcher chips in the **Fetcher health** row light up as each library lands. The ~90 second figure you may see in marketing copy was measured on an above-average Steam library (~2,000+ games); extremely large libraries take longer. Watch the fetcher log for progress.
 
 3. Browse the **Dashboard**, **Library**, **Wishlist**, and **itch.io** tabs. See [Using the dashboard](using-the-dashboard.md).
 

--- a/index.html
+++ b/index.html
@@ -30,7 +30,9 @@
         var valid = { dashboard: 1, library: 1, wishlist: 1, itch: 1, connections: 1, pro: 1 };
         if (!valid[view]) view = 'dashboard';
         document.documentElement.setAttribute('data-init-view', view);
-        var theme = localStorage.getItem('baklog-color-theme') || 'default';
+        var pid = localStorage.getItem('baklog-active-profile') || 'default';
+        var themeSuffix = pid && pid !== 'default' ? ':' + pid : '';
+        var theme = localStorage.getItem('baklog-color-theme' + themeSuffix) || 'default';
         var validThemes = { default: 1, dark: 1, 'log-jammin': 1, ember: 1, synthwave: 1, terminal: 1 };
         if (theme === 'timber') theme = 'log-jammin';
         if (!validThemes[theme]) theme = 'default';

--- a/js/api-client.js
+++ b/js/api-client.js
@@ -118,19 +118,20 @@ export async function baklogFetch(url, init = {}) {
   return fetchWithAuthRetry(url, init, method);
 }
 
-/** Mint a single-use SSE ticket (EventSource cannot send Authorization). */
-export async function mintStreamTicket() {
+/** Mint a limited-reuse SSE ticket (EventSource cannot send Authorization). */
+export async function mintStreamTicket(runId = null) {
   if (!isAccountAuthMode()) return null;
-  const res = await baklogFetch('/api/auth/stream-ticket', { method: 'POST' });
+  const body = runId ? JSON.stringify({ run_id: runId }) : undefined;
+  const res = await baklogFetch('/api/auth/stream-ticket', { method: 'POST', body });
   if (!res.ok) return null;
   const data = await res.json().catch(() => ({}));
   return data.ticket || null;
 }
 
 /** Append ?ticket= for authenticated SSE streams. */
-export async function urlWithStreamTicket(url) {
+export async function urlWithStreamTicket(url, { runId = null } = {}) {
   if (!isAccountAuthMode()) return url;
-  const ticket = await mintStreamTicket();
+  const ticket = await mintStreamTicket(runId);
   if (!ticket) {
     throw new Error('Could not mint SSE stream ticket');
   }

--- a/js/cover-gallery.js
+++ b/js/cover-gallery.js
@@ -8,6 +8,7 @@ import {
 } from './game-core.js';
 import { trapFocus } from './focus-trap.js';
 import { visibleListForKeyboard } from './table-ui.js';
+import { galleryModeStorageKey } from './profiles.js';
 
 /** @type {HTMLDialogElement | null} */
 let dialog = null;
@@ -28,7 +29,7 @@ const MAX_VIEW_H_RATIO = 0.85;
 /** @type {'cover' | 'landscape'} */
 function loadGalleryMode() {
   try {
-    const v = localStorage.getItem(GALLERY_MODE_KEY);
+    const v = localStorage.getItem(galleryModeStorageKey());
     return v === 'landscape' ? 'landscape' : 'cover';
   } catch {
     return 'cover';
@@ -40,7 +41,7 @@ let galleryMode = loadGalleryMode();
 
 function persistGalleryMode() {
   try {
-    localStorage.setItem(GALLERY_MODE_KEY, galleryMode);
+    localStorage.setItem(galleryModeStorageKey(), galleryMode);
   } catch { /* ignore quota / private mode */ }
 }
 

--- a/js/covers.js
+++ b/js/covers.js
@@ -5,6 +5,7 @@
 
 import { sanitizeCoverUrl, spotlightCropForAspect } from "./game-core.js";
 import { escapeAttr, isSafeHttpUrl } from "./dom-util.js";
+import { dashFailedCoversStorageKey, landscapeCoversStorageKey } from "./profiles.js";
 
 /** Cover URL safe for HTML src= attributes (escaped + http/https only). */
 export function safeCoverAttrUrl(url) {
@@ -34,7 +35,7 @@ function escHtml(s) {
 const DASH_FAILED_COVERS_KEY = "baklog-dash-failed-covers";
 window.__dashFailedCovers = window.__dashFailedCovers || (() => {
   try {
-    const stored = JSON.parse(localStorage.getItem(DASH_FAILED_COVERS_KEY) || "[]");
+    const stored = JSON.parse(localStorage.getItem(dashFailedCoversStorageKey()) || "[]");
     return new Set(Array.isArray(stored) ? stored : []);
   } catch { return new Set(); }
 })();
@@ -45,7 +46,7 @@ function persistDashFailedCovers() {
     _dashFailedSaveTimer = 0;
     try {
       localStorage.setItem(
-        DASH_FAILED_COVERS_KEY,
+        dashFailedCoversStorageKey(),
         JSON.stringify([...window.__dashFailedCovers].slice(-2000)),
       );
     } catch {}
@@ -97,7 +98,7 @@ window.coverFallback = function (img) {
 };
 const LANDSCAPE_CACHE_KEY = "baklog-landscape-covers";
 window.__landscapeCovers = (() => {
-  try { return new Set(JSON.parse(localStorage.getItem(LANDSCAPE_CACHE_KEY) || "[]")); }
+  try { return new Set(JSON.parse(localStorage.getItem(landscapeCoversStorageKey()) || "[]")); }
   catch { return new Set(); }
 })();
 let _landscapeSaveTimer = 0;
@@ -105,7 +106,7 @@ function persistLandscapeCache() {
   if (_landscapeSaveTimer) return;
   _landscapeSaveTimer = setTimeout(() => {
     _landscapeSaveTimer = 0;
-    try { localStorage.setItem(LANDSCAPE_CACHE_KEY, JSON.stringify([...window.__landscapeCovers].slice(-1500))); } catch {}
+    try { localStorage.setItem(landscapeCoversStorageKey(), JSON.stringify([...window.__landscapeCovers].slice(-1500))); } catch {}
   }, 800);
 }
 window.coverLandscapeAttr = function (url) {

--- a/js/dashboard-insights.js
+++ b/js/dashboard-insights.js
@@ -101,6 +101,7 @@ import { appendCreativeInsights, appendCreativeMarqueeChips } from './creative-m
 import { marqueeTip, insightTip, metricKeyForLabel, metricKeyForInsight } from './metric-tips.js';
 import { noteMarqueeMetricKeys, noteInsightMetricKeys } from './metrics-rendered.js';
 import { familyForInsight, familyForLabel, spreadByFamily } from './stat-families.js';
+import { metricSeedSessionKey } from './profiles.js';
 
 /** Sabermetric marquee/pill appearance weights (session-stable RNG). */
 export const METRIC_WEIGHT = {
@@ -133,8 +134,6 @@ function isInsightMetricEnabled(html) {
   return !disabledMetricSet().has(key);
 }
 
-const METRIC_SEED_KEY = '__baklogMetricSeed';
-
 let _insightTimer = null;
 let _lastInsights = null;
 let _insightFadeTimer = null;
@@ -150,11 +149,11 @@ export function stopInsightRotation() {
 function metricRng() {
   let seed;
   try {
-    const raw = sessionStorage.getItem(METRIC_SEED_KEY);
+    const raw = sessionStorage.getItem(metricSeedSessionKey());
     seed = raw != null ? Number(raw) : NaN;
     if (!Number.isFinite(seed)) {
       seed = (Date.now() ^ (Math.random() * 0xffffffff)) >>> 0;
-      sessionStorage.setItem(METRIC_SEED_KEY, String(seed));
+      sessionStorage.setItem(metricSeedSessionKey(), String(seed));
     }
   } catch {
     seed = (Date.now() ^ (Math.random() * 0xffffffff)) >>> 0;

--- a/js/fetcher-health.js
+++ b/js/fetcher-health.js
@@ -2626,7 +2626,7 @@ export const fetcherRunner = (() => {
     }
     let esUrl;
     try {
-      esUrl = await urlWithStreamTicket(streamUrl(runId));
+      esUrl = await urlWithStreamTicket(streamUrl(runId), { runId });
     } catch (_) {
       scheduleReconnect(runId, key, src, { queuedOnly });
       return;

--- a/js/fetcher-health.js
+++ b/js/fetcher-health.js
@@ -29,6 +29,7 @@ import {
   LS_CLAIMS_LAST_AUTO_RUN,
   LS_RECONNECT_DISMISSED,
   profileScopedStorageKey,
+  statLayoutStorageKey,
 } from './profiles.js';
 import { markClaimsPendingAutoRun } from './claimable.js';
 import { savePrefs } from './prefs.js';
@@ -1179,7 +1180,6 @@ export {
   startFastAgeTick,
 };
 
-const STAT_LAYOUT_KEY = 'baklog-fetcher-stat-layout';
 const STAT_LAYOUTS = ['compact', 'landscape'];
 
 export function toggleLegendTips() {
@@ -1189,7 +1189,7 @@ export function toggleLegendTips() {
 
 function statLayout() {
   try {
-    const v = localStorage.getItem(STAT_LAYOUT_KEY);
+    const v = localStorage.getItem(statLayoutStorageKey());
     return STAT_LAYOUTS.includes(v) ? v : 'compact';
   } catch {
     return 'compact';
@@ -1210,7 +1210,7 @@ function syncStatLayoutToggle() {
 
 export function cycleStatLayout() {
   const next = statLayout() === 'compact' ? 'landscape' : 'compact';
-  try { localStorage.setItem(STAT_LAYOUT_KEY, next); } catch { /* ignore */ }
+  try { localStorage.setItem(statLayoutStorageKey(), next); } catch { /* ignore */ }
   renderDashboardFetcherHealth();
   return next;
 }
@@ -1422,6 +1422,7 @@ export const fetcherRunner = (() => {
     reconnectTimers.clear();
     reconnectAttempts.clear();
     for (const { es } of sourcesByRunId.values()) {
+      es.onerror = null;
       try { es.close(); } catch (_) {}
     }
     sourcesByRunId.clear();
@@ -2619,8 +2620,9 @@ export const fetcherRunner = (() => {
     clearReconnect(runId);
     const prior = sourcesByRunId.get(runId);
     if (prior) {
-      try { prior.es.close(); } catch (_) {}
       sourcesByRunId.delete(runId);
+      prior.es.onerror = null;
+      try { prior.es.close(); } catch (_) {}
     }
     let esUrl;
     try {
@@ -2661,6 +2663,8 @@ export const fetcherRunner = (() => {
     es.addEventListener('line', evt => {
       try {
         const data = JSON.parse(evt.data);
+        if (evt.lastEventId) recordLineSeq(runId, evt.lastEventId);
+        else if (data.seq != null) recordLineSeq(runId, data.seq);
         const text = data.text || '';
         recentLog.push(text);
         if (recentLog.length > 40) recentLog.shift();
@@ -2734,10 +2738,13 @@ export const fetcherRunner = (() => {
 
     es.onerror = async () => {
       if (suppressedRunIds.has(runId) || cancelInFlight) return;
-      if (!sourcesByRunId.has(runId)) return;
-      // Close immediately so the browser cannot auto-reconnect with a consumed ticket.
-      try { es.close(); } catch (_) {}
+      const attached = sourcesByRunId.get(runId);
+      if (!attached || attached.es !== es) return;
+      // Let the browser retry with the same ticket URL (multi-use tickets on the server).
+      if (es.readyState === EventSource.CONNECTING) return;
       sourcesByRunId.delete(runId);
+      es.onerror = null;
+      try { es.close(); } catch (_) {}
       try {
         const snap = await fetchRunsSnapshot();
         if (!snap) throw new Error('no snapshot');

--- a/js/metrics-rendered.js
+++ b/js/metrics-rendered.js
@@ -8,28 +8,12 @@ import { state } from './state.js';
 import { METRIC_KEYS, metricKeyForInsight } from './metric-tips.js';
 import { savePrefs } from './prefs.js';
 import { mergeUntappedBatchSeed } from './metrics-untapped-batch.js';
-
-const RENDERED_BASE = 'baklog-metrics-rendered';
-const ACTIVE_PROFILE_LS = 'baklog-active-profile';
-
-function profileSuffix() {
-  let pid = 'default';
-  try {
-    pid = localStorage.getItem(ACTIVE_PROFILE_LS) || 'default';
-  } catch {
-    pid = 'default';
-  }
-  return pid && pid !== 'default' ? `:${pid}` : '';
-}
-
-function renderedKey() {
-  return `${RENDERED_BASE}${profileSuffix()}`;
-}
+import { metricsRenderedStorageKey } from './profiles.js';
 
 /** @returns {string[]} */
 export function loadRenderedMetricKeys() {
   try {
-    const raw = localStorage.getItem(renderedKey());
+    const raw = localStorage.getItem(metricsRenderedStorageKey());
     const arr = raw ? JSON.parse(raw) : [];
     return Array.isArray(arr) ? arr.filter((k) => typeof k === 'string' && k) : [];
   } catch {
@@ -39,7 +23,7 @@ export function loadRenderedMetricKeys() {
 
 function writeRenderedMetricKeys(keys) {
   try {
-    localStorage.setItem(renderedKey(), JSON.stringify([...new Set(keys.filter(Boolean))]));
+    localStorage.setItem(metricsRenderedStorageKey(), JSON.stringify([...new Set(keys.filter(Boolean))]));
   } catch {
     /* ignore storage failures */
   }

--- a/js/metrics-untapped-batch.js
+++ b/js/metrics-untapped-batch.js
@@ -1,8 +1,7 @@
 // One-time seed: the 2026-06-08 untapped-metadata batch starts in Unused (hidden)
 // until the maintainer moves them to Used. Auto-sync preserves manual hides.
 
-const BATCH_SEEDED_BASE = 'baklog-metrics-untapped-batch-seeded';
-const ACTIVE_PROFILE_LS = 'baklog-active-profile';
+import { untappedBatchMarkerStorageKey } from './profiles.js';
 
 /** @type {readonly string[]} */
 export const UNTAPPED_BATCH_METRIC_KEYS = Object.freeze([
@@ -29,21 +28,9 @@ export const UNTAPPED_BATCH_METRIC_KEYS = Object.freeze([
   'upcoming wishlist',
 ]);
 
-function profileSuffix(profileId) {
-  let pid = profileId;
-  if (pid == null) {
-    try {
-      pid = localStorage.getItem(ACTIVE_PROFILE_LS) || 'default';
-    } catch {
-      pid = 'default';
-    }
-  }
-  return pid && pid !== 'default' ? `:${pid}` : '';
-}
-
 /** @param {string} [profileId] */
 export function untappedBatchMarkerKey(profileId) {
-  return `${BATCH_SEEDED_BASE}${profileSuffix(profileId)}`;
+  return untappedBatchMarkerStorageKey(profileId);
 }
 
 /**

--- a/js/personal-storage.js
+++ b/js/personal-storage.js
@@ -151,15 +151,26 @@ function safeLocalSet(key, value) {
   }
 }
 
+export function cancelPendingPersonalSave() {
+  if (_savePersonalTimer) {
+    clearTimeout(_savePersonalTimer);
+    _savePersonalTimer = null;
+  }
+}
+
 export function savePersonal() {
+  if (personalStore.isProfileSwitchSaveBlocked?.()) return;
   clearTimeout(_savePersonalTimer);
   _savePersonalTimer = setTimeout(() => {
+    _savePersonalTimer = null;
+    if (personalStore.isProfileSwitchSaveBlocked?.()) return;
     safeLocalSet(personalStorageKey(), JSON.stringify(state.personal));
     personalStore.notify();
   }, 250);
 }
 
 export function flushSavePersonal() {
+  if (personalStore.isProfileSwitchSaveBlocked?.()) return;
   if (!_savePersonalTimer) return;
   clearTimeout(_savePersonalTimer);
   _savePersonalTimer = null;

--- a/js/personal-store.js
+++ b/js/personal-store.js
@@ -157,7 +157,7 @@ export const personalStore = (() => {
   // rule, so the cleared claim reappears on the next reload. Union both sides
   // instead, keeping the newer numeric timestamp when a key exists on both
   // (non-numeric legacy values are preserved if that's all we have).
-  const DISMISSAL_MAP_KEYS = new Set(['__dismissedClaims', '__dismissedClaimKeys']);
+  const DISMISSAL_MAP_KEYS = new Set(['__dismissedClaims', '__dismissedClaimKeys', '__purgedClaimKeys']);
 
   function _mergeDismissalMaps(baseMap, incomingMap) {
     const base = baseMap && typeof baseMap === 'object' && !Array.isArray(baseMap) ? baseMap : {};
@@ -216,15 +216,10 @@ export const personalStore = (() => {
   }
 
   function _loadLegacyUnscopedPersonal() {
-    if (personalStorageKey() === STORAGE_KEY) return null;
-    try {
-      const raw = localStorage.getItem(STORAGE_KEY);
-      if (!raw) return null;
-      const parsed = JSON.parse(raw);
-      return parsed && typeof parsed === 'object' ? parsed : null;
-    } catch {
-      return null;
-    }
+    // Pre-multi-profile, personal lived at unscoped STORAGE_KEY (default's cache).
+    // Default still reads/writes that key via personalStorageKey(); never merge it
+    // into other profiles — that leaked default dismissals/personal into promo/test.
+    return null;
   }
 
   function applyServerDoc(doc) {

--- a/js/personal-store.js
+++ b/js/personal-store.js
@@ -27,7 +27,12 @@ export const personalStore = (() => {
   let dirty = false;
   let initComplete = false;
   let pendingMigration = null;
+  let profileSwitchSaveBlock = false;
   const PUSH_DEBOUNCE_MS = 600;
+
+  function isProfileSwitchSaveBlocked() {
+    return profileSwitchSaveBlock;
+  }
 
   function snapshotLocal() {
     const snap = {
@@ -251,6 +256,7 @@ export const personalStore = (() => {
   }
 
   async function init() {
+    profileSwitchSaveBlock = false;
     const localSnapBeforeProbe = snapshotLocal();
     const available = await probe();
     if (!available) return { migrated: false, pendingMigration: null };
@@ -309,6 +315,7 @@ export const personalStore = (() => {
   }
 
   function notify() {
+    if (profileSwitchSaveBlock) return;
     if (apiAvailable !== true) return;
     if (!initComplete) {
       dirty = true;
@@ -368,6 +375,7 @@ export const personalStore = (() => {
   }
 
   function flushSync() {
+    if (profileSwitchSaveBlock) return;
     if (apiAvailable !== true) return;
     if (!initComplete) return;
     if (!dirty && !pushTimer) return;
@@ -403,6 +411,11 @@ export const personalStore = (() => {
     }
     dirty = false;
     initComplete = false;
+    profileSwitchSaveBlock = true;
+    try {
+      const { cancelPendingPersonalSave } = await import('./personal-storage.js');
+      cancelPendingPersonalSave();
+    } catch (_) { /* ignore */ }
   }
 
   return {
@@ -413,6 +426,7 @@ export const personalStore = (() => {
     prepareForProfileSwitch,
     uploadLocalToServer,
     dismissMigration,
+    isProfileSwitchSaveBlocked,
   };
 })();
 

--- a/js/pro-view.js
+++ b/js/pro-view.js
@@ -19,6 +19,7 @@ import { PRO_PROMO } from './sponsored-deals.js';
 import { switchView } from './filters-ui.js';
 import { state } from './state.js';
 import { saveActiveView } from './prefs.js';
+import { proWelcomeSessionKey } from './profiles.js';
 
 export const PRO_WELCOME_STORAGE_KEY = 'baklog-pro-welcome';
 
@@ -42,7 +43,7 @@ function clearActivationPending() {
 
 function completeProActivation({ message = 'Pro is active - reloading…', reloadMs = 500 } = {}) {
   try {
-    sessionStorage.setItem(PRO_WELCOME_STORAGE_KEY, '1');
+    sessionStorage.setItem(proWelcomeSessionKey(), '1');
   } catch (_) { /* private mode */ }
   clearActivationPending();
   setProStatus(message, true);
@@ -276,13 +277,13 @@ export function goToProView() {
 export function showProWelcomeBanner() {
   let flagged = false;
   try {
-    flagged = sessionStorage.getItem(PRO_WELCOME_STORAGE_KEY) === '1';
+    flagged = sessionStorage.getItem(proWelcomeSessionKey()) === '1';
   } catch (_) { /* private mode */ }
   if (!flagged || !isPro()) return;
   const host = document.getElementById('proWelcomeBanner');
   if (!host) return;
   try {
-    sessionStorage.removeItem(PRO_WELCOME_STORAGE_KEY);
+    sessionStorage.removeItem(proWelcomeSessionKey());
   } catch (_) { /* private mode */ }
   host.innerHTML = `<div class="migration-banner-body">
       <div>

--- a/js/profiles.js
+++ b/js/profiles.js
@@ -11,7 +11,14 @@ import {
   getAccountProfileId,
   signOutAccount,
 } from './auth-gate.js';
-import { KNOWN_LIBRARY_KEYS_KEY, LIBRARY_FIRST_SEEN_KEY, MANUAL_KEY, PREFS_KEY, STORAGE_KEY } from './state.js';
+import {
+  COLOR_THEME_KEY,
+  KNOWN_LIBRARY_KEYS_KEY,
+  LIBRARY_FIRST_SEEN_KEY,
+  MANUAL_KEY,
+  PREFS_KEY,
+  STORAGE_KEY,
+} from './state.js';
 import { bindEscapeClose, trapFocus } from './focus-trap.js';
 import { escapeAttr } from './dom-util.js';
 import {
@@ -38,8 +45,17 @@ export const LS_FETCHER_SUPPRESSED_RUNS = 'fetcher-suppressed-run-ids';
 export const LS_FETCHER_LAST_SEQ = 'fetcher-last-seq-by-run';
 export const LS_LIBRARY_WATCH = 'baklog-library-watch';
 export const LS_SPOTLIGHT_RECENT_KEYS = 'baklog-spotlight-recent';
+export const LS_AD_CURSORS = 'baklog-ad-cursors';
+export const LS_STAT_LAYOUT = 'baklog-fetcher-stat-layout';
+export const LS_GALLERY_MODE = 'baklog.coverGalleryMode';
+export const LS_DASH_FAILED_COVERS = 'baklog-dash-failed-covers';
+export const LS_LANDSCAPE_COVERS = 'baklog-landscape-covers';
+export const LS_METRICS_RENDERED = 'baklog-metrics-rendered';
+export const LS_UNTAPPED_BATCH = 'baklog-metrics-untapped-batch-seeded';
 /** Session-only; profile-suffixed like prefs. */
 export const LS_ACTIVE_VIEW_SESSION = `${PREFS_KEY}:activeView`;
+export const LS_METRIC_SEED = '__baklogMetricSeed';
+export const LS_PRO_WELCOME = 'baklog-pro-welcome';
 
 export const PROFILE_SCOPED_STORAGE_KEYS = Object.freeze([
   PREFS_KEY,
@@ -56,6 +72,14 @@ export const PROFILE_SCOPED_STORAGE_KEYS = Object.freeze([
   LS_CLAIMS_LAST_AUTO_RUN,
   LS_AUTO_STALE_LAST_RUN,
   LS_LIBRARY_WATCH,
+  LS_AD_CURSORS,
+  COLOR_THEME_KEY,
+  LS_STAT_LAYOUT,
+  LS_GALLERY_MODE,
+  LS_DASH_FAILED_COVERS,
+  LS_LANDSCAPE_COVERS,
+  LS_METRICS_RENDERED,
+  LS_UNTAPPED_BATCH,
 ]);
 
 /** Profile-suffixed sessionStorage keys (fetcher SSE resume state + active tab). */
@@ -63,6 +87,8 @@ export const PROFILE_SCOPED_SESSION_KEYS = Object.freeze([
   LS_ACTIVE_VIEW_SESSION,
   LS_FETCHER_SUPPRESSED_RUNS,
   LS_FETCHER_LAST_SEQ,
+  LS_METRIC_SEED,
+  LS_PRO_WELCOME,
 ]);
 
 let _status = null;
@@ -149,6 +175,42 @@ export function itadSnapshotStorageKey() {
 
 export function claimsSnapshotStorageKey() {
   return `${CLAIMS_SNAPSHOT_PREFIX}${profileKeySuffix()}`;
+}
+
+export function colorThemeStorageKey(id) {
+  return `${COLOR_THEME_KEY}${profileKeySuffix(id)}`;
+}
+
+export function statLayoutStorageKey(id) {
+  return `${LS_STAT_LAYOUT}${profileKeySuffix(id)}`;
+}
+
+export function galleryModeStorageKey(id) {
+  return `${LS_GALLERY_MODE}${profileKeySuffix(id)}`;
+}
+
+export function dashFailedCoversStorageKey(id) {
+  return `${LS_DASH_FAILED_COVERS}${profileKeySuffix(id)}`;
+}
+
+export function landscapeCoversStorageKey(id) {
+  return `${LS_LANDSCAPE_COVERS}${profileKeySuffix(id)}`;
+}
+
+export function metricsRenderedStorageKey(id) {
+  return `${LS_METRICS_RENDERED}${profileKeySuffix(id)}`;
+}
+
+export function untappedBatchMarkerStorageKey(id) {
+  return `${LS_UNTAPPED_BATCH}${profileKeySuffix(id)}`;
+}
+
+export function metricSeedSessionKey(id) {
+  return `${LS_METRIC_SEED}${profileKeySuffix(id)}`;
+}
+
+export function proWelcomeSessionKey(id) {
+  return `${LS_PRO_WELCOME}${profileKeySuffix(id)}`;
 }
 
 /** Prefix a localStorage base key with the active profile suffix. */

--- a/js/sponsored-deals.js
+++ b/js/sponsored-deals.js
@@ -48,6 +48,7 @@ import { isPro } from './auth-gate.js';
 import { noteSponsoredImpression } from './anon-metrics.js';
 import { PRO_CHECKOUT_MONTHLY } from './pro-checkout.js';
 import { affiliateUrl } from './affiliate.js';
+import { LS_AD_CURSORS, profileScopedStorageKey } from './profiles.js';
 
 const SPONSORS_LOCAL_PATH = 'sponsors.json';
 const SPONSORS_FALLBACK_PATH = 'curated/sponsors.json';
@@ -106,7 +107,9 @@ const AD_LOCATION_SET = new Set(AD_LOCATIONS);
 /** @deprecated use AD_LOCATIONS — kept for tests migrating off placement strings */
 export const SPONSOR_PLACEMENTS = AD_LOCATIONS;
 
-const CURSOR_STORAGE_KEY = 'baklog-ad-cursors';
+function adCursorStorageKey() {
+  return profileScopedStorageKey(LS_AD_CURSORS);
+}
 /** @type {Map<string, { start: number, eligibleLen: number }>} */
 const sessionLocationPicks = new Map();
 
@@ -142,12 +145,12 @@ function isDismissed(id) {
 export function __resetDismissedSponsorsForTest() {
   dismissedThisSession.clear();
   sessionLocationPicks.clear();
-  try { localStorage.removeItem(CURSOR_STORAGE_KEY); } catch (_) { /* noop */ }
+  try { localStorage.removeItem(adCursorStorageKey()); } catch (_) { /* noop */ }
 }
 
 export function __resetLocationCursorsForTest() {
   sessionLocationPicks.clear();
-  try { localStorage.removeItem(CURSOR_STORAGE_KEY); } catch (_) { /* noop */ }
+  try { localStorage.removeItem(adCursorStorageKey()); } catch (_) { /* noop */ }
 }
 
 /** Test helper: apply v1 items[] or v2 doc into state. */
@@ -163,7 +166,7 @@ export function __migrateV1ForTest(doc) {
 
 function readCursors() {
   try {
-    const raw = localStorage.getItem(CURSOR_STORAGE_KEY);
+    const raw = localStorage.getItem(adCursorStorageKey());
     return raw ? JSON.parse(raw) : {};
   } catch (_) {
     return {};
@@ -172,7 +175,7 @@ function readCursors() {
 
 function writeCursors(cursors) {
   try {
-    localStorage.setItem(CURSOR_STORAGE_KEY, JSON.stringify(cursors));
+    localStorage.setItem(adCursorStorageKey(), JSON.stringify(cursors));
   } catch (_) { /* noop */ }
 }
 

--- a/js/state.js
+++ b/js/state.js
@@ -3,6 +3,7 @@ export const PREFS_KEY = 'steam-backlog-ui-prefs';
 export const MANUAL_KEY = 'steam-backlog-manual-games';
 export const LIBRARY_FIRST_SEEN_KEY = 'steam-backlog-library-first-seen';
 export const KNOWN_LIBRARY_KEYS_KEY = 'baklog-known-library-keys';
+export const COLOR_THEME_KEY = 'baklog-color-theme';
 
 export const state = {
   allGames: [],

--- a/js/theme.js
+++ b/js/theme.js
@@ -3,7 +3,12 @@
  * Boot IIFE in index.html mirrors KEY for FOUC-free first paint.
  */
 
-export const COLOR_THEME_KEY = 'baklog-color-theme';
+import { COLOR_THEME_KEY } from './state.js';
+import { BAKLOG_THEME_CHANGE } from './custom-events.js';
+
+export { COLOR_THEME_KEY };
+
+export const THEME_CHANGE_EVENT = BAKLOG_THEME_CHANGE;
 
 export const THEMES = ['default', 'dark', 'log-jammin', 'ember', 'synthwave', 'terminal'];
 
@@ -36,24 +41,30 @@ function resolveThemeId(stored) {
   return alias && THEMES.includes(alias) ? alias : 'default';
 }
 
+function themeStorageKey() {
+  try {
+    const pid = localStorage.getItem('baklog-active-profile') || 'default';
+    const suffix = pid && pid !== 'default' ? `:${pid}` : '';
+    return `${COLOR_THEME_KEY}${suffix}`;
+  } catch {
+    return COLOR_THEME_KEY;
+  }
+}
+
 export function getColorTheme() {
   try {
-    const v = localStorage.getItem(COLOR_THEME_KEY);
+    const v = localStorage.getItem(themeStorageKey());
     return resolveThemeId(v);
   } catch {
     return 'default';
   }
 }
 
-import { BAKLOG_THEME_CHANGE } from './custom-events.js';
-
-export const THEME_CHANGE_EVENT = BAKLOG_THEME_CHANGE;
-
 export function setColorTheme(theme) {
   const t = resolveThemeId(theme);
   const prev = document.documentElement.getAttribute('data-theme');
   try {
-    localStorage.setItem(COLOR_THEME_KEY, t);
+    localStorage.setItem(themeStorageKey(), t);
   } catch {
     /* ignore */
   }

--- a/scripts/audit_profile_isolation.py
+++ b/scripts/audit_profile_isolation.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Backward-compatible entry point — see scripts/audit_security.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from audit_security import main  # noqa: E402
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_security.py
+++ b/scripts/audit_security.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Unified local security audit: profile isolation + client storage registry.
+
+Usage:
+  .\\.venv\\Scripts\\python.exe scripts\\audit_security.py
+  .\\.venv\\Scripts\\python.exe scripts\\audit_security.py --fail-on high
+  .\\.venv\\Scripts\\python.exe scripts\\audit_security.py --ignore-disk-bleed
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+PROFILES_DIR = ROOT / "profiles"
+JS_DIR = ROOT / "js"
+
+GLOBAL_LS_ALLOWLIST = frozenset({
+    "baklog-active-profile",
+    "baklog-debug",
+    "baklog-debug-pro",
+    "baklog-perf",
+    "baklog-error-log",
+    "steam-backlog-personal",
+    "baklog-admin.knownAutoIds",
+})
+
+GLOBAL_SS_ALLOWLIST = frozenset({
+    "baklog-stale-chunk-reload",
+})
+
+EXPECTED_SCOPED_LS_BASES = frozenset({
+    "steam-backlog-ui-prefs",
+    "baklog-itad-snapshot",
+    "baklog-claims-snapshot",
+    "steam-backlog-personal",
+    "steam-backlog-manual-games",
+    "steam-backlog-library-first-seen",
+    "baklog-known-library-keys",
+    "baklog-spotlight-recent",
+    "baklog-fetcher-auth-cooldown",
+    "baklog-reconnect-dismissed",
+    "baklog-itad-last-auto-run",
+    "baklog-claims-last-auto-run",
+    "baklog-auto-stale-last-run",
+    "baklog-library-watch",
+    "baklog-ad-cursors",
+    "baklog-color-theme",
+    "baklog-fetcher-stat-layout",
+    "baklog.coverGalleryMode",
+    "baklog-dash-failed-covers",
+    "baklog-landscape-covers",
+    "baklog-metrics-rendered",
+    "baklog-metrics-untapped-batch-seeded",
+})
+
+EXPECTED_SCOPED_SS_BASES = frozenset({
+    "fetcher-suppressed-run-ids",
+    "fetcher-last-seq-by-run",
+    "__baklogMetricSeed",
+    "baklog-pro-welcome",
+})
+
+PERSONAL_BLEED_KEYS = ("__dismissedClaims", "__dismissedClaimKeys", "__purgedClaimKeys")
+
+
+@dataclass
+class Finding:
+    severity: str
+    code: str
+    message: str
+
+
+@dataclass
+class AuditReport:
+    findings: list[Finding] = field(default_factory=list)
+
+    def add(self, severity: str, code: str, message: str) -> None:
+        self.findings.append(Finding(severity, code, message))
+
+
+def _personal_blob(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    inner = doc.get("personal")
+    return inner if isinstance(inner, dict) else doc if isinstance(doc, dict) else {}
+
+
+def _personal_maps(personal: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for key in PERSONAL_BLEED_KEYS:
+        val = personal.get(key)
+        if isinstance(val, dict) and val:
+            out[key] = val
+    return out
+
+
+def _shared_identical_entries(a_map: dict[str, Any], b_map: dict[str, Any], min_count: int = 3) -> list[str]:
+    shared = set(a_map) & set(b_map)
+    identical = [k for k in shared if a_map[k] == b_map[k]]
+    return identical if len(identical) >= min_count else []
+
+
+def audit_disk_personal_bleed(report: AuditReport, *, skip: bool = False) -> None:
+    if skip or not PROFILES_DIR.is_dir():
+        return
+    profiles: dict[str, dict[str, dict[str, Any]]] = {}
+    for entry in sorted(PROFILES_DIR.iterdir()):
+        if not entry.is_dir():
+            continue
+        maps = _personal_maps(_personal_blob(entry / "data" / "personal.json"))
+        if maps:
+            profiles[entry.name] = maps
+
+    ids = list(profiles.keys())
+    for i, a in enumerate(ids):
+        for b in ids[i + 1:]:
+            for field_key in PERSONAL_BLEED_KEYS:
+                a_map = profiles[a].get(field_key) or {}
+                b_map = profiles[b].get(field_key) or {}
+                identical = _shared_identical_entries(a_map, b_map)
+                if not identical:
+                    continue
+                code = "DISMISS_BLEED" if field_key == "__dismissedClaims" else "PERSONAL_BLEED"
+                report.add(
+                    "high",
+                    code,
+                    f"profiles/{a} and profiles/{b} share {len(identical)} "
+                    f"{field_key} id(s) with identical values (likely legacy bleed). "
+                    f"Sample: {identical[:3]}",
+                )
+
+
+def audit_profile_catalog_isolation(report: AuditReport) -> None:
+    if not PROFILES_DIR.is_dir():
+        return
+    for entry in sorted(PROFILES_DIR.iterdir()):
+        if not entry.is_dir():
+            continue
+        for cat in entry.glob("games_*.json"):
+            if not cat.is_file():
+                report.add(
+                    "high",
+                    "CATALOG_MISSING",
+                    f"{cat.relative_to(ROOT)} is not a regular file",
+                )
+
+
+def _registry_source_text() -> str:
+    chunks: list[str] = []
+    for rel in ("state.js", "profiles.js"):
+        path = JS_DIR / rel
+        if path.is_file():
+            chunks.append(path.read_text(encoding="utf-8", errors="replace"))
+    return "\n".join(chunks)
+
+
+def audit_scoped_registry(report: AuditReport) -> None:
+    text = _registry_source_text()
+    if not text:
+        return
+    for base in EXPECTED_SCOPED_LS_BASES | EXPECTED_SCOPED_SS_BASES:
+        if base not in text:
+            report.add(
+                "medium",
+                "REGISTRY_DRIFT",
+                f"Expected profile-scoped base {base!r} missing from js/profiles.js / state.js",
+            )
+    if "LS_ACTIVE_VIEW_SESSION" not in text:
+        report.add(
+            "medium",
+            "REGISTRY_DRIFT",
+            "LS_ACTIVE_VIEW_SESSION missing from js/profiles.js session registry",
+        )
+
+
+def _parse_storage_key_helpers() -> set[str]:
+    profiles_js = JS_DIR / "profiles.js"
+    if not profiles_js.is_file():
+        return set()
+    text = profiles_js.read_text(encoding="utf-8", errors="replace")
+    helpers = set(re.findall(r"export function (\w+StorageKey|\w+SessionKey)", text))
+    return helpers
+
+
+def audit_helper_registry_coverage(report: AuditReport) -> None:
+    profiles_js = JS_DIR / "profiles.js"
+    if not profiles_js.is_file():
+        return
+    text = profiles_js.read_text(encoding="utf-8", errors="replace")
+    ls_match = re.search(
+        r"PROFILE_SCOPED_STORAGE_KEYS = Object\.freeze\(\[(.*?)\]\)",
+        text,
+        re.S,
+    )
+    ss_match = re.search(
+        r"PROFILE_SCOPED_SESSION_KEYS = Object\.freeze\(\[(.*?)\]\)",
+        text,
+        re.S,
+    )
+    if not ls_match or not ss_match:
+        report.add("high", "REGISTRY_DRIFT", "Could not parse PROFILE_SCOPED_* lists in js/profiles.js")
+        return
+    ls_bases = set(re.findall(r"(?:LS_\w+|PREFS_KEY|STORAGE_KEY|[A-Z_]+_PREFIX)", ls_match.group(1)))
+    for helper in _parse_storage_key_helpers():
+        if helper.endswith("SessionKey"):
+            continue
+        # helpers resolve at runtime — ensure exported names exist
+        if f"export function {helper}" not in text:
+            report.add("medium", "REGISTRY_DRIFT", f"Missing helper export {helper} in js/profiles.js")
+
+
+def audit_js_localstorage_keys(report: AuditReport) -> None:
+    pattern = re.compile(
+        r"localStorage\.(?:getItem|setItem|removeItem)\(\s*['\"]([^'\"]+)['\"]",
+    )
+    for js_path in sorted(JS_DIR.glob("*.js")):
+        text = js_path.read_text(encoding="utf-8", errors="replace")
+        for match in pattern.finditer(text):
+            key = match.group(1)
+            if "${" in key:
+                continue
+            if key in GLOBAL_LS_ALLOWLIST or key in EXPECTED_SCOPED_LS_BASES:
+                continue
+            report.add(
+                "medium",
+                "LS_UNSCOPED",
+                f"localStorage key {key!r} in {js_path.relative_to(ROOT)} without profile scoping",
+            )
+
+
+def audit_js_sessionstorage_keys(report: AuditReport) -> None:
+    pattern = re.compile(
+        r"sessionStorage\.(?:getItem|setItem|removeItem)\(\s*['\"]([^'\"]+)['\"]",
+    )
+    for js_path in sorted(JS_DIR.glob("*.js")):
+        text = js_path.read_text(encoding="utf-8", errors="replace")
+        for match in pattern.finditer(text):
+            key = match.group(1)
+            if key in GLOBAL_SS_ALLOWLIST or key in EXPECTED_SCOPED_SS_BASES:
+                continue
+            report.add(
+                "medium",
+                "SS_UNSCOPED",
+                f"sessionStorage key {key!r} in {js_path.relative_to(ROOT)} without profile scoping",
+            )
+
+
+def _bleed_remediation_hint() -> str:
+    return (
+        "Remediation: reload the app (client no longer merges default localStorage into other profiles). "
+        "Run scripts/clean_profile_dismiss_bleed.py --dry-run then --apply, or restore hidden claims in the UI."
+    )
+
+
+def run_audit(*, ignore_disk_bleed: bool = False) -> AuditReport:
+    report = AuditReport()
+    audit_disk_personal_bleed(report, skip=ignore_disk_bleed)
+    audit_profile_catalog_isolation(report)
+    audit_scoped_registry(report)
+    audit_helper_registry_coverage(report)
+    audit_js_localstorage_keys(report)
+    audit_js_sessionstorage_keys(report)
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--fail-on",
+        choices=("high", "medium", "low"),
+        help="Exit 1 when findings at or above this severity exist",
+    )
+    parser.add_argument(
+        "--ignore-disk-bleed",
+        action="store_true",
+        help="Skip DISMISS_BLEED / PERSONAL_BLEED checks on profiles/ disk data (CI)",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON report on stdout")
+    args = parser.parse_args(argv)
+    report = run_audit(ignore_disk_bleed=args.ignore_disk_bleed)
+    order = {"high": 0, "medium": 1, "low": 2}
+    report.findings.sort(key=lambda f: (order[f.severity], f.code))
+    if args.json:
+        print(json.dumps({"findings": [asdict(f) for f in report.findings]}, indent=2))
+    elif not report.findings:
+        print("security audit: OK (no findings)")
+    else:
+        by_sev: dict[str, int] = {"high": 0, "medium": 0, "low": 0}
+        for f in report.findings:
+            by_sev[f.severity] = by_sev.get(f.severity, 0) + 1
+            print(f"[{f.severity}] {f.code}: {f.message}")
+        print(
+            f"\nsecurity audit: {len(report.findings)} finding(s) "
+            f"(high={by_sev.get('high', 0)}, medium={by_sev.get('medium', 0)}, low={by_sev.get('low', 0)})"
+        )
+        if any(f.code in ("DISMISS_BLEED", "PERSONAL_BLEED") for f in report.findings):
+            print(f"\n{_bleed_remediation_hint()}")
+    if args.fail_on and report.findings:
+        worst = min(order[f.severity] for f in report.findings)
+        if worst <= order[args.fail_on]:
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/clean_profile_dismiss_bleed.py
+++ b/scripts/clean_profile_dismiss_bleed.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Remove legacy cross-profile dismiss/purge entries copied from default.
+
+Usage:
+  .\\.venv\\Scripts\\python.exe scripts\\clean_profile_dismiss_bleed.py --dry-run
+  .\\.venv\\Scripts\\python.exe scripts\\clean_profile_dismiss_bleed.py --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+PROFILES_DIR = ROOT / "profiles"
+BLEED_KEYS = ("__dismissedClaims", "__dismissedClaimKeys", "__purgedClaimKeys")
+
+
+def _load_personal(path: Path) -> dict[str, Any]:
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(doc.get("personal"), dict):
+        return doc
+    return {"personal": doc if isinstance(doc, dict) else {}}
+
+
+def _backup(path: Path) -> Path:
+    backup_dir = path.parent / "personal_backups"
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(tz=UTC).strftime("%Y%m%d-%H%M%S")
+    dest = backup_dir / f"personal-{stamp}.json"
+    shutil.copy2(path, dest)
+    return dest
+
+
+def _bleed_ids(default_maps: dict[str, dict[str, Any]], profile_maps: dict[str, dict[str, Any]]) -> dict[str, list[str]]:
+    removed: dict[str, list[str]] = {}
+    for key in BLEED_KEYS:
+        d_map = default_maps.get(key) or {}
+        p_map = profile_maps.get(key) or {}
+        bleed = [cid for cid in p_map if cid in d_map and p_map[cid] == d_map[cid]]
+        if bleed:
+            removed[key] = bleed
+    return removed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--dry-run", action="store_true")
+    group.add_argument("--apply", action="store_true")
+    parser.add_argument(
+        "--reference",
+        default="default",
+        help="Reference profile id to treat as source of inherited entries (default: default)",
+    )
+    args = parser.parse_args()
+
+    ref_path = PROFILES_DIR / args.reference / "data" / "personal.json"
+    if not ref_path.is_file():
+        print(f"reference profile personal.json missing: {ref_path}", file=sys.stderr)
+        return 1
+
+    ref_doc = _load_personal(ref_path)
+    ref_personal = ref_doc.get("personal") or {}
+    ref_maps = {k: ref_personal.get(k) or {} for k in BLEED_KEYS if isinstance(ref_personal.get(k), dict)}
+
+    changed = 0
+    for entry in sorted(PROFILES_DIR.iterdir()):
+        if not entry.is_dir() or entry.name == args.reference:
+            continue
+        path = entry / "data" / "personal.json"
+        if not path.is_file():
+            continue
+        doc = _load_personal(path)
+        personal = doc.setdefault("personal", {})
+        profile_maps = {k: personal.get(k) or {} for k in BLEED_KEYS if isinstance(personal.get(k), dict)}
+        removed = _bleed_ids(ref_maps, profile_maps)
+        if not removed:
+            continue
+        total = sum(len(v) for v in removed.values())
+        print(f"profiles/{entry.name}: would remove {total} inherited entries")
+        for key, ids in removed.items():
+            print(f"  {key}: {len(ids)} (sample {ids[:3]})")
+        if args.apply:
+            for key, ids in removed.items():
+                cur = personal.get(key)
+                if not isinstance(cur, dict):
+                    continue
+                for cid in ids:
+                    cur.pop(cid, None)
+            backup = _backup(path)
+            path.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+            print(f"  applied (backup {backup.relative_to(ROOT)})")
+        changed += 1
+
+    if not changed:
+        print("no bleed entries found on non-reference profiles")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/clean_profile_dismiss_bleed.py
+++ b/scripts/clean_profile_dismiss_bleed.py
@@ -58,45 +58,81 @@ def main() -> int:
         default="default",
         help="Reference profile id to treat as source of inherited entries (default: default)",
     )
+    parser.add_argument(
+        "--strip-peer",
+        nargs=2,
+        metavar=("SOURCE", "TARGET"),
+        help="Remove from TARGET profile dismiss entries matching SOURCE timestamps (e.g. test promo)",
+    )
     args = parser.parse_args()
 
     ref_path = PROFILES_DIR / args.reference / "data" / "personal.json"
-    if not ref_path.is_file():
+    if not args.strip_peer and not ref_path.is_file():
         print(f"reference profile personal.json missing: {ref_path}", file=sys.stderr)
         return 1
 
-    ref_doc = _load_personal(ref_path)
-    ref_personal = ref_doc.get("personal") or {}
-    ref_maps = {k: ref_personal.get(k) or {} for k in BLEED_KEYS if isinstance(ref_personal.get(k), dict)}
+    ref_maps: dict[str, dict[str, Any]] = {}
+    if not args.strip_peer:
+        ref_doc = _load_personal(ref_path)
+        ref_personal = ref_doc.get("personal") or {}
+        ref_maps = {k: ref_personal.get(k) or {} for k in BLEED_KEYS if isinstance(ref_personal.get(k), dict)}
 
     changed = 0
-    for entry in sorted(PROFILES_DIR.iterdir()):
-        if not entry.is_dir() or entry.name == args.reference:
-            continue
-        path = entry / "data" / "personal.json"
-        if not path.is_file():
-            continue
-        doc = _load_personal(path)
-        personal = doc.setdefault("personal", {})
-        profile_maps = {k: personal.get(k) or {} for k in BLEED_KEYS if isinstance(personal.get(k), dict)}
-        removed = _bleed_ids(ref_maps, profile_maps)
-        if not removed:
-            continue
-        total = sum(len(v) for v in removed.values())
-        print(f"profiles/{entry.name}: would remove {total} inherited entries")
-        for key, ids in removed.items():
-            print(f"  {key}: {len(ids)} (sample {ids[:3]})")
-        if args.apply:
+    if not args.strip_peer:
+        for entry in sorted(PROFILES_DIR.iterdir()):
+            if not entry.is_dir() or entry.name == args.reference:
+                continue
+            path = entry / "data" / "personal.json"
+            if not path.is_file():
+                continue
+            doc = _load_personal(path)
+            personal = doc.setdefault("personal", {})
+            profile_maps = {k: personal.get(k) or {} for k in BLEED_KEYS if isinstance(personal.get(k), dict)}
+            removed = _bleed_ids(ref_maps, profile_maps)
+            if not removed:
+                continue
+            total = sum(len(v) for v in removed.values())
+            print(f"profiles/{entry.name}: would remove {total} inherited entries")
             for key, ids in removed.items():
-                cur = personal.get(key)
-                if not isinstance(cur, dict):
-                    continue
-                for cid in ids:
-                    cur.pop(cid, None)
-            backup = _backup(path)
-            path.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-            print(f"  applied (backup {backup.relative_to(ROOT)})")
-        changed += 1
+                print(f"  {key}: {len(ids)} (sample {ids[:3]})")
+            if args.apply:
+                for key, ids in removed.items():
+                    cur = personal.get(key)
+                    if not isinstance(cur, dict):
+                        continue
+                    for cid in ids:
+                        cur.pop(cid, None)
+                backup = _backup(path)
+                path.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+                print(f"  applied (backup {backup.relative_to(ROOT)})")
+            changed += 1
+
+    if args.strip_peer:
+        a_id, b_id = args.strip_peer
+        a_path = PROFILES_DIR / a_id / "data" / "personal.json"
+        b_path = PROFILES_DIR / b_id / "data" / "personal.json"
+        if a_path.is_file() and b_path.is_file():
+            a_doc = _load_personal(a_path)
+            b_doc = _load_personal(b_path)
+            b_personal = b_doc.setdefault("personal", {})
+            a_maps = {k: (a_doc.get("personal") or {}).get(k) or {} for k in BLEED_KEYS}
+            b_maps = {k: b_personal.get(k) or {} for k in BLEED_KEYS if isinstance(b_personal.get(k), dict)}
+            removed = _bleed_ids(a_maps, b_maps)
+            if removed:
+                total = sum(len(v) for v in removed.values())
+                print(f"peer strip profiles/{b_id} vs profiles/{a_id}: {total} matching entries")
+                if args.apply:
+                    for key, ids in removed.items():
+                        cur = b_personal.get(key)
+                        if isinstance(cur, dict):
+                            for cid in ids:
+                                cur.pop(cid, None)
+                    backup = _backup(b_path)
+                    b_path.write_text(json.dumps(b_doc, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+                    print(f"  applied (backup {backup.relative_to(ROOT)})")
+                    changed += 1
+                else:
+                    changed += 1
 
     if not changed:
         print("no bleed entries found on non-reference profiles")

--- a/scripts/test-all.ps1
+++ b/scripts/test-all.ps1
@@ -50,4 +50,8 @@ Write-Host "==> audit free surface"
 python scripts/audit_free_surface_data.py --fail-on high --out .audit/report.json --baseline-out .audit/baseline.json --findings-out .audit/findings.yaml --handoff-out .audit/handoff.md --csv-out .audit/rows.csv
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+Write-Host "==> audit profile security"
+python scripts/audit_security.py --fail-on high --ignore-disk-bleed
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
 exit 0

--- a/server.py
+++ b/server.py
@@ -3239,7 +3239,7 @@ class Handler(SimpleHTTPRequestHandler):
         config["frozen"] = is_frozen()
         config["version"] = _app_version()
         config["chromium_available"] = _chromium_available()
-        from shared.install_paths import frozen_bundle_dir, is_frozen
+        from shared.install_paths import frozen_bundle_dir
         from shared.server_support import is_running_from_temp_dir
 
         config["running_from_temp"] = is_frozen() and is_running_from_temp_dir(frozen_bundle_dir())

--- a/server.py
+++ b/server.py
@@ -175,9 +175,17 @@ _LOCAL_HOSTNAMES = frozenset({"127.0.0.1", "localhost", "::1"})
 # this map is only populated if something calls _register_epic_oauth_state (legacy redirect flow).
 _epic_oauth_states: dict[str, tuple[float, str]] = {}
 _epic_oauth_states_lock = threading.Lock()
-_stream_tickets: dict[str, tuple[str, float]] = {}
+_stream_tickets: dict[str, tuple[str, float, int, str | None]] = {}
 _stream_tickets_lock = threading.Lock()
-_STREAM_TICKET_TTL_SEC = 30.0
+_STREAM_TICKET_TTL_SEC = 90.0
+# EventSource auto-reconnects with the same URL; single-use tickets caused 401
+# loops when a failed connect (404/503) consumed the ticket first.
+_STREAM_TICKET_MAX_USES = 12
+# Block the stream handler briefly on first connect so a run submitted on another
+# dev-server process (split-brain on localhost) can finish and land in shared history.
+_STREAM_ATTACH_SHORT_WAIT_SEC = 2.0
+_STREAM_ATTACH_LONG_WAIT_SEC = 300.0
+_STREAM_ATTACH_POLL_SEC = 0.1
 _LOG_REDACT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"(Bearer\s+)[A-Za-z0-9._\-]+", re.I), r"\1[redacted]"),
     # Cookie / Set-Cookie values run to end-of-line (they may contain spaces,
@@ -263,27 +271,72 @@ def _consume_epic_oauth_state(state: str | None) -> str | None:
 
 def _prune_expired_stream_tickets() -> None:
     now = time.time()
-    expired = [k for k, (_, exp) in _stream_tickets.items() if exp < now]
+    expired = [k for k, (_, exp, _uses, _run) in _stream_tickets.items() if exp < now]
     for k in expired:
         _stream_tickets.pop(k, None)
 
 
-def _mint_stream_ticket(profile_id: str) -> str:
+def _mint_stream_ticket(profile_id: str, *, run_id: str | None = None) -> str:
     ticket = secrets.token_urlsafe(32)
     with _stream_tickets_lock:
         _prune_expired_stream_tickets()
-        _stream_tickets[ticket] = (profile_id, time.time() + _STREAM_TICKET_TTL_SEC)
+        _stream_tickets[ticket] = (
+            profile_id,
+            time.time() + _STREAM_TICKET_TTL_SEC,
+            _STREAM_TICKET_MAX_USES,
+            run_id,
+        )
     return ticket
 
 
+def _peek_stream_ticket(ticket: str | None, run_id: str | None = None) -> str | None:
+    """Validate a ticket without consuming a use (404/503 must not burn tickets)."""
+    if not ticket:
+        return None
+    now = time.time()
+    with _stream_tickets_lock:
+        entry = _stream_tickets.get(ticket)
+        if not entry:
+            return None
+        profile_id, expiry, _uses_left, bound_run = entry
+        if expiry < now:
+            return None
+        if bound_run and run_id and bound_run != run_id:
+            return None
+    return profile_id
+
+
+def _commit_stream_ticket(ticket: str | None, run_id: str | None = None) -> str | None:
+    """Consume one ticket use once the stream endpoint is ready to respond."""
+    if not ticket:
+        return None
+    now = time.time()
+    with _stream_tickets_lock:
+        entry = _stream_tickets.get(ticket)
+        if not entry:
+            return None
+        profile_id, expiry, uses_left, bound_run = entry
+        if expiry < now:
+            _stream_tickets.pop(ticket, None)
+            return None
+        if bound_run and run_id and bound_run != run_id:
+            return None
+        if uses_left <= 1:
+            _stream_tickets.pop(ticket, None)
+        else:
+            _stream_tickets[ticket] = (profile_id, expiry, uses_left - 1, bound_run)
+    return profile_id
+
+
 def _consume_stream_ticket(ticket: str | None) -> str | None:
+    """Legacy single-use consume for auth-provider SSE (no run binding)."""
     if not ticket:
         return None
     with _stream_tickets_lock:
         entry = _stream_tickets.pop(ticket, None)
     if not entry:
         return None
-    profile_id, expiry = entry
+    profile_id, expiry, _uses_left, _bound_run = entry
     if expiry < time.time():
         return None
     return profile_id
@@ -962,6 +1015,10 @@ def _write_active_runs(runs: list[dict[str, Any]]) -> None:
         _write_json_atomic(ACTIVE_RUNS_FILE, {"runs": runs})
 
 
+def _run_id_active_on_disk(run_id: str) -> bool:
+    return any(entry.get("id") == run_id for entry in _read_active_runs())
+
+
 def _filter_runs_by_lane(runs: list[Run], lane: str | None) -> list[Run]:
     """Restrict a run list to one lane. lane="fetcher" drops internal (admin)
     runs; lane="internal" keeps only them; None passes everything through."""
@@ -1635,6 +1692,19 @@ class RunManager:
                 while len(self._history) > MAX_HISTORY:
                     self._history.pop()
 
+    def _register_pending_run(self, run: Run) -> None:
+        """Cross-process hint so stream handlers can wait for another dev server."""
+        entry = {
+            "id": run.id,
+            "pid": 0,
+            "key": run.key,
+            "label": run.label,
+            "started_at": run.started_at or time.time(),
+        }
+        active = [e for e in _read_active_runs() if e.get("id") != run.id]
+        active.append(entry)
+        _write_active_runs(active)
+
     def _register_active_process(self, run: Run, pid: int) -> None:
         entry = {
             "id": run.id,
@@ -1752,6 +1822,7 @@ class RunManager:
             self._pending.append(run)
             self._runs_by_id[run.id] = run
             self._queue.put(run)
+        self._register_pending_run(run)
         self._persist_queue()
         self._ensure_worker_thread()
         return run
@@ -1804,6 +1875,7 @@ class RunManager:
             self._pending.append(run)
             self._runs_by_id[run.id] = run
             self._internal_queue.put(run)
+        self._register_pending_run(run)
         self._persist_queue()
         self._ensure_worker_thread()
         return run
@@ -2717,6 +2789,48 @@ def _run_accessible(run: Run | None) -> Run | None:
     return None
 
 
+def _stream_terminal_accessible(run_id: str) -> dict[str, Any] | None:
+    terminal = MANAGER.stream_terminal_summary(run_id)
+    if terminal is None:
+        return None
+    if (
+        _profile_run_isolation_enabled()
+        and terminal.get("profile_id") != get_active_profile_id()
+    ):
+        return None
+    return terminal
+
+
+def _resolve_stream_target(run_id: str) -> tuple[Run | None, dict[str, Any] | None]:
+    run = _run_accessible(MANAGER.get(run_id))
+    if run is not None:
+        return run, None
+    return None, _stream_terminal_accessible(run_id)
+
+
+def _wait_for_stream_target(
+    run_id: str, *, since: int
+) -> tuple[Run | None, dict[str, Any] | None]:
+    run, terminal = _resolve_stream_target(run_id)
+    if run is not None or terminal is not None or since > 0:
+        return run, terminal
+    short_deadline = time.time() + _STREAM_ATTACH_SHORT_WAIT_SEC
+    while time.time() < short_deadline:
+        run, terminal = _resolve_stream_target(run_id)
+        if run is not None or terminal is not None:
+            return run, terminal
+        time.sleep(_STREAM_ATTACH_POLL_SEC)
+    if not _run_id_active_on_disk(run_id):
+        return None, None
+    long_deadline = time.time() + _STREAM_ATTACH_LONG_WAIT_SEC
+    while time.time() < long_deadline:
+        run, terminal = _resolve_stream_target(run_id)
+        if run is not None or terminal is not None:
+            return run, terminal
+        time.sleep(_STREAM_ATTACH_POLL_SEC)
+    return None, None
+
+
 class Handler(SimpleHTTPRequestHandler):
     def handle_one_request(self) -> None:  # http.server API
         _note_activity()  # reset the idle-shutdown countdown on any client contact
@@ -2847,8 +2961,6 @@ class Handler(SimpleHTTPRequestHandler):
             self._handle_epic_oauth_callback()
             return
         if path.startswith("/api/stream/"):
-            if not _authorize_stream(self):
-                return
             self._handle_stream(path[len("/api/stream/"):])
             return
         if path.startswith("/api/auth/") and path.endswith("/stream"):
@@ -3127,9 +3239,10 @@ class Handler(SimpleHTTPRequestHandler):
         config["frozen"] = is_frozen()
         config["version"] = _app_version()
         config["chromium_available"] = _chromium_available()
+        from shared.install_paths import frozen_bundle_dir, is_frozen
         from shared.server_support import is_running_from_temp_dir
 
-        config["running_from_temp"] = is_running_from_temp_dir(ROOT)
+        config["running_from_temp"] = is_frozen() and is_running_from_temp_dir(frozen_bundle_dir())
         _send_json(self, HTTPStatus.OK, config)
 
     def _handle_support_get(self, path: str) -> None:
@@ -3466,6 +3579,12 @@ class Handler(SimpleHTTPRequestHandler):
             snap["queue"] = [
                 r for r in (snap.get("queue") or []) if r.get("profile_id") == pid
             ]
+            internal_active = snap.get("internal_active")
+            if internal_active and internal_active.get("profile_id") != pid:
+                snap["internal_active"] = None
+            snap["internal_queue"] = [
+                r for r in (snap.get("internal_queue") or []) if r.get("profile_id") == pid
+            ]
             snap["history"] = [
                 r for r in (snap.get("history") or []) if r.get("profile_id") == pid
             ]
@@ -3585,8 +3704,24 @@ class Handler(SimpleHTTPRequestHandler):
         )
 
     def _handle_stream_ticket_mint(self) -> None:
-        """Single-use ticket for EventSource streams (cannot send Authorization)."""
-        ticket = _mint_stream_ticket(get_active_profile_id())
+        """Limited-reuse ticket for EventSource streams (cannot send Authorization)."""
+        payload, err = _read_json_body(self)
+        if err == "empty body":
+            payload = {}
+        elif err:
+            _send_json(self, HTTPStatus.BAD_REQUEST, {"error": err})
+            return
+        assert payload is not None
+        run_id: str | None = None
+        profile_id = get_active_profile_id()
+        run = None
+        raw_run = payload.get("run_id") if isinstance(payload, dict) else None
+        if raw_run:
+            run_id = str(raw_run).strip().split("/", 1)[0].split("?", 1)[0] or None
+            run = MANAGER.get(run_id) if run_id else None
+            if run is not None:
+                profile_id = run.profile_id
+        ticket = _mint_stream_ticket(profile_id, run_id=run_id)
         _send_json(self, HTTPStatus.OK, {"ticket": ticket})
 
     def _handle_auth_status(self) -> None:
@@ -3923,20 +4058,24 @@ class Handler(SimpleHTTPRequestHandler):
 
     def _handle_stream(self, run_id: str) -> None:
         global _sse_connections
+        from shared.supabase_auth import auth_enabled
+
         run_id = run_id.strip("/").split("/", 1)[0].split("?", 1)[0]
         since = _stream_resume_since(self)
-        run = _run_accessible(MANAGER.get(run_id))
-        if run is None:
-            terminal = MANAGER.stream_terminal_summary(run_id)
-            if terminal is not None:
-                if (
-                    _profile_run_isolation_enabled()
-                    and terminal.get("profile_id") != get_active_profile_id()
-                ):
-                    terminal = None
-            if terminal is None:
-                self.send_error(HTTPStatus.NOT_FOUND, "Unknown run id")
+        ticket = _stream_ticket_from_handler(self)
+        if auth_enabled():
+            profile_id = _peek_stream_ticket(ticket, run_id)
+            if not profile_id:
+                _send_auth_required(self)
                 return
+            set_request_profile_id(profile_id)
+
+        run, terminal = _wait_for_stream_target(run_id, since=since)
+        if run is None and terminal is None:
+            self.send_error(HTTPStatus.NOT_FOUND, "Unknown run id")
+            return
+
+        if run is None and terminal is not None:
             with _sse_lock:
                 if _sse_connections >= MAX_SSE_CONNECTIONS:
                     _send_json(
@@ -3946,6 +4085,11 @@ class Handler(SimpleHTTPRequestHandler):
                     )
                     return
                 _sse_connections += 1
+            if auth_enabled() and not _commit_stream_ticket(ticket, run_id):
+                with _sse_lock:
+                    _sse_connections = max(0, _sse_connections - 1)
+                _send_auth_required(self)
+                return
             self.send_response(HTTPStatus.OK)
             self.send_header("Content-Type", "text/event-stream")
             self.send_header("Cache-Control", "no-store")
@@ -3987,6 +4131,12 @@ class Handler(SimpleHTTPRequestHandler):
                 )
                 return
             _sse_connections += 1
+
+        if auth_enabled() and not _commit_stream_ticket(ticket, run_id):
+            with _sse_lock:
+                _sse_connections = max(0, _sse_connections - 1)
+            _send_auth_required(self)
+            return
 
         self.send_response(HTTPStatus.OK)
         self.send_header("Content-Type", "text/event-stream")
@@ -4183,8 +4333,8 @@ def _check_data_dir_writable() -> None:
     except OSError:
         msg = (
             f"BAKLOG cannot write to its data folder:\n  {target}\n"
-            "Move BAKLOG to a writable location (e.g. Desktop or Documents), "
-            "or set BAKLOG_DATA_DIR to a writable folder."
+            "On Windows the default is %LOCALAPPDATA%\\BAKLOG-Data. "
+            "Move BAKLOG to a writable location or set BAKLOG_DATA_DIR."
         )
         print(msg, file=sys.stderr, flush=True)
         raise SystemExit(1) from None

--- a/server.py
+++ b/server.py
@@ -3220,7 +3220,6 @@ class Handler(SimpleHTTPRequestHandler):
             from shared.profiles import create_profile
 
             created = create_profile(str(payload.get("label") or ""))
-            _refresh_personal_paths()
             _send_json(self, HTTPStatus.CREATED, created)
         except ValueError as exc:
             _send_json(self, HTTPStatus.BAD_REQUEST, {"error": str(exc)})

--- a/tests/admin-run-console-lifecycle.test.js
+++ b/tests/admin-run-console-lifecycle.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRunConsole } from '../admin/run-console.js';
 
 function mountConsoleDom() {
@@ -17,10 +17,36 @@ function mountConsoleDom() {
   `;
 }
 
+function installMockEventSource({ fireOnClose = true } = {}) {
+  class MockEventSource {
+    constructor(url) {
+      this.url = url;
+      this.onerror = null;
+      this.readyState = 2;
+      this._handlers = {};
+      MockEventSource.last = this;
+      this.close = vi.fn(() => {
+        if (fireOnClose && this.onerror) this.onerror(new Event('error'));
+      });
+    }
+    addEventListener(type, fn) {
+      this._handlers[type] = fn;
+    }
+  }
+  MockEventSource.last = null;
+  global.EventSource = MockEventSource;
+  return MockEventSource;
+}
+
 describe('createRunConsole local lifecycle', () => {
   beforeEach(() => {
     mountConsoleDom();
     vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    delete global.EventSource;
+    vi.useRealTimers();
   });
 
   it('beginLocal exposes cancel, aborts fetch signal, and endLocal clears running state', async () => {
@@ -43,5 +69,41 @@ describe('createRunConsole local lifecycle', () => {
     consoleApi.endLocal('cancelled');
     expect(document.getElementById('runConsoleStatus').textContent).toMatch(/cancelled/);
     expect(document.getElementById('runCancelBtn').hidden).toBe(true);
+  });
+});
+
+describe('createRunConsole SSE reconnect', () => {
+  beforeEach(() => {
+    mountConsoleDom();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    delete global.EventSource;
+    vi.useRealTimers();
+  });
+
+  it('does not schedule duplicate reconnects when close() re-fires onerror', async () => {
+    vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb) => {
+      cb(0);
+      return 0;
+    });
+    const MockES = installMockEventSource({ fireOnClose: true });
+    const adminFetch = vi.fn().mockResolvedValue({ history: [] });
+    const consoleApi = createRunConsole({
+      adminFetch,
+      streamUrl: async () => '/api/stream/test-run',
+    });
+
+    void consoleApi.subscribe('test-run', 'Fetch claim sources');
+    await Promise.resolve();
+
+    const es = MockES.last;
+    expect(es).toBeTruthy();
+
+    es.onerror(new Event('error'));
+    const body = document.getElementById('runConsoleBody');
+    const droppedLines = (body.textContent.match(/stream dropped/g) || []).length;
+    expect(droppedLines).toBe(1);
   });
 });

--- a/tests/personal-store-profile.test.js
+++ b/tests/personal-store-profile.test.js
@@ -529,4 +529,37 @@ describe('personalStore.prepareForProfileSwitch', () => {
     expect(state.personal.__dismissedClaims).toBeUndefined();
     expect(state.personal.__dismissedClaimKeys).toBeUndefined();
   });
+
+  it('blocks debounced savePersonal after prepareForProfileSwitch (switch race)', async () => {
+    vi.resetModules();
+    localStorage.clear();
+    localStorage.setItem('baklog-active-profile', 'test');
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url, opts) => {
+        if (url === '/api/personal' && opts?.method === 'GET') {
+          return {
+            ok: true,
+            json: async () => ({ personal: {}, prefs: {}, manual: [] }),
+          };
+        }
+        if (url === '/api/personal' && opts?.method === 'PUT') {
+          return { ok: true, json: async () => JSON.parse(opts.body) };
+        }
+        return { ok: false, status: 500, text: async () => '' };
+      }),
+    );
+
+    const { personalStore, state } = await loadStore();
+    const { savePersonal } = await import('../js/personal-storage.js');
+    await personalStore.init();
+    state.personal.__dismissedClaims = { 'epic-construction-simulator-3': 123 };
+    savePersonal();
+    await personalStore.prepareForProfileSwitch();
+    localStorage.setItem('baklog-active-profile', 'promo');
+    savePersonal();
+    expect(localStorage.getItem('steam-backlog-personal:promo')).toBeNull();
+    expect(personalStore.isProfileSwitchSaveBlocked()).toBe(true);
+  });
 });

--- a/tests/personal-store-profile.test.js
+++ b/tests/personal-store-profile.test.js
@@ -486,4 +486,47 @@ describe('personalStore.prepareForProfileSwitch', () => {
     await personalStore.init();
     expect(state.libraryFirstSeenByKey['steam:1']).toBe(5000);
   });
+
+  it('does not merge unscoped default localStorage dismissals into non-default profile', async () => {
+    vi.resetModules();
+    localStorage.clear();
+    localStorage.setItem('baklog-active-profile', 'promo');
+    // Unscoped key is default's pre-multi-profile cache — must not bleed into promo.
+    localStorage.setItem(
+      'steam-backlog-personal',
+      JSON.stringify({
+        __dismissedClaims: { 'epic-citizen-sleeper-944858': 1781799498808 },
+        __dismissedClaimKeys: { 'title:citizen sleeper': 1781799498808 },
+      }),
+    );
+    localStorage.setItem(
+      'steam-backlog-personal:promo',
+      JSON.stringify({ game1: { status: 'backlog' } }),
+    );
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url, opts) => {
+        if (url === '/api/personal' && opts?.method === 'GET') {
+          return {
+            ok: true,
+            json: async () => ({
+              personal: { game1: { status: 'backlog' } },
+              prefs: {},
+              manual: [],
+            }),
+          };
+        }
+        if (url === '/api/personal' && opts?.method === 'PUT') {
+          return { ok: true, json: async () => JSON.parse(opts.body) };
+        }
+        return { ok: false, status: 500, text: async () => '' };
+      }),
+    );
+
+    const { personalStore, state } = await loadStore();
+    await personalStore.init();
+    expect(state.personal.__dismissedClaims).toBeUndefined();
+    expect(state.personal.__dismissedClaimKeys).toBeUndefined();
+  });
 });

--- a/tests/pro-view.test.js
+++ b/tests/pro-view.test.js
@@ -4,9 +4,11 @@ import { isProPromoSponsorId, proPromoBannerHtml, PRO_PROMO, PRO_PROMO_ITEM } fr
 vi.mock('../js/auth-gate.js', () => ({
   isPro: vi.fn(() => false),
   isAccountAuthMode: vi.fn(() => false),
+  isLocalProfilesEnabled: vi.fn(() => false),
   licenseActivationEnabled: vi.fn(() => true),
   proCheckoutUrls: vi.fn(() => ({})),
   getAccountEmail: vi.fn(() => ''),
+  getAccountProfileId: vi.fn(() => ''),
   refreshAccountPlan: vi.fn(async () => 'free'),
 }));
 
@@ -132,12 +134,13 @@ describe('post-checkout return', () => {
     authGate.refreshAccountPlan.mockResolvedValue('pro');
     const reload = vi.fn();
     vi.stubGlobal('location', { ...window.location, reload });
-    const { PRO_WELCOME_STORAGE_KEY, markCheckoutSuccessPending, handleCheckoutSuccessReturn } = await import('../js/pro-view.js');
+    const { markCheckoutSuccessPending, handleCheckoutSuccessReturn } = await import('../js/pro-view.js');
+    const { proWelcomeSessionKey } = await import('../js/profiles.js');
     markCheckoutSuccessPending();
     await handleCheckoutSuccessReturn();
     expect(authGate.refreshAccountPlan).toHaveBeenCalled();
     expect(document.getElementById('proViewStatus').textContent).toContain('Pro is active');
-    expect(sessionStorage.getItem(PRO_WELCOME_STORAGE_KEY)).toBe('1');
+    expect(sessionStorage.getItem(proWelcomeSessionKey())).toBe('1');
     vi.advanceTimersByTime(500);
     expect(reload).toHaveBeenCalled();
   });
@@ -195,13 +198,14 @@ describe('Pro activation UX', () => {
   it('showProWelcomeBanner renders once when flag is set and user is Pro', async () => {
     const authGate = await import('../js/auth-gate.js');
     authGate.isPro.mockReturnValue(true);
-    const { PRO_WELCOME_STORAGE_KEY, showProWelcomeBanner } = await import('../js/pro-view.js');
-    sessionStorage.setItem(PRO_WELCOME_STORAGE_KEY, '1');
+    const { showProWelcomeBanner } = await import('../js/pro-view.js');
+    const { proWelcomeSessionKey } = await import('../js/profiles.js');
+    sessionStorage.setItem(proWelcomeSessionKey(), '1');
     showProWelcomeBanner();
     const banner = document.getElementById('proWelcomeBanner');
     expect(banner.classList.contains('hidden')).toBe(false);
     expect(banner.textContent).toContain("You're on Pro");
-    expect(sessionStorage.getItem(PRO_WELCOME_STORAGE_KEY)).toBeNull();
+    expect(sessionStorage.getItem(proWelcomeSessionKey())).toBeNull();
     banner.querySelector('.pro-welcome-dismiss')?.click();
     expect(banner.classList.contains('hidden')).toBe(true);
   });

--- a/tests/profiles.test.js
+++ b/tests/profiles.test.js
@@ -18,10 +18,19 @@ import {
   PROFILE_SCOPED_STORAGE_KEYS,
   activeViewSessionKey,
   claimsSnapshotStorageKey,
+  colorThemeStorageKey,
+  dashFailedCoversStorageKey,
+  galleryModeStorageKey,
   knownLibraryKeysStorageKey,
+  landscapeCoversStorageKey,
   libraryFirstSeenStorageKey,
+  metricSeedSessionKey,
+  metricsRenderedStorageKey,
   prefsStorageKey,
+  proWelcomeSessionKey,
+  statLayoutStorageKey,
   itadSnapshotStorageKey,
+  untappedBatchMarkerStorageKey,
   profileScopedStorageKey,
   spotlightRecentKeysStorageKey,
   clearProfileLocalStorage,
@@ -31,7 +40,7 @@ import {
   activeProfileId,
 } from '../js/profiles.js';
 import * as authGate from '../js/auth-gate.js';
-import { KNOWN_LIBRARY_KEYS_KEY, LIBRARY_FIRST_SEEN_KEY, MANUAL_KEY, PREFS_KEY, STORAGE_KEY } from '../js/state.js';
+import { COLOR_THEME_KEY, KNOWN_LIBRARY_KEYS_KEY, LIBRARY_FIRST_SEEN_KEY, MANUAL_KEY, PREFS_KEY, STORAGE_KEY } from '../js/state.js';
 
 const PROFILE_SUFFIX = ':work';
 
@@ -72,13 +81,21 @@ describe('profiles storage keys', () => {
       itadSnapshotStorageKey,
       claimsSnapshotStorageKey,
       spotlightRecentKeysStorageKey,
+      colorThemeStorageKey,
+      statLayoutStorageKey,
+      galleryModeStorageKey,
+      dashFailedCoversStorageKey,
+      landscapeCoversStorageKey,
+      metricsRenderedStorageKey,
+      untappedBatchMarkerStorageKey,
     ];
     for (const helper of localHelpers) {
       expect(PROFILE_SCOPED_STORAGE_KEYS).toContain(storageBaseFromKey(helper()));
     }
-    expect(PROFILE_SCOPED_SESSION_KEYS).toContain(
-      storageBaseFromKey(activeViewSessionKey()),
-    );
+    const sessionHelpers = [activeViewSessionKey, metricSeedSessionKey, proWelcomeSessionKey];
+    for (const helper of sessionHelpers) {
+      expect(PROFILE_SCOPED_SESSION_KEYS).toContain(storageBaseFromKey(helper()));
+    }
     for (const base of PROFILE_SCOPED_STORAGE_KEYS) {
       if (base === PREFS_KEY) continue;
       expect(profileScopedStorageKey(base)).toBe(`${base}${PROFILE_SUFFIX}`);

--- a/tests/test_profile_isolation_audit.py
+++ b/tests/test_profile_isolation_audit.py
@@ -1,0 +1,61 @@
+"""Tests for scripts/audit_security.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import scripts.audit_security as audit
+
+
+def test_audit_flags_identical_dismiss_timestamps_across_profiles(tmp_path: Path) -> None:
+    profiles = tmp_path / "profiles"
+    for pid, ts in (("default", 1000), ("promo", 1000)):
+        dest = profiles / pid / "data"
+        dest.mkdir(parents=True)
+        personal = {
+            "personal": {
+                "__dismissedClaims": {
+                    "epic-a": ts,
+                    "epic-b": ts,
+                    "epic-c": ts,
+                }
+            }
+        }
+        (dest / "personal.json").write_text(json.dumps(personal), encoding="utf-8")
+
+    report = audit.AuditReport()
+    old = audit.PROFILES_DIR
+    audit.PROFILES_DIR = profiles
+    try:
+        audit.audit_disk_personal_bleed(report)
+    finally:
+        audit.PROFILES_DIR = old
+
+    codes = [f.code for f in report.findings]
+    assert "DISMISS_BLEED" in codes
+
+
+def test_audit_ok_when_dismissals_differ(tmp_path: Path) -> None:
+    profiles = tmp_path / "profiles"
+    for pid, ts in (("default", 1000), ("promo", 2000)):
+        dest = profiles / pid / "data"
+        dest.mkdir(parents=True)
+        personal = {"personal": {"__dismissedClaims": {"epic-a": ts}}}
+        (dest / "personal.json").write_text(json.dumps(personal), encoding="utf-8")
+
+    report = audit.AuditReport()
+    old = audit.PROFILES_DIR
+    audit.PROFILES_DIR = profiles
+    try:
+        audit.audit_disk_personal_bleed(report)
+    finally:
+        audit.PROFILES_DIR = old
+
+    assert not any(f.code == "DISMISS_BLEED" for f in report.findings)
+
+
+def test_audit_scoped_registry_passes_on_repo_profiles_js() -> None:
+    report = audit.AuditReport()
+    audit.audit_scoped_registry(report)
+    assert not any(f.code == "REGISTRY_DRIFT" for f in report.findings)

--- a/tests/test_server_supabase_auth.py
+++ b/tests/test_server_supabase_auth.py
@@ -100,6 +100,20 @@ def _request(
         return exc.code, exc.read()
 
 
+def _stream_open_status(base: str, path: str) -> int:
+    """GET /api/stream/* and return status without reading the SSE body."""
+    import http.client
+    from urllib.parse import urlparse
+
+    parsed = urlparse(f"{base}{path}")
+    conn = http.client.HTTPConnection(parsed.hostname, parsed.port, timeout=3)
+    try:
+        conn.request("GET", parsed.path + (f"?{parsed.query}" if parsed.query else ""))
+        return conn.getresponse().status
+    finally:
+        conn.close()
+
+
 def _get_json(base: str, path: str, *, auth: str | None = None) -> tuple[int, dict]:
     status, raw = _request(base, path, auth=auth)
     try:
@@ -323,7 +337,41 @@ def test_stream_ticket_mint_and_sse_access(auth_server) -> None:
     assert status == 401
 
 
-def test_stream_ticket_single_use(auth_server) -> None:
+def test_stream_ticket_limited_reuse(auth_server) -> None:
+    base, secret, _tmp = auth_server
+    sub = "550e8400-e29b-41d4-a716-446655440000"
+    profile_id = sub.lower()
+    account_profiles.ensure_profile_for_user(sub, "a@example.com")
+    run_id = "ticket-reuse-terminal"
+    summary = {
+        "id": run_id,
+        "status": "done",
+        "exit_code": 0,
+        "started_at": "2026-01-01T00:00:00Z",
+        "ended_at": "2026-01-01T00:00:01Z",
+        "profile_id": profile_id,
+    }
+    with server.MANAGER._lock:
+        server.MANAGER._history.appendleft(summary)
+    status, raw = _request(
+        base,
+        "/api/auth/stream-ticket",
+        method="POST",
+        auth=_bearer(secret, sub=sub),
+        headers={"Content-Type": "application/json"},
+        body=b"{}",
+    )
+    assert status == 200
+    ticket = json.loads(raw.decode("utf-8"))["ticket"]
+    max_uses = server._STREAM_TICKET_MAX_USES
+    for _ in range(max_uses):
+        status_ok = _stream_open_status(base, f"/api/stream/{run_id}?ticket={ticket}")
+        assert status_ok == 200
+    status_exhausted = _stream_open_status(base, f"/api/stream/{run_id}?ticket={ticket}")
+    assert status_exhausted == 401
+
+
+def test_stream_ticket_not_consumed_on_unknown_run(auth_server) -> None:
     base, secret, _tmp = auth_server
     sub = "550e8400-e29b-41d4-a716-446655440000"
     account_profiles.ensure_profile_for_user(sub, "a@example.com")
@@ -337,10 +385,10 @@ def test_stream_ticket_single_use(auth_server) -> None:
     )
     assert status == 200
     ticket = json.loads(raw.decode("utf-8"))["ticket"]
-    status1, _ = _request(base, f"/api/stream/abc?ticket={ticket}")
-    assert status1 != 401
-    status2, _ = _request(base, f"/api/stream/abc?ticket={ticket}")
-    assert status2 == 401
+    status404, _ = _request(base, f"/api/stream/missing-run?ticket={ticket}")
+    assert status404 == 404
+    status_ok, _ = _request(base, f"/api/stream/abc?ticket={ticket}")
+    assert status_ok != 401
 
 
 def test_epic_callback_without_bearer(auth_server) -> None:


### PR DESCRIPTION
## Summary
- Scope all client storage keys per profile and add security audit tooling (`scripts/audit_security.py`, `scripts/audit_profile_isolation.py`).
- Fix profile-switch dismiss bleed by blocking saves after `prepareForProfileSwitch`.
- Fix admin SSE reconnect spam from split-brain dev servers and ticket burns.
- Fix `/api/config` crash from `is_frozen` import shadowing on the profile-security branch.

## Test plan
- [x] `pytest tests/test_server_supabase_auth.py tests/test_profile_isolation_audit.py`
- [ ] Verify profile switch does not bleed dismiss state across profiles
- [ ] Verify admin console SSE stays stable with a single dev server
