### PR TITLE
feat(auth): shared connect loop and smoother store sign-in

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "hooks": {
+    "stop": [
+      {
+        "command": ".venv/Scripts/python.exe scripts/hooks/remind-tracker.py",
+        "loop_limit": 1
+      },
+      {
+        "command": ".venv/Scripts/python.exe scripts/hooks/cleanup-baklog-strays.py",
+        "loop_limit": 1
+      }
+    ]
+  }
+}

--- a/.cursor/rules/frontend.mdc
+++ b/.cursor/rules/frontend.mdc
@@ -62,10 +62,10 @@ There are **two completely separate** ad/banner systems. Picking the wrong one i
 - Commit, push, let **Vercel redeploy** baklog.app.
 - **Verify live:** `Invoke-WebRequest https://baklog.app/sponsors.json` and confirm your id + copy are present. Do not trust the local repo file — confirm the hosted feed.
 
-**2. Hardcoded JS banners** (the dashboard `PRO_PROMO` banner `proPromoBannerHtml`, the wishlist house banner, and the Connections-tab Pro card `renderConnectionsProLink` / `CONN_PRO_PITCH` in `js/pro-view.js`). Source: `js/` only — **not** `sponsors.json`. To update:
+**2. Hardcoded JS banners** (the dashboard `PRO_PROMO` banner `proPromoBannerHtml`, the wishlist house banner, and the Connections-tab background-refresh note via `bgRefreshPlanNote()` in `js/connections.js`). Source: `js/` only — **not** `sponsors.json`. To update:
 
 - Edit the `js/` source. In dev the server sends raw ESM with `Cache-Control: no-store`, so a **page reload** picks it up (an already-open SPA tab must be reloaded — modules don't hot-swap).
 - If the server runs built mode (`BAKLOG_SERVE_BUILT=1` or a frozen PyInstaller exe), run `npm run build` to regenerate `dist/` first.
-- The Connections Pro card only renders on the **Connections tab** in a **non‑Pro** session (`isPro()` false). It's hidden for Pro users / `?pro=1`.
+- The Connections background-refresh note only renders on the **Connections tab** in a **non‑Pro** session (`isPro()` false). It's hidden for Pro users / `?pro=1`.
 
 **Quick triage when a banner won't show:** (a) which system is it? (b) for feed-driven, is the **hosted** feed updated (curl it)? (c) for JS, did you reload / rebuild? (d) are you Pro / on the right tab? (e) is the slot dismissed this session?

--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,13 @@ ITAD_API_KEY=
 # (webhook sets plan server-side).
 # BAKLOG_POLAR_ORG_ID=
 
+# BAKLOG Pro checkout CTAs in the app (Support tab). Default off during beta.
+# Set to 1 when Polar checkout should be live for hosted users.
+# BAKLOG_PRO_CHECKOUT=0
+
+# Pure-local dev override for plan tier (ignored when Supabase auth is enabled).
+# BAKLOG_PLAN=pro
+
 # itch.io — generate at https://itch.io/user/settings/api-keys (fetch_itch.py)
 ITCH_API_KEY=
 

--- a/.gitignore
+++ b/.gitignore
@@ -54,8 +54,8 @@ debug-*.log
 .cursor/*
 !.cursor/rules/
 !.cursor/rules/**
+!.cursor/hooks.json
 .cursor/rules/internal-*.mdc
-.cursor/hooks.json
 .baklog_server.pid
 
 # Generated Lighthouse reports (npm run / npx lighthouse)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Deep reference (maintainer clone only): `docs/ARCHITECTURE.md` in the private `b
 Two **separate** systems; mixing them up is why banner edits "don't show". Full guide: `.cursor/rules/frontend.mdc` → "Banners & ads".
 
 - **Feed-driven** (`house-*` deal slots, dash-spotlight Pro slides, paid `ad-*`): from `sponsors.json`. App resolution order (first non-empty wins): local profile `/sponsors.json` → **hosted `baklog.app/sponsors.json`** → bundled `curated/sponsors.json`. The **hosted feed wins on any online machine**, so editing `curated/sponsors.json` alone changes nothing. To ship: edit `landing/sponsors.json` (mirror `curated/`), keep the rule-6 sponsor sync pairs aligned (and add to `PRO_PROMO_SPONSOR_IDS` if it should open the Pro tab), commit, push, let Vercel redeploy, then **verify with `Invoke-WebRequest https://baklog.app/sponsors.json`**.
-- **Hardcoded JS** (dashboard `PRO_PROMO` banner, wishlist house banner, Connections Pro card `renderConnectionsProLink`/`CONN_PRO_PITCH` in `js/pro-view.js`): from `js/` source only. Edit + reload (dev raw ESM is `no-store`); run `npm run build` if serving built `dist/`. The Connections card renders only on the Connections tab for non‑Pro sessions.
+- **Hardcoded JS** (dashboard `PRO_PROMO` banner, wishlist house banner, Connections background-refresh note via `bgRefreshPlanNote()` in `js/connections.js`): from `js/` source only. Edit + reload (dev raw ESM is `no-store`); run `npm run build` if serving built `dist/`. The Connections note renders only on the Connections tab for non‑Pro sessions.
 
 ## Weight guardrails (CI)
 

--- a/auth/cdp_browser.py
+++ b/auth/cdp_browser.py
@@ -111,7 +111,123 @@ def _kill_pids(pids: list[int]) -> list[int]:
     return killed
 
 
-_BLANK_URLS = frozenset({"", "about:blank", "chrome://newtab/"})
+_CHROMIUM_EXE_NAMES = frozenset({"chrome.exe", "msedge.exe", "msedgewebview2.exe"})
+
+
+def _profile_dir_needles(profile: Path) -> tuple[str, ...]:
+    """Normalized path strings for matching ``--user-data-dir=`` on command lines."""
+    resolved = profile.resolve()
+    raw = str(resolved)
+    return tuple({raw.lower(), raw.replace("\\", "/").lower()})
+
+
+def _clear_stale_chromium_profile_lock_files(profile: Path) -> bool:
+    """Remove Chrome singleton lock files when no browser holds the profile."""
+    removed = False
+    for name in ("SingletonLock", "SingletonSocket", "SingletonCookie", "lockfile", "LOCK"):
+        path = profile / name
+        if not path.exists():
+            continue
+        try:
+            path.unlink()
+            removed = True
+        except OSError:
+            pass
+    return removed
+
+
+def pids_holding_chromium_profile(user_data_dir: str | Path) -> list[int]:
+    """Return PIDs of Chrome/Edge processes using this persistent profile (best-effort)."""
+    needles = _profile_dir_needles(Path(user_data_dir))
+    if not needles:
+        return []
+    pids: set[int] = set()
+    flags = _subprocess_no_window_flags()
+    if os.name == "nt":
+        ps_cmd = (
+            "Get-CimInstance Win32_Process | "
+            "Where-Object { $_.Name -in @('chrome.exe','msedge.exe','msedgewebview2.exe') } | "
+            "ForEach-Object { $_.ProcessId.ToString() + '|' + ([string]$_.CommandLine) }"
+        )
+        try:
+            out = subprocess.check_output(
+                ["powershell", "-NoProfile", "-Command", ps_cmd],
+                text=True,
+                encoding="utf-8",
+                errors="ignore",
+                creationflags=flags,
+                timeout=12,
+            )
+        except Exception:
+            return []
+        for line in out.splitlines():
+            if "|" not in line:
+                continue
+            pid_s, cmd = line.split("|", 1)
+            cmd_l = cmd.lower()
+            if not any(needle in cmd_l and "--user-data-dir" in cmd_l for needle in needles):
+                continue
+            try:
+                pids.add(int(pid_s.strip()))
+            except ValueError:
+                pass
+        return sorted(pids)
+    try:
+        out = subprocess.check_output(
+            ["ps", "-ax", "-o", "pid=,command="],
+            text=True,
+            errors="ignore",
+            timeout=8,
+        )
+    except Exception:
+        return []
+    for line in out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            continue
+        pid_s, cmd = parts[0], parts[1]
+        cmd_l = cmd.lower()
+        exe = Path(cmd.split()[0]).name.lower() if cmd.split() else ""
+        if exe not in _CHROMIUM_EXE_NAMES:
+            continue
+        if not any(needle in cmd_l and "--user-data-dir" in cmd_l for needle in needles):
+            continue
+        try:
+            pids.add(int(pid_s))
+        except ValueError:
+            pass
+    return sorted(pids)
+
+
+def release_chromium_profile_lock(user_data_dir: str | Path) -> list[int]:
+    """Close orphan Chrome/Edge windows holding ``user_data_dir`` (Connect/fetch collision)."""
+    profile = Path(user_data_dir)
+    pids = pids_holding_chromium_profile(profile)
+    if pids:
+        _kill_pids(pids)
+        time.sleep(0.35)
+    else:
+        _clear_stale_chromium_profile_lock_files(profile)
+    return pids
+
+
+_BLANK_URLS = frozenset({
+    "",
+    "about:blank",
+    "chrome://newtab/",
+    "chrome://new-tab-page/",
+    "edge://newtab/",
+    "edge://new-tab-page/",
+})
+_BLANK_URL_PREFIXES = (
+    "chrome://new-tab",
+    "chrome://newtab",
+    "edge://new-tab",
+    "edge://newtab",
+)
 
 
 # Hides the navigator.webdriver automation signal without a launch flag (the
@@ -509,6 +625,11 @@ class CdpPage:
                 h(resp)
             except Exception:
                 pass
+        for h in self._context._response_handlers:
+            try:
+                h(resp)
+            except Exception:
+                pass
 
     def _handle_network_event(self, method: str, params: dict) -> None:
         if method == "Network.requestWillBeSent":
@@ -520,6 +641,15 @@ class CdpPage:
             cdp_req = CdpRequest(url=url, headers=headers, post_data=post)
             self._pending_requests[req_id] = cdp_req
             self._dispatch_request(cdp_req)
+        elif method == "Network.requestWillBeSentExtraInfo":
+            req_id = params.get("requestId", "")
+            extra = params.get("headers") or {}
+            cdp_req = self._pending_requests.get(req_id)
+            if cdp_req and extra:
+                merged = dict(cdp_req.headers)
+                merged.update({str(k).lower(): v for k, v in extra.items()})
+                cdp_req.headers = merged
+                self._dispatch_request(cdp_req)
         elif method == "Network.responseReceived":
             req_id = params.get("requestId", "")
             resp_data = params.get("response") or {}
@@ -829,9 +959,11 @@ class CdpContext:
         self._pages_by_session: dict[str, CdpPage] = {}
         self._pages_by_target: dict[str, CdpPage] = {}
         self._request_handlers: list[Callable[[_RequestProxy], None]] = []
+        self._response_handlers: list[Callable[[CdpResponse], None]] = []
         self._init_scripts: list[str] = []
         self._page_handlers: list[Callable[[CdpPage], None]] = []
         self._ubisoft_native_popup_targets: set[str] = set()
+        self._connect_launch_primary_target: str | None = None
         self._ws_dead = False
         self.request = CdpHttpClient(self)
 
@@ -840,6 +972,8 @@ class CdpContext:
             self._page_handlers.append(handler)
         elif event == "request":
             self._request_handlers.append(handler)
+        elif event == "response":
+            self._response_handlers.append(handler)
 
     def add_init_script(self, source: str) -> None:
         self._init_scripts.append(source)
@@ -954,6 +1088,17 @@ class CdpContext:
             url = (page.url or "").strip()
             others = [p for p in self.pages if p is not page and not p.is_closed]
 
+            if is_blank_browser_url(url) and others:
+                try:
+                    page.close()
+                except Exception:
+                    pass
+                try:
+                    others[0].bring_to_front()
+                except Exception:
+                    pass
+                return
+
             if _should_preserve_popup(url):
                 # Blank OAuth popups must stay open but should not steal focus
                 # until they navigate to a real sign-in URL.
@@ -1050,6 +1195,13 @@ class CdpContext:
         target_id = info.get("targetId", "")
         if not target_id or target_id in self._pages_by_target:
             return
+        primary = self._connect_launch_primary_target
+        if primary and target_id != primary:
+            try:
+                self._send("Target.closeTarget", {"targetId": target_id})
+            except Exception:
+                pass
+            return
         if target_id in self._ubisoft_native_popup_targets:
             return
         opener_id = str(info.get("openerId") or info.get("openerFrameId") or "")
@@ -1074,6 +1226,13 @@ class CdpContext:
         sid = params.get("sessionId") or ""
         target_id = info.get("targetId", "")
         if info.get("type") != "page" or not sid or not target_id:
+            return
+        primary = self._connect_launch_primary_target
+        if primary and target_id != primary:
+            try:
+                self._send("Target.closeTarget", {"targetId": target_id})
+            except Exception:
+                pass
             return
         # Safety net: if a Ubisoft login popup ever gets attached, release it so it
         # keeps running natively (the real gate is in _on_target_created).
@@ -1207,6 +1366,25 @@ class CdpContext:
         self.close()
 
 
+class ConnectBrowserClosed(RuntimeError):
+    """Raised when the headed connect browser closes before credentials are saved."""
+
+
+def browser_session_gone(context: CdpContext | Any) -> bool:
+    """True when the headed connect browser is no longer usable."""
+    if getattr(context, "_ws_dead", False):
+        return True
+    pages = list(getattr(context, "pages", ()) or ())
+    if pages:
+        return all(p.is_closed for p in pages)
+    return False
+
+
+def abort_if_browser_closed(context: CdpContext | Any) -> None:
+    if browser_session_gone(context):
+        raise ConnectBrowserClosed()
+
+
 def _reader_loop(
     ws: websocket.WebSocket,
     pending: dict[int, dict],
@@ -1303,12 +1481,93 @@ def _ensure_persistent_session_prefs(profile: Path) -> None:
         pass
 
 
+def _target_list_url(port: int, target_id: str) -> str:
+    try:
+        targets = _fetch_json(f"http://127.0.0.1:{port}/json/list", timeout=5)
+        for t in targets:
+            if t.get("id") == target_id:
+                return (t.get("url") or "").strip()
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError):
+        pass
+    return ""
+
+
+def _close_stray_page_targets(
+    context: CdpContext, port: int, keep_target_id: str
+) -> None:
+    try:
+        targets = _fetch_json(f"http://127.0.0.1:{port}/json/list", timeout=5)
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError):
+        return
+    for t in targets:
+        if t.get("type") != "page":
+            continue
+        tid = (t.get("id") or "").strip()
+        if not tid or tid == keep_target_id:
+            continue
+        try:
+            context._send("Target.closeTarget", {"targetId": tid})
+        except Exception:
+            pass
+        page = context._pages_by_target.pop(tid, None)
+        if page is not None:
+            page._closed = True
+            if page in context.pages:
+                context.pages.remove(page)
+
+
+def _page_effective_url(page: CdpPage, port: int) -> str:
+    try:
+        current = (page.url or "").strip()
+    except Exception:
+        current = ""
+    if not current:
+        current = (page._url or "").strip()
+    if not current:
+        current = _target_list_url(port, page._target_id)
+    return current
+
+
+def _wait_for_non_blank_url(
+    page: CdpPage, port: int, *, timeout_s: float = 20.0
+) -> str:
+    deadline = time.time() + timeout_s
+    last = ""
+    while time.time() < deadline:
+        last = _page_effective_url(page, port)
+        if last and not is_blank_browser_url(last):
+            return last
+        time.sleep(0.2)
+    return last
+
+
+def _ensure_page_navigated(
+    page: CdpPage,
+    url: str,
+    port: int,
+    *,
+    timeout_s: float = 25.0,
+) -> str:
+    target = (url or "").strip()
+    if not target:
+        return _page_effective_url(page, port)
+    current = _wait_for_non_blank_url(page, port, timeout_s=min(8.0, timeout_s))
+    if current and not is_blank_browser_url(current):
+        return current
+    try:
+        page.goto(target, wait_until="domcontentloaded", timeout=int(timeout_s * 1000))
+    except Exception:
+        pass
+    return _wait_for_non_blank_url(page, port, timeout_s=timeout_s) or current
+
+
 def launch_persistent_profile(
     user_data_dir: str | Path,
     *,
     headless: bool | str = False,
     window_position: tuple[int, int] | None = None,
     window_size: tuple[int, int] | None = None,
+    initial_url: str | None = None,
 ) -> CdpContext:
     """Launch Chrome/Edge with a persistent profile and return a CDP context.
 
@@ -1424,16 +1683,47 @@ def launch_persistent_profile(
     })
     context._send("Target.setDiscoverTargets", {"discover": True})
 
-    # Attach existing page targets (new ones are attached via _on_target_created).
-    targets = _fetch_json(f"http://127.0.0.1:{port}/json/list", timeout=5)
-    page_targets = [t for t in targets if t.get("type") == "page"]
-    for t in page_targets:
-        page = context._attach_page(t["id"])
-        if page not in context.pages:
+    start_url = (initial_url or "").strip()
+    if start_url:
+        for pg in list(context.pages):
+            if not pg.is_closed:
+                try:
+                    pg.close()
+                except Exception:
+                    pass
+        context.pages.clear()
+        result = context._send("Target.createTarget", {"url": start_url})
+        target_id = result.get("targetId", "")
+        context._connect_launch_primary_target = target_id or None
+        try:
+            page = context._attach_page(target_id)
             context.pages.append(page)
+            _close_stray_page_targets(context, port, target_id)
+            final_url = _ensure_page_navigated(page, start_url, port)
+            for pg in list(context.pages):
+                if pg._target_id != target_id and not pg.is_closed:
+                    try:
+                        pg.close()
+                    except Exception:
+                        pass
+            context.pages = [
+                p for p in context.pages if p._target_id == target_id and not p.is_closed
+            ]
+            if page not in context.pages:
+                context.pages.append(page)
+        finally:
+            context._connect_launch_primary_target = None
+    else:
+        # Attach existing page targets (new ones are attached via _on_target_created).
+        targets = _fetch_json(f"http://127.0.0.1:{port}/json/list", timeout=5)
+        page_targets = [t for t in targets if t.get("type") == "page"]
+        for t in page_targets:
+            page = context._attach_page(t["id"])
+            if page not in context.pages:
+                context.pages.append(page)
 
-    if not context.pages:
-        context.new_page()
+        if not context.pages:
+            context.new_page()
 
     # Mask the automation signal via a CDP init script instead of the
     # --disable-blink-features=AutomationControlled launch flag (which triggers
@@ -1444,9 +1734,63 @@ def launch_persistent_profile(
     return context
 
 
+def open_connect_page(context: CdpContext, url: str) -> CdpPage:
+    """Open a connect tab already navigated to ``url`` (avoids stuck about:blank tabs).
+
+    Chrome often boots with one or more ``about:blank`` targets. ``Page.navigate`` on
+    those targets can fail if CDP attaches a second blank popup first (WinError 10054).
+    Creating the target with the destination URL lets the browser navigate natively.
+    """
+    target_url = (url or "").strip()
+    if not target_url:
+        raise ValueError("connect url required")
+
+    result = context._send("Target.createTarget", {"url": target_url})
+    target_id = result.get("targetId", "")
+    context._connect_launch_primary_target = target_id or None
+    page: CdpPage | None = None
+    final_url = ""
+    try:
+        page = context._attach_page(target_id)
+        if page not in context.pages:
+            context.pages.append(page)
+
+        _close_stray_page_targets(context, context._port, target_id)
+        final_url = _ensure_page_navigated(page, target_url, context._port)
+
+        for pg in list(context.pages):
+            if pg is page or pg.is_closed:
+                continue
+            if is_blank_browser_url(_page_effective_url(pg, context._port)):
+                try:
+                    pg.close()
+                except Exception:
+                    pass
+    finally:
+        context._connect_launch_primary_target = None
+
+    try:
+        if page is not None:
+            page.bring_to_front()
+    except Exception:
+        pass
+    try:
+        if page is not None:
+            page.focus_window()
+    except Exception:
+        pass
+    if page is None:
+        raise RuntimeError("Failed to open connect page")
+    return page
+
+
 def is_blank_browser_url(url: str) -> bool:
-    """True for about:blank and other empty popup URLs."""
-    return (url or "").strip() in _BLANK_URLS
+    """True for about:blank, new-tab pages, and other empty popup URLs."""
+    u = (url or "").strip()
+    if u in _BLANK_URLS:
+        return True
+    lower = u.lower()
+    return any(lower.startswith(prefix) for prefix in _BLANK_URL_PREFIXES)
 
 
 _POPUP_MERGE_READY = re.compile(

--- a/auth/connect_extractors.py
+++ b/auth/connect_extractors.py
@@ -1,0 +1,432 @@
+"""Reusable credential extractors for headed browser connect flows."""
+
+from __future__ import annotations
+
+import queue
+import threading
+from collections.abc import Callable
+from typing import Any
+
+HUMBLE_LIBRARY_URL = "https://www.humblebundle.com/home/library"
+HUMBLE_ORDERS_API = "https://www.humblebundle.com/api/v1/user/order"
+BATTLENET_GAMES_URL = "https://account.battle.net/games"
+
+
+def pick_gog_al_from_cookies(cookies: list[dict]) -> str:
+    gog_al = next((c["value"] for c in cookies if c.get("name") == "gog-al" and c.get("value")), "")
+    if gog_al:
+        return str(gog_al)
+    parts = []
+    for c in cookies:
+        domain = (c.get("domain") or "").lstrip(".")
+        if "gog.com" not in domain:
+            continue
+        name = c.get("name") or ""
+        value = c.get("value")
+        if name and value is not None:
+            parts.append(f"{name}={value}")
+    header = "; ".join(parts)
+    if "gog-al=" in header:
+        return header.split("gog-al=")[-1].split(";")[0].strip()
+    return ""
+
+
+def _cookie_header(cookies: list[dict], domains: tuple[str, ...]) -> str:
+    parts: list[str] = []
+    for c in cookies:
+        domain = (c.get("domain") or "").lstrip(".")
+        if not any(domain.endswith(d.lstrip(".")) or d.lstrip(".") in domain for d in domains):
+            continue
+        name = c.get("name") or ""
+        value = c.get("value")
+        if name and value is not None:
+            parts.append(f"{name}={value}")
+    return "; ".join(parts)
+
+
+def _humble_has_session(context: Any) -> bool:
+    try:
+        resp = context.request.get(HUMBLE_ORDERS_API, timeout=15_000)
+        if resp.status == 200:
+            body = resp.text().strip()
+            if body.startswith("[") or body.startswith("{"):
+                return True
+        if resp.status in (401, 403):
+            return False
+    except Exception:  # noqa: BLE001
+        pass
+    return False
+
+
+def _battlenet_has_session(context: Any) -> bool:
+    for c in context.cookies():
+        domain = (c.get("domain") or "").lstrip(".")
+        if domain.endswith("battle.net") and c.get("name") and c.get("value"):
+            return True
+    return False
+
+
+class HeaderSniffer:
+    """Capture request headers (e.g. Authorization Bearer, Ubisoft API headers)."""
+
+    def __init__(
+        self,
+        *,
+        url_substr: str,
+        fields: dict[str, str],
+        normalize: Callable[[str | None], str | None] | None = None,
+    ) -> None:
+        self.url_substr = url_substr.lower()
+        self.fields = {k.lower(): v for k, v in fields.items()}
+        self.normalize = normalize
+        self.captured: dict[str, str] = {}
+
+    def attach(self, context: Any) -> None:
+        def on_request(request: Any) -> None:
+            url = (getattr(request, "url", None) or "").lower()
+            if self.url_substr not in url:
+                return
+            headers = getattr(request, "headers", {}) or {}
+            for header_key, cred_key in self.fields.items():
+                val = headers.get(header_key) or headers.get(header_key.title())
+                if not val:
+                    continue
+                if self.normalize and cred_key.endswith("TOKEN"):
+                    norm = self.normalize(val)
+                    if norm:
+                        self.captured[cred_key] = norm
+                else:
+                    self.captured[cred_key] = str(val).strip()
+
+        context.on("request", on_request)
+
+    def ready(self) -> bool:
+        return all(self.captured.get(k) for k in self.fields.values())
+
+    def creds(self) -> dict[str, str]:
+        return dict(self.captured)
+
+
+class GraphqlResponseSniffer:
+    """Queue GraphQL response bodies without parsing on the CDP callback thread."""
+
+    def __init__(
+        self,
+        *,
+        url_match: Callable[[str], bool],
+        accept: Callable[[dict[str, Any]], bool],
+    ) -> None:
+        self.url_match = url_match
+        self.accept = accept
+        self._queue: queue.Queue[dict[str, Any]] = queue.Queue()
+        self._lock = threading.Lock()
+        self.matched = False
+
+    def attach(self, page: Any) -> None:
+        def on_response(response: Any) -> None:
+            try:
+                url = getattr(response, "url", None) or ""
+                if not self.url_match(url):
+                    return
+                if int(getattr(response, "status", 0) or 0) != 200:
+                    return
+                payload = response.json()
+                if not isinstance(payload, dict):
+                    return
+                self._queue.put(payload)
+            except Exception:  # noqa: BLE001
+                pass
+
+        page.on("response", on_response)
+
+    def drain(self) -> bool:
+        changed = False
+        while True:
+            try:
+                payload = self._queue.get_nowait()
+            except queue.Empty:
+                break
+            if self.accept(payload):
+                with self._lock:
+                    self.matched = True
+                changed = True
+        return changed
+
+    @property
+    def success(self) -> bool:
+        with self._lock:
+            return self.matched
+
+
+def extract_gog_session(context: Any) -> dict[str, str] | None:
+    gog_al = pick_gog_al_from_cookies(context.cookies())
+    if gog_al:
+        return {"GOG_AL": gog_al}
+    return None
+
+
+def gog_connect_hint(page: Any) -> str:
+    url = (getattr(page, "url", None) or "").lower()
+    if "login" in url or "signin" in url or "auth" in url:
+        return "Sign in to your GOG account in the browser window."
+    return (
+        "Sign in at gog.com if prompted. We'll save your session automatically "
+        "once you're logged in."
+    )
+
+
+def extract_humble_session(context: Any, page: Any) -> dict[str, str] | None:
+    if _humble_has_session(context):
+        try:
+            page.goto(HUMBLE_LIBRARY_URL, wait_until="domcontentloaded", timeout=15_000)
+            page.wait_for_timeout(800)
+        except Exception:  # noqa: BLE001
+            pass
+        return {"HUMBLE_PROFILE": "ready"}
+    return None
+
+
+def humble_connect_hint(page: Any) -> str:
+    url = (getattr(page, "url", None) or "").lower()
+    if "login" in url or "sign" in url and "library" not in url:
+        return "Sign in to Humble Bundle in the browser window (email or Google)."
+    if "humblebundle.com" not in url:
+        return "Open humblebundle.com and sign in if prompted."
+    return "On humblebundle.com? We'll open your library to confirm the session."
+
+
+def extract_battlenet_session(context: Any) -> dict[str, str] | None:
+    from clients.battlenet_client import probe_session
+
+    if not _battlenet_has_session(context):
+        return None
+    header = _cookie_header(context.cookies(), (".battle.net", "battle.net"))
+    if not header:
+        return None
+    probe_session(header)
+    return {"BATTLENET_COOKIE": header}
+
+
+def battlenet_connect_hint(page: Any) -> str:
+    url = (getattr(page, "url", None) or "").lower()
+    if "login" in url or "signin" in url or "authorize" in url:
+        return "Sign in to your Battle.net account in the browser window."
+    if "battle.net" not in url:
+        return "Open account.battle.net/games after signing in."
+    return (
+        "On your Games page? Wait until your library list finishes loading, "
+        "then we'll save the session automatically."
+    )
+
+
+def extract_ea_bearer_session(
+    context: Any,
+    *,
+    sniffer: HeaderSniffer,
+) -> dict[str, str] | None:
+    from clients.ea_session import probe_ea_token
+
+    if not sniffer.captured.get("EA_BEARER_TOKEN"):
+        return None
+    token = sniffer.captured["EA_BEARER_TOKEN"]
+    cookies = context.cookies()
+    probe = probe_ea_token(token, cookies)
+    if probe.get("ok"):
+        return {"EA_PROFILE": "ready", "EA_BEARER_TOKEN": token}
+    err = (probe.get("error") or "")[:200]
+    if "PersistedQueryNotFound" in err:
+        return {"EA_PROFILE": "ready", "EA_BEARER_TOKEN": token}
+    sniffer.captured.clear()
+    return None
+
+
+def ea_connect_hint(page: Any, *, saw_token: bool) -> str:
+    url = (getattr(page, "url", None) or "").lower()
+    if "signin.ea.com" in url or "/login" in url:
+        return "Sign in to your EA account in the browser window."
+    if saw_token:
+        return "Verifying your EA session — keep the window open."
+    return "Signed in — wait for the deals page to finish loading so we can save your session."
+
+
+def build_ea_header_sniffer() -> HeaderSniffer:
+    from clients.ea_session import EA_GRAPHQL_HOST, normalize_bearer
+
+    return HeaderSniffer(
+        url_substr=EA_GRAPHQL_HOST,
+        fields={"authorization": "EA_BEARER_TOKEN"},
+        normalize=normalize_bearer,
+    )
+
+
+class DeferredGraphqlResponseSniffer:
+    """Queue raw GraphQL responses; parse on drain() to avoid CDP callback deadlocks."""
+
+    def __init__(
+        self,
+        *,
+        url_match: Callable[[str], bool],
+        accept: Callable[[dict[str, Any]], bool],
+        debug_entry: Callable[[str, dict[str, Any]], dict[str, Any]] | None = None,
+    ) -> None:
+        self.url_match = url_match
+        self.accept = accept
+        self.debug_entry = debug_entry
+        self._pending: list[Any] = []
+        self._lock = threading.Lock()
+        self.matched = False
+        self.debug_log: list[dict[str, Any]] = []
+
+    def attach(self, page: Any) -> None:
+        def on_response(response: Any) -> None:
+            try:
+                url = getattr(response, "url", None) or ""
+                if not self.url_match(url):
+                    return
+                if int(getattr(response, "status", 0) or 0) != 200:
+                    return
+                self._pending.append(response)
+            except Exception:  # noqa: BLE001
+                pass
+
+        page.on("response", on_response)
+
+    def drain(self) -> bool:
+        changed = False
+        while self._pending:
+            resp = self._pending.pop(0)
+            try:
+                payload = resp.json()
+            except Exception:  # noqa: BLE001
+                continue
+            if not isinstance(payload, dict):
+                continue
+            if self.debug_entry is not None:
+                try:
+                    self.debug_log.append(self.debug_entry(getattr(resp, "url", "") or "", payload))
+                except Exception:  # noqa: BLE001
+                    pass
+            if self.accept(payload):
+                with self._lock:
+                    self.matched = True
+                changed = True
+        return changed
+
+    @property
+    def success(self) -> bool:
+        with self._lock:
+            return self.matched
+
+
+def build_epic_wishlist_graphql_sniffer() -> DeferredGraphqlResponseSniffer:
+    from auth.epic_wishlist_session import graphql_debug_entry, is_epic_graphql_url, wishlist_graphql_ok
+
+    return DeferredGraphqlResponseSniffer(
+        url_match=is_epic_graphql_url,
+        accept=wishlist_graphql_ok,
+        debug_entry=graphql_debug_entry,
+    )
+
+
+UBISOFT_API_HOST = "public-ubiservices.ubi.com"
+
+
+def build_ubisoft_header_sniffer() -> HeaderSniffer:
+    return HeaderSniffer(
+        url_substr=UBISOFT_API_HOST,
+        fields={
+            "authorization": "UBISOFT_AUTH",
+            "ubi-sessionid": "UBISOFT_SESSION_ID",
+            "ubi-appid": "UBISOFT_APP_ID",
+        },
+    )
+
+
+def extract_ubisoft_session(sniffer: HeaderSniffer) -> dict[str, str] | None:
+    if sniffer.captured.get("UBISOFT_AUTH") and sniffer.captured.get("UBISOFT_SESSION_ID"):
+        return sniffer.creds()
+    return None
+
+
+def ubisoft_session_captured(sniffer: HeaderSniffer) -> bool:
+    return bool(
+        sniffer.captured.get("UBISOFT_AUTH") and sniffer.captured.get("UBISOFT_SESSION_ID")
+    )
+
+
+def ubisoft_connect_hint(
+    *,
+    urls: list[str],
+    seen_success: bool,
+    captured: bool,
+) -> str:
+    joined = " ".join(urls)
+    if "account.ubisoft" in joined or "login" in joined:
+        return (
+            "Finish Ubisoft sign-in and 2FA in the browser window (use the popup if it "
+            "stays open). Close DevTools if you see a yellow 'Debugger paused' banner."
+        )
+    if seen_success and not captured:
+        return "Signed in — opening your Ubisoft games list to finish capturing the session."
+    if not captured:
+        return "Signed in? Open your Ubisoft Connect games list so we can capture the session."
+    return "Almost there — keep the window open while we finish capturing your session."
+
+
+NINTENDO_ACCOUNT_URL = "https://ec.nintendo.com/my/transactions/"
+_NINTENDO_SESSION_COOKIES = (
+    "MIST",
+    "JViDD",
+    "_gh_sess",
+    "NASID",
+    "ecsid",
+    "__Secure-next-auth.session-token",
+)
+
+
+def nintendo_has_session(context: Any) -> bool:
+    """True when known eShop session cookies exist on ec.nintendo.com."""
+    for c in context.cookies():
+        domain = (c.get("domain") or "").lstrip(".")
+        if not domain.startswith("ec.nintendo.com"):
+            continue
+        name = c.get("name") or ""
+        if name in _NINTENDO_SESSION_COOKIES and c.get("value"):
+            return True
+    return False
+
+
+def nintendo_session_has_id_token(context: Any) -> bool:
+    """Verify /api/auth/session returns an idToken (GraphQL prerequisite)."""
+    try:
+        from clients.nintendo_client import PLAYWRIGHT_REQUEST_TIMEOUT_MS, probe_session_id_token
+
+        return bool(
+            probe_session_id_token(
+                context.request.get, timeout=PLAYWRIGHT_REQUEST_TIMEOUT_MS
+            ).get("ok")
+        )
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def extract_nintendo_session(context: Any) -> dict[str, str] | None:
+    if not nintendo_has_session(context) or not nintendo_session_has_id_token(context):
+        return None
+    header = _cookie_header(context.cookies(), ("nintendo.com",))
+    if header:
+        return {"NINTENDO_COOKIE": header}
+    return None
+
+
+def nintendo_connect_hint(page: Any, *, on_account: bool) -> str:
+    url = (getattr(page, "url", None) or "").lower()
+    if "login" in url or "signin" in url or "authorize" in url:
+        return "Sign in to your Nintendo Account in the browser window."
+    if on_account:
+        return "Signed in — opening your eShop transactions page to capture the session."
+    return "Loading your Nintendo eShop transactions — keep the window open."
+
+
+def cookie_header(cookies: list[dict], domains: tuple[str, ...]) -> str:
+    return _cookie_header(cookies, domains)

--- a/auth/connect_loop.py
+++ b/auth/connect_loop.py
@@ -1,0 +1,55 @@
+"""Shared connect polling loop for headed browser sign-in."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Any
+
+from auth.cdp_browser import abort_if_browser_closed
+
+PollResult = dict[str, str] | None
+HintFn = Callable[[], str | None]
+CheckFn = Callable[[], PollResult]
+
+
+def run_connect_poll(
+    *,
+    context: Any,
+    session: Any | None,
+    deadline: float,
+    poll_sec: float,
+    check: CheckFn,
+    hint: HintFn | None = None,
+    hint_interval: float = 8.0,
+    on_signed_in: Callable[[PollResult], None] | None = None,
+    timeout_message: str,
+) -> dict[str, str]:
+    """Poll until ``check()`` returns creds or the deadline passes."""
+    last_hint = 0.0
+    page = None
+    pages = getattr(context, "pages", None) or []
+    if pages:
+        page = pages[0]
+
+    while time.time() < deadline:
+        abort_if_browser_closed(context)
+        creds = check()
+        if creds:
+            if on_signed_in:
+                on_signed_in(creds)
+            return creds
+
+        now = time.time()
+        if session and hint and now - last_hint >= hint_interval:
+            last_hint = now
+            msg = hint()
+            if msg:
+                session.emit("waiting_for_user", {"message": msg})
+
+        if page is not None:
+            page.wait_for_timeout(int(poll_sec * 1000))
+        else:
+            time.sleep(poll_sec)
+
+    raise RuntimeError(timeout_message)

--- a/auth/manager.py
+++ b/auth/manager.py
@@ -643,11 +643,21 @@ def disconnect(provider: str) -> None:
 
 # Cloudflare-gated storefronts where wiping the profile on reconnect forces a
 # new cf_clearance challenge every time and Epic drops the storefront session.
-PRESERVE_PROFILE_ON_RECONNECT = frozenset({"epic_wishlist"})
+PRESERVE_PROFILE_ON_RECONNECT = frozenset(
+    k for k, s in PROVIDERS.items() if s.preserve_profile_on_reconnect
+)
 
 
 def _should_clear_on_reconnect(provider: str) -> bool:
     return provider not in PRESERVE_PROFILE_ON_RECONNECT
+
+
+def _unfinished_session_for(provider: str) -> AuthSession | None:
+    with _sessions_lock:
+        for session in _active_sessions.values():
+            if session.provider == provider and not session._finished.is_set():
+                return session
+    return None
 
 
 def start_browser_auth(provider: str, *, fresh: bool = False) -> str:
@@ -656,6 +666,12 @@ def start_browser_auth(provider: str, *, fresh: bool = False) -> str:
         raise ValueError(f"{provider} uses manual sign-in — click Open in browser and paste your API key")
     if spec.kind not in ("browser", "oauth"):
         raise ValueError(f"{provider} does not support browser sign-in")
+    existing = _unfinished_session_for(provider)
+    if existing is not None:
+        raise ValueError(
+            f"A sign-in window for {spec.label} is already open. "
+            "Finish or close it before starting again."
+        )
     if fresh and _should_clear_on_reconnect(provider):
         # Reconnect: drop the old profile cookies so the sign-in window starts
         # logged out instead of resurrecting the stale/expired session.
@@ -671,7 +687,6 @@ def start_browser_auth(provider: str, *, fresh: bool = False) -> str:
     with _sessions_lock:
         _active_sessions[session_id] = session
 
-
     def _worker() -> None:
         try:
             creds = run_browser_auth(provider, session)
@@ -684,12 +699,9 @@ def start_browser_auth(provider: str, *, fresh: bool = False) -> str:
                 session.emit("error", {"message": msg})
                 return
 
-            from auth.session_probe import (
-                ADVISORY_BROWSER_PROBE,
-                probe_browser_session,
-            )
+            from auth.session_probe import probe_browser_session
 
-            if provider in ADVISORY_BROWSER_PROBE:
+            if spec.post_connect_probe == "advisory":
                 # Headed sign-in already confirmed the session via the live page
                 # (the connect window won't close until xbox.com reports
                 # isSignedIn). The headless re-check is both unreliable AND

--- a/auth/registry.py
+++ b/auth/registry.py
@@ -9,6 +9,7 @@ from auth.epic_wishlist_session import epic_store_login_url
 from clients.amazon_web_client import amazon_signin_url
 
 AuthKind = Literal["form", "browser", "oauth", "local", "manual"]
+PostConnectProbe = Literal["required", "advisory", "skip"]
 
 
 @dataclass(frozen=True)
@@ -37,6 +38,10 @@ class ProviderSpec:
     # OS restriction for this provider. Empty = all platforms (the common case).
     # Amazon Games reads a Windows-only launcher DB, so it sets ("win32",).
     platforms: tuple[str, ...] = ()
+    connect_strategy: str = ""
+    preserve_profile_on_reconnect: bool = False
+    post_connect_probe: PostConnectProbe = "required"
+    login_success_url: str = ""
 
 
 PROVIDERS: dict[str, ProviderSpec] = {
@@ -71,6 +76,7 @@ PROVIDERS: dict[str, ProviderSpec] = {
             "On Windows/macOS with GOG Galaxy installed, the local Galaxy source below "
             "is preferred — no browser sign-in needed.",
         ),
+        connect_strategy="cookie_probe",
     ),
     "gog_galaxy": ProviderSpec(
         key="gog_galaxy",
@@ -159,6 +165,10 @@ PROVIDERS: dict[str, ProviderSpec] = {
             "Cloudflare may show a quick checkbox; clear it, then let the wishlist fully load before closing.",
             "Storefront sessions are short (~7 days), so expect to reconnect this one more often.",
         ),
+        connect_strategy="graphql_response",
+        preserve_profile_on_reconnect=True,
+        post_connect_probe="required",
+        login_success_url="https://store.epicgames.com/wishlist",
     ),
     "amazon": ProviderSpec(
         key="amazon",
@@ -244,6 +254,9 @@ PROVIDERS: dict[str, ProviderSpec] = {
             "Easiest login: click \u201cSign in another way\u201d and have Microsoft email you a one-time "
             "code \u2014 no password or authenticator needed.",
         ),
+        connect_strategy="xhr_sniffer",
+        post_connect_probe="advisory",
+        login_success_url="https://www.xbox.com/en-us/wishlist",
     ),
     "itch": ProviderSpec(
         key="itch",
@@ -310,6 +323,7 @@ PROVIDERS: dict[str, ProviderSpec] = {
             "Battle.net sessions are short (~7 days) \u2014 reconnect here when the library looks stale.",
             "Covers Blizzard titles tied to your account (WoW, Diablo, Overwatch, etc.).",
         ),
+        connect_strategy="cookie_api_probe",
     ),
     "nintendo": ProviderSpec(
         key="nintendo",
@@ -366,6 +380,7 @@ PROVIDERS: dict[str, ProviderSpec] = {
                 "titles and dedupe against Steam by name."
             ),
         ),
+        connect_strategy="profile_marker",
     ),
     "ubisoft": ProviderSpec(
         key="ubisoft",
@@ -401,6 +416,8 @@ PROVIDERS: dict[str, ProviderSpec] = {
             "Each sync uses your saved session token; the browser profile is refreshed when needed.",
             "Only PC titles sold on EA are listed \u2014 Steam/Epic copies stay on those store fetchers.",
         ),
+        connect_strategy="bearer_header",
+        login_success_url="https://www.ea.com/",
     ),
 }
 

--- a/auth/runner.py
+++ b/auth/runner.py
@@ -19,6 +19,8 @@ from auth.api_keys import (
 )
 from auth.cdp_browser import (
     STEALTH_INIT_SCRIPT,
+    ConnectBrowserClosed,
+    abort_if_browser_closed,
     auth_banner_init_script,
     is_blank_browser_url,
     launch_persistent_profile,
@@ -55,6 +57,25 @@ def _drive_connect_page(page, context):
             return pg
     pages = _connect_pages(page, context)
     return pages[0]
+
+
+def _wait_for_connect_page(context, *, timeout_s: float = 15.0):
+    """Return a live connect page, preferring a non-blank tab when CDP attaches popups."""
+    deadline = time.time() + timeout_s
+    last_err = ""
+    while time.time() < deadline:
+        live = [p for p in context.pages if not p.is_closed]
+        if live:
+            for pg in live:
+                if not is_blank_browser_url(pg.url or ""):
+                    return pg
+            return live[0]
+        try:
+            return context.new_page()
+        except Exception as exc:  # noqa: BLE001
+            last_err = str(exc)
+            time.sleep(0.25)
+    raise RuntimeError(last_err or "Connect browser has no usable page")
 PSN_SSOCOOKIE_URL = "https://ca.account.sony.com/api/v1/ssocookie"
 PSN_SSOCOOKIE_INTERVAL_SEC = 10
 
@@ -127,87 +148,40 @@ def _battlenet_has_session(context) -> bool:
 
 def _extract_battlenet_inline(page, context, session: AuthSession | None = None) -> dict[str, str]:
     """Open account.battle.net/games and save cookies only after the library API works."""
+    from auth.connect_extractors import battlenet_connect_hint, extract_battlenet_session
+    from auth.connect_loop import run_connect_poll
+
     try:
         page.goto(BATTLENET_GAMES_URL, wait_until="domcontentloaded", timeout=25_000)
     except Exception:  # noqa: BLE001
         pass
 
-    deadline = time.time() + SUCCESS_WAIT_SEC
-    last_msg = 0.0
-    while time.time() < deadline:
-        if _battlenet_has_session(context):
-            header = _cookie_header(context.cookies(), (".battle.net", "battle.net"))
-            if not header:
-                break
-            from clients.battlenet_client import probe_session
+    def _on_signed_in(_creds: dict[str, str]) -> None:
+        if session:
+            session.emit("signed_in", {"url": page.url or BATTLENET_GAMES_URL})
 
-            probe_session(header)
-            if session:
-                session.emit("signed_in", {"url": page.url or BATTLENET_GAMES_URL})
-            return {"BATTLENET_COOKIE": header}
-
-        now = time.time()
-        if session and now - last_msg > 8:
-            last_msg = now
-            url = (page.url or "").lower()
-            if "login" in url or "signin" in url or "authorize" in url:
-                msg = "Sign in to your Battle.net account in the browser window."
-            elif "battle.net" not in url:
-                msg = "Open account.battle.net/games after signing in."
-            else:
-                msg = (
-                    "On your Games page? Wait until your library list finishes loading, "
-                    "then we'll save the session automatically."
-                )
-            session.emit("waiting_for_user", {"message": msg})
-
-        page.wait_for_timeout(int(POLL_SEC * 1000))
-
-    raise RuntimeError(
-        "Could not verify a Battle.net library session — sign in at account.battle.net/games, "
-        "wait until your Games list loads, then click Connect again."
+    return run_connect_poll(
+        context=context,
+        session=session,
+        deadline=time.time() + SUCCESS_WAIT_SEC,
+        poll_sec=POLL_SEC,
+        check=lambda: extract_battlenet_session(context),
+        hint=lambda: battlenet_connect_hint(page),
+        on_signed_in=_on_signed_in,
+        timeout_message=(
+            "Could not verify a Battle.net library session — sign in at account.battle.net/games, "
+            "wait until your Games list loads, then click Connect again."
+        ),
     )
 
 
 NINTENDO_ACCOUNT_URL = "https://ec.nintendo.com/my/transactions/"
-# Nintendo session cookies that prove we can read the eShop purchase history.
-# Capturing any nintendo.com cookie isn't enough — sign-in completes on
-# accounts.nintendo.com, but the eShop session cookies only get set once we're
-# actually on ec.nintendo.com, so we must land there before reading the jar.
-_NINTENDO_SESSION_COOKIES = (
-    "MIST",
-    "JViDD",
-    "_gh_sess",
-    "NASID",
-    "ecsid",
-    "__Secure-next-auth.session-token",
+from auth.connect_extractors import (  # noqa: E402
+    extract_nintendo_session,
+    nintendo_connect_hint,
+    nintendo_has_session as _nintendo_has_session,
+    nintendo_session_has_id_token as _nintendo_session_has_id_token,
 )
-
-
-def _nintendo_has_session(context) -> bool:
-    """True when known eShop session cookies exist on ec.nintendo.com."""
-    for c in context.cookies():
-        domain = (c.get("domain") or "").lstrip(".")
-        if not domain.startswith("ec.nintendo.com"):
-            continue
-        name = c.get("name") or ""
-        if name in _NINTENDO_SESSION_COOKIES and c.get("value"):
-            return True
-    return False
-
-
-def _nintendo_session_has_id_token(context) -> bool:
-    """Verify /api/auth/session returns an idToken (GraphQL prerequisite)."""
-    try:
-        from clients.nintendo_client import PLAYWRIGHT_REQUEST_TIMEOUT_MS, probe_session_id_token
-
-        return bool(
-            probe_session_id_token(
-                context.request.get, timeout=PLAYWRIGHT_REQUEST_TIMEOUT_MS
-            ).get("ok")
-        )
-    except Exception:
-        return False
 
 
 def _extract_nintendo_inline(page, context, session: AuthSession | None = None) -> dict[str, str]:
@@ -231,15 +205,11 @@ def _extract_nintendo_inline(page, context, session: AuthSession | None = None) 
         url = (drive.url or "").lower()
         signed_in = "ec.nintendo.com" in url and "login" not in url and "connect" not in url
 
-        # Once signed in (we've returned to ec.nintendo.com), the eShop session
-        # cookies should be present — capture and finish.
-        if signed_in and _nintendo_has_session(context) and _nintendo_session_has_id_token(context):
-            header = _cookie_header(context.cookies(), ("nintendo.com",))
-            if header:
-                return {"NINTENDO_COOKIE": header}
+        if signed_in:
+            creds = extract_nintendo_session(context)
+            if creds:
+                return creds
 
-        # User finished sign-in but we're parked on accounts.nintendo.com / home —
-        # auto-redirect to the transactions page so the eShop cookies get set.
         on_account = (
             "accounts.nintendo.com" in url
             or "nintendo.com" in url
@@ -261,21 +231,16 @@ def _extract_nintendo_inline(page, context, session: AuthSession | None = None) 
         now = time.time()
         if session and now - last_hint > 10:
             last_hint = now
-            if "login" in url or "signin" in url or "authorize" in url:
-                msg = "Sign in to your Nintendo Account in the browser window."
-            elif on_account:
-                msg = "Signed in — opening your eShop transactions page to capture the session."
-            else:
-                msg = "Loading your Nintendo eShop transactions — keep the window open."
-            session.emit("waiting_for_user", {"message": msg})
+            session.emit(
+                "waiting_for_user",
+                {"message": nintendo_connect_hint(drive, on_account=on_account)},
+            )
 
         page.wait_for_timeout(int(POLL_SEC * 1000))
 
-    # Last resort: session cookies + idToken probe (not merely any nintendo.com cookie).
-    if _nintendo_has_session(context) and _nintendo_session_has_id_token(context):
-        header = _cookie_header(context.cookies(), ("nintendo.com",))
-        if header:
-            return {"NINTENDO_COOKIE": header}
+    creds = extract_nintendo_session(context)
+    if creds:
+        return creds
     raise RuntimeError(
         "No Nintendo session captured — sign in, then make sure the eShop transactions page "
         "at ec.nintendo.com finished loading. Close any blank tab and click Connect again if needed."
@@ -409,49 +374,37 @@ def _extract_epic_inline(page, context, session: AuthSession | None = None) -> d
 
 def pick_gog_al_from_cookies(cookies: list[dict]) -> str:
     """Return the gog-al session value from Playwright cookie dicts, or \"\"."""
-    gog_al = next((c["value"] for c in cookies if c.get("name") == "gog-al" and c.get("value")), "")
-    if gog_al:
-        return str(gog_al)
-    header = _cookie_header(cookies, ("gog.com",))
-    if header and "gog-al=" in header:
-        return header.split("gog-al=")[-1].split(";")[0].strip()
-    return ""
+    from auth.connect_extractors import pick_gog_al_from_cookies as _pick
+
+    return _pick(cookies)
 
 
 def _extract_gog_inline(page, context, session: AuthSession | None = None) -> dict[str, str]:
     """Poll for gog-al after the user signs in — do not trust the /en homepage URL."""
+    from auth.connect_extractors import extract_gog_session, gog_connect_hint
+    from auth.connect_loop import run_connect_poll
+
     try:
         page.goto("https://www.gog.com/", wait_until="domcontentloaded", timeout=25_000)
     except Exception:  # noqa: BLE001
         pass
 
-    deadline = time.time() + SUCCESS_WAIT_SEC
-    last_msg = 0.0
-    while time.time() < deadline:
-        gog_al = pick_gog_al_from_cookies(context.cookies())
-        if gog_al:
-            if session:
-                session.emit("signed_in", {"url": page.url or "https://www.gog.com/"})
-            return {"GOG_AL": gog_al}
+    def _on_signed_in(creds: dict[str, str]) -> None:
+        if session:
+            session.emit("signed_in", {"url": page.url or "https://www.gog.com/"})
 
-        now = time.time()
-        if session and now - last_msg > 8:
-            last_msg = now
-            url = (page.url or "").lower()
-            if "login" in url or "signin" in url or "auth" in url:
-                msg = "Sign in to your GOG account in the browser window."
-            else:
-                msg = (
-                    "Sign in at gog.com if prompted. We'll save your session automatically "
-                    "once you're logged in."
-                )
-            session.emit("waiting_for_user", {"message": msg})
-
-        page.wait_for_timeout(int(POLL_SEC * 1000))
-
-    raise RuntimeError(
-        "Could not capture a GOG session in time — sign in at gog.com in the browser window, "
-        "then click Connect again."
+    return run_connect_poll(
+        context=context,
+        session=session,
+        deadline=time.time() + SUCCESS_WAIT_SEC,
+        poll_sec=POLL_SEC,
+        check=lambda: extract_gog_session(context),
+        hint=lambda: gog_connect_hint(page),
+        on_signed_in=_on_signed_in,
+        timeout_message=(
+            "Could not capture a GOG session in time — sign in at gog.com in the browser window, "
+            "then click Connect again."
+        ),
     )
 
 
@@ -503,11 +456,8 @@ def _psn_on_blocked_account_page(url: str, body: str) -> bool:
     return False
 
 
-def _fetch_npsso_background(page, context) -> str:
-    """Fetch npsso via in-page request — never navigate away from the store."""
-    npsso = _psn_cookie(context)
-    if npsso:
-        return npsso
+def _fetch_npsso_via_ssocookie(page) -> str:
+    """Fetch npsso from Sony's ssocookie endpoint (browser session must be signed in)."""
     try:
         result = page.evaluate(
             """async () => {
@@ -529,7 +479,22 @@ def _fetch_npsso_background(page, context) -> str:
             return result
     except Exception:
         pass
-    return _psn_cookie(context)
+    return ""
+
+
+def _fetch_npsso_background(page, context) -> tuple[str, str]:
+    """Return ``(token, source)`` where source is ``ssocookie``, ``cookie``, or ``""``.
+
+    Sony's ssocookie endpoint is the source of truth after sign-in. The browser
+    cookie jar can keep a stale npsso from a prior session and must not win.
+    """
+    via_api = _fetch_npsso_via_ssocookie(page)
+    cookie_jar = _psn_cookie(context)
+    if via_api:
+        return via_api, "ssocookie"
+    if cookie_jar:
+        return cookie_jar, "cookie"
+    return "", ""
 
 
 def _extract_psn(page, context, session: AuthSession | None = None) -> dict[str, str]:
@@ -546,7 +511,7 @@ def _extract_psn(page, context, session: AuthSession | None = None) -> dict[str,
         now = time.time()
         if now - last_ssocookie >= PSN_SSOCOOKIE_INTERVAL_SEC:
             last_ssocookie = now
-            fresh = _fetch_npsso_background(page, context)
+            fresh, _source = _fetch_npsso_background(page, context)
             if fresh and fresh not in tried_cookie:
                 result = _check_npsso(fresh)
                 if result == PSN_CHECK_VALID:
@@ -623,23 +588,16 @@ def _extract_epic_wishlist_inline(page, context, session) -> dict[str, str]:
     fetch_epic_wishlist.py. Connect completes when wishlistItems is present in
     either a GraphQL response or Epic's dehydrated React Query HTML state.
     """
+    from auth.connect_extractors import build_epic_wishlist_graphql_sniffer
     from auth.epic_wishlist_session import (
-        graphql_debug_entry,
-        is_epic_graphql_url,
         storefront_bounced_to_home,
         wishlist_capture_complete_from_html,
-        wishlist_graphql_ok,
     )
 
+    sniffer = build_epic_wishlist_graphql_sniffer()
     wishlist_loaded = False
     saw_id_login = False
     did_post_login_nav = False
-    # Reader-thread handlers must NOT call response.json()/getResponseBody — that
-    # issues another CDP command and waits on the very thread that pumps the
-    # reply, deadlocking until timeout and freezing cookie polling. Just stash
-    # candidate responses; the polling thread parses their bodies safely.
-    candidates: list[Any] = []
-    seen_graphql: list[dict[str, Any]] = []
 
     try:
         _debug_path = profile_dir("epic_wishlist").parent / "epic_wishlist_connect_debug.json"
@@ -647,45 +605,18 @@ def _extract_epic_wishlist_inline(page, context, session) -> dict[str, str]:
         _debug_path = None
 
     def _write_debug() -> None:
-        if _debug_path is None:
+        if _debug_path is None or not sniffer.debug_log:
             return
         try:
             _debug_path.parent.mkdir(parents=True, exist_ok=True)
             _debug_path.write_text(
-                json.dumps(seen_graphql[:50], indent=2, default=str, ensure_ascii=False),
+                json.dumps(sniffer.debug_log[:50], indent=2, default=str, ensure_ascii=False),
                 encoding="utf-8",
             )
         except Exception:  # noqa: BLE001
             pass
 
-    def on_response(response) -> None:
-        try:
-            if not is_epic_graphql_url(response.url or ""):
-                return
-            if response.status == 200:
-                candidates.append(response)
-        except Exception:  # noqa: BLE001
-            pass
-
-    def _drain_candidates() -> bool:
-        found = False
-        while candidates:
-            resp = candidates.pop(0)
-            try:
-                payload = resp.json()
-            except Exception:  # noqa: BLE001
-                continue
-            try:
-                seen_graphql.append(graphql_debug_entry(resp.url or "", payload))
-            except Exception:  # noqa: BLE001
-                pass
-            if wishlist_graphql_ok(payload):
-                found = True
-        if seen_graphql:
-            _write_debug()
-        return found
-
-    page.on("response", on_response)
+    sniffer.attach(page)
     try:
         page.goto(epic_store_login_url(), wait_until="domcontentloaded", timeout=25_000)
     except Exception:  # noqa: BLE001
@@ -694,8 +625,9 @@ def _extract_epic_wishlist_inline(page, context, session) -> dict[str, str]:
     deadline = time.time() + SUCCESS_WAIT_SEC
     last_msg = 0.0
     while time.time() < deadline:
-        if not wishlist_loaded and _drain_candidates():
+        if not wishlist_loaded and sniffer.drain():
             wishlist_loaded = True
+            _write_debug()
         url = page.url or ""
         ul = url.lower()
         on_wishlist = _epic_on_wishlist(url)
@@ -718,8 +650,9 @@ def _extract_epic_wishlist_inline(page, context, session) -> dict[str, str]:
                 page.goto(EPIC_WISHLIST_URL, wait_until="domcontentloaded", timeout=25_000)
             except Exception:  # noqa: BLE001
                 pass
-            if not wishlist_loaded and _drain_candidates():
+            if not wishlist_loaded and sniffer.drain():
                 wishlist_loaded = True
+                _write_debug()
         if wishlist_loaded:
             try:
                 page.wait_for_timeout(800)
@@ -1245,39 +1178,25 @@ def _humble_has_session(context) -> bool:
 
 def _extract_humble_inline(page, context, session) -> dict[str, str]:
     """Open humblebundle.com/home/library, wait for sign-in, return marker cred."""
+    from auth.connect_extractors import extract_humble_session, humble_connect_hint
+    from auth.connect_loop import run_connect_poll
+
     try:
         page.goto(HUMBLE_LIBRARY_URL, wait_until="domcontentloaded", timeout=25_000)
     except Exception:  # noqa: BLE001
         pass
 
-    deadline = time.time() + SUCCESS_WAIT_SEC
-    last_msg = 0.0
-    while time.time() < deadline:
-        if _humble_has_session(context):
-            try:
-                page.goto(HUMBLE_LIBRARY_URL, wait_until="domcontentloaded", timeout=15_000)
-                page.wait_for_timeout(800)
-            except Exception:  # noqa: BLE001
-                pass
-            return {"HUMBLE_PROFILE": "ready"}
-
-        now = time.time()
-        if session and now - last_msg > 8:
-            last_msg = now
-            url = (page.url or "").lower()
-            if "login" in url or "sign" in url and "library" not in url:
-                msg = "Sign in to Humble Bundle in the browser window (email or Google)."
-            elif "humblebundle.com" not in url:
-                msg = "Open humblebundle.com/home/library after signing in."
-            else:
-                msg = "On the library page? Finish sign-in if prompted, then wait a moment."
-            session.emit("waiting_for_user", {"message": msg})
-
-        page.wait_for_timeout(int(HUMBLE_POLL_SEC * 1000))
-
-    raise RuntimeError(
-        "Could not detect a Humble sign-in \u2014 sign in at humblebundle.com/home/library "
-        "and keep the window open until it closes."
+    return run_connect_poll(
+        context=context,
+        session=session,
+        deadline=time.time() + SUCCESS_WAIT_SEC,
+        poll_sec=HUMBLE_POLL_SEC,
+        check=lambda: extract_humble_session(context, page),
+        hint=lambda: humble_connect_hint(page),
+        timeout_message=(
+            "Could not detect a Humble sign-in - sign in at humblebundle.com/home/library "
+            "and keep the window open until it closes."
+        ),
     )
 
 
@@ -1308,23 +1227,15 @@ def _ubisoft_active_page(live: list) -> object | None:
 
 
 def _extract_ubisoft(page, context, session: AuthSession | None = None) -> dict[str, str]:
-    captured: dict[str, str] = {}
+    from auth.connect_extractors import (
+        build_ubisoft_header_sniffer,
+        extract_ubisoft_session,
+        ubisoft_connect_hint,
+        ubisoft_session_captured,
+    )
 
-    def on_request(request) -> None:
-        if "public-ubiservices.ubi.com" not in request.url:
-            return
-        auth = request.headers.get("authorization") or request.headers.get("Authorization")
-        ubi_session = request.headers.get("ubi-sessionid") or request.headers.get("Ubi-SessionId")
-        app_id = request.headers.get("ubi-appid") or request.headers.get("Ubi-AppId")
-        if auth:
-            captured["UBISOFT_AUTH"] = auth
-        if ubi_session:
-            captured["UBISOFT_SESSION_ID"] = ubi_session
-        if app_id:
-            captured["UBISOFT_APP_ID"] = app_id
-
-    # Sniff on every page so a request fired from the post-2FA landing tab still counts.
-    context.on("request", on_request)
+    sniffer = build_ubisoft_header_sniffer()
+    sniffer.attach(context)
     try:
         page.goto("https://www.ubisoft.com/en-us/ubisoft-connect", wait_until="domcontentloaded", timeout=25_000)
     except Exception:
@@ -1335,15 +1246,15 @@ def _extract_ubisoft(page, context, session: AuthSession | None = None) -> dict[
     seen_success = False
     nudged = 0
     while time.time() < deadline:
-        if captured.get("UBISOFT_AUTH") and captured.get("UBISOFT_SESSION_ID"):
-            return captured
+        creds = extract_ubisoft_session(sniffer)
+        if creds:
+            return creds
 
         live = [pg for pg in context.pages if not pg.is_closed]
         main = _ubisoft_active_page(live) or (live[0] if live else context.new_page())
         urls = [(pg.url or "").lower() for pg in live]
         if len(live) > 1:
             main_url = (main.url or "").lower()
-            # Don't steal focus from the Ubisoft SDK while it hands off to the opener.
             if "connect.ubisoft.com/login" in main_url or UBISOFT_SUCCESS_URL in main_url:
                 try:
                     main.bring_to_front()
@@ -1351,9 +1262,6 @@ def _extract_ubisoft(page, context, session: AuthSession | None = None) -> dict[
                     pass
         on_success = any(UBISOFT_SUCCESS_URL in u for u in urls)
 
-        # Post-2FA we land on connect.ubisoft.com/logged-in.html. That page doesn't
-        # call ubiservices on its own, so drive a real tab to the library to trigger
-        # the authenticated API requests we sniff for credentials.
         if on_success and not seen_success:
             seen_success = True
             if session:
@@ -1373,18 +1281,11 @@ def _extract_ubisoft(page, context, session: AuthSession | None = None) -> dict[
         now = time.time()
         if session and now - last_hint > 10:
             last_hint = now
-            joined = " ".join(urls)
-            if "account.ubisoft" in joined or "login" in joined:
-                msg = (
-                    "Finish Ubisoft sign-in and 2FA in the browser window (use the popup if it "
-                    "stays open). Close DevTools if you see a yellow 'Debugger paused' banner."
-                )
-            elif seen_success and not captured:
-                msg = "Signed in — opening your Ubisoft games list to finish capturing the session."
-            elif not captured:
-                msg = "Signed in? Open your Ubisoft Connect games list so we can capture the session."
-            else:
-                msg = "Almost there — keep the window open while we finish capturing your session."
+            msg = ubisoft_connect_hint(
+                urls=urls,
+                seen_success=seen_success,
+                captured=ubisoft_session_captured(sniffer),
+            )
             session.emit("waiting_for_user", {"message": msg})
 
         page.wait_for_timeout(int(POLL_SEC * 1000))
@@ -1397,76 +1298,66 @@ def _extract_ubisoft(page, context, session: AuthSession | None = None) -> dict[
 
 def _extract_ea(page, context, session: AuthSession | None = None) -> dict[str, str]:
     """Confirm ea.com login, persist profile + web-session Bearer token."""
-    from clients.ea_session import (
-        EA_DEALS_URL,
-        EA_GRAPHQL_HOST,
-        EA_LOGIN_URL,
-        normalize_bearer,
-        probe_ea_token,
+    from auth.connect_extractors import (
+        build_ea_header_sniffer,
+        ea_connect_hint,
+        extract_ea_bearer_session,
     )
+    from auth.connect_loop import run_connect_poll
+    from clients.ea_session import EA_DEALS_URL, EA_HOME_URL, EA_LOGIN_URL
 
-    saw_token: dict[str, Any] = {"ok": False, "value": ""}
+    sniffer = build_ea_header_sniffer()
+    sniffer.attach(context)
+    nudged = {"done": False}
 
-    def on_request(request) -> None:
-        if EA_GRAPHQL_HOST not in (request.url or ""):
-            return
-        auth = request.headers.get("authorization") or request.headers.get("Authorization")
-        token = normalize_bearer(auth)
-        if token:
-            saw_token["ok"] = True
-            saw_token["value"] = token
+    def _active_page():
+        return _drive_connect_page(page, context)
 
-    context.on("request", on_request)
-    try:
-        page.goto(EA_LOGIN_URL, wait_until="domcontentloaded", timeout=25_000)
-    except Exception:
-        pass
-
-    deadline = time.time() + SUCCESS_WAIT_SEC
-    last_hint = 0.0
-    nudged = False
-    while time.time() < deadline:
-        if saw_token["ok"] and saw_token["value"]:
-            cookies = context.cookies()
-            if probe_ea_token(saw_token["value"], cookies).get("ok"):
-                return {
-                    "EA_PROFILE": "ready",
-                    "EA_BEARER_TOKEN": saw_token["value"],
-                }
-            saw_token["ok"] = False
-            saw_token["value"] = ""
-
-        url = (page.url or "").lower()
-        signed_in = "ea.com" in url and "login" not in url and "signin.ea.com" not in url
-        if signed_in and not nudged:
-            nudged = True
+    def _maybe_nudge_deals() -> None:
+        active = _active_page()
+        url = (active.url or "").lower()
+        signed_in = (
+            url.rstrip("/") in (EA_HOME_URL.rstrip("/"), EA_HOME_URL.rstrip("/") + "/")
+            or ("ea.com" in url and "login" not in url and "signin.ea.com" not in url)
+        )
+        if signed_in and not nudged["done"]:
+            nudged["done"] = True
             if session:
-                session.emit("signed_in", {"url": page.url or EA_LOGIN_URL})
+                session.emit("signed_in", {"url": active.url or EA_LOGIN_URL})
             try:
-                page.bring_to_front()
+                active.bring_to_front()
             except Exception:
                 pass
             try:
-                page.goto(EA_DEALS_URL, wait_until="domcontentloaded", timeout=25_000)
+                active.goto(EA_DEALS_URL, wait_until="domcontentloaded", timeout=25_000)
             except Exception:
                 pass
 
-        now = time.time()
-        if session and now - last_hint > 10:
-            last_hint = now
-            if "signin.ea.com" in url or "/login" in url:
-                msg = "Sign in to your EA account in the browser window."
-            elif signed_in and not saw_token["ok"]:
-                msg = "Signed in — wait for the deals page to finish loading so we can save your session."
-            else:
-                msg = "Keep the window open while we confirm your EA App session."
-            session.emit("waiting_for_user", {"message": msg})
+    def _check() -> dict[str, str] | None:
+        abort_if_browser_closed(context)
+        active = _active_page()
+        if is_blank_browser_url(active.url or ""):
+            try:
+                active.goto(EA_LOGIN_URL, wait_until="domcontentloaded", timeout=25_000)
+            except Exception:
+                pass
+        _maybe_nudge_deals()
+        return extract_ea_bearer_session(context, sniffer=sniffer)
 
-        page.wait_for_timeout(int(POLL_SEC * 1000))
+    def _hint() -> str:
+        return ea_connect_hint(_active_page(), saw_token=bool(sniffer.captured.get("EA_BEARER_TOKEN")))
 
-    raise RuntimeError(
-        "EA session not confirmed — sign in at ea.com, then wait on the deals page "
-        "before the window closes."
+    return run_connect_poll(
+        context=context,
+        session=session,
+        deadline=time.time() + SUCCESS_WAIT_SEC,
+        poll_sec=POLL_SEC,
+        check=_check,
+        hint=_hint,
+        timeout_message=(
+            "EA session not confirmed — sign in at ea.com, then wait on the deals page "
+            "before the window closes."
+        ),
     )
 
 
@@ -1616,73 +1507,85 @@ def run_browser_auth(provider: str, session: AuthSession) -> dict[str, str] | No
     )
     session.emit("waiting_for_user", {"message": connect_hint})
 
-    with launch_persistent_profile(user_data, headless=False) as context:
-        context.add_init_script(_STEALTH_INIT)
-        # Paint a persistent, click-through banner inside the popup so users see
-        # the same guidance there (not just on the dashboard). Keep it in sync
-        # with the live waiting_for_user / signed_in messages.
-        context.add_init_script(auth_banner_init_script(connect_hint))
+    from auth.cdp_browser import release_chromium_profile_lock
 
-        def _sync_auth_banner(event: str, data: dict) -> None:
-            if event == "waiting_for_user":
-                context.set_auth_banner((data or {}).get("message") or connect_hint)
-            elif event == "signed_in":
-                context.set_auth_banner(
-                    "Signed in \u2014 keep this window open until it closes automatically."
-                )
+    release_chromium_profile_lock(user_data)
 
-        session.add_listener(_sync_auth_banner)
-        page = context.pages[0] if context.pages else context.new_page()
-
-        # Raise the connect window to the OS foreground — on Windows it often
-        # opens behind the dashboard/IDE, and Page.bringToFront alone only swaps
-        # the active tab without focusing the window.
+    with launch_persistent_profile(
+        user_data,
+        headless=False,
+        initial_url=spec.login_url if provider == "ea" else None,
+    ) as context:
         try:
-            page.focus_window()
-        except Exception:
-            pass
+            context.add_init_script(_STEALTH_INIT)
+            # Paint a persistent, click-through banner inside the popup so users see
+            # the same guidance there (not just on the dashboard). Keep it in sync
+            # with the live waiting_for_user / signed_in messages.
+            context.add_init_script(auth_banner_init_script(connect_hint))
 
-        if provider in INLINE_PROVIDERS:
-            if provider == "psn":
-                try:
-                    page.goto(PSN_STORE_URL, wait_until="domcontentloaded", timeout=20000)
-                except Exception:
-                    pass
-                creds = _extract_psn(page, context, session)
-            elif provider == "epic_wishlist":
-                creds = _extract_epic_wishlist_inline(page, context, session)
-            elif provider == "xbox_wishlist":
-                creds = _extract_xbox_wishlist_inline(page, context, session)
-            elif provider == "nintendo_wishlist":
-                creds = _extract_nintendo_wishlist_inline(page, context, session)
-            elif provider in ("steam", "itch", "itad", "xbox"):
-                try:
-                    page.goto(spec.login_url, wait_until="domcontentloaded", timeout=20000)
-                except Exception:
-                    pass
-                api_extractors = {
-                    "steam": extract_steam,
-                    "itch": extract_itch,
-                    "itad": extract_itad,
-                    "xbox": extract_xbox,
-                }
-                creds = api_extractors[provider](page, context, session)
-            elif provider == "ubisoft":
-                creds = _extract_ubisoft(page, context, session)
-            elif provider == "ea":
-                creds = _extract_ea(page, context, session)
-            elif provider == "nintendo":
-                creds = _extract_nintendo_inline(page, context, session)
-            elif provider == "epic":
-                creds = _extract_epic_inline(page, context, session)
-            elif provider == "humble":
-                creds = _extract_humble_inline(page, context, session)
-            elif provider == "amazon_web":
-                creds = _extract_amazon_web(page, context, session)
-            elif provider == "battlenet":
-                creds = _extract_battlenet_inline(page, context, session)
-            elif provider == "gog":
-                creds = _extract_gog_inline(page, context, session)
-            else:  # pragma: no cover — gate above guarantees an inline provider
-                raise RuntimeError(f"No inline handler for {provider}")
-            return creds
+            def _sync_auth_banner(event: str, data: dict) -> None:
+                if event == "waiting_for_user":
+                    context.set_auth_banner((data or {}).get("message") or connect_hint)
+                elif event == "signed_in":
+                    context.set_auth_banner(
+                        "Signed in \u2014 keep this window open until it closes automatically."
+                    )
+
+            session.add_listener(_sync_auth_banner)
+            page = _wait_for_connect_page(context)
+            page = _drive_connect_page(page, context)
+
+            # Raise the connect window to the OS foreground — on Windows it often
+            # opens behind the dashboard/IDE, and Page.bringToFront alone only swaps
+            # the active tab without focusing the window.
+            try:
+                page.focus_window()
+            except Exception:
+                pass
+
+            if provider in INLINE_PROVIDERS:
+                if provider == "psn":
+                    try:
+                        page.goto(PSN_STORE_URL, wait_until="domcontentloaded", timeout=20000)
+                    except Exception:
+                        pass
+                    creds = _extract_psn(page, context, session)
+                elif provider == "epic_wishlist":
+                    creds = _extract_epic_wishlist_inline(page, context, session)
+                elif provider == "xbox_wishlist":
+                    creds = _extract_xbox_wishlist_inline(page, context, session)
+                elif provider == "nintendo_wishlist":
+                    creds = _extract_nintendo_wishlist_inline(page, context, session)
+                elif provider in ("steam", "itch", "itad", "xbox"):
+                    try:
+                        page.goto(spec.login_url, wait_until="domcontentloaded", timeout=20000)
+                    except Exception:
+                        pass
+                    api_extractors = {
+                        "steam": extract_steam,
+                        "itch": extract_itch,
+                        "itad": extract_itad,
+                        "xbox": extract_xbox,
+                    }
+                    creds = api_extractors[provider](page, context, session)
+                elif provider == "ubisoft":
+                    creds = _extract_ubisoft(page, context, session)
+                elif provider == "ea":
+                    creds = _extract_ea(page, context, session)
+                elif provider == "nintendo":
+                    creds = _extract_nintendo_inline(page, context, session)
+                elif provider == "epic":
+                    creds = _extract_epic_inline(page, context, session)
+                elif provider == "humble":
+                    creds = _extract_humble_inline(page, context, session)
+                elif provider == "amazon_web":
+                    creds = _extract_amazon_web(page, context, session)
+                elif provider == "battlenet":
+                    creds = _extract_battlenet_inline(page, context, session)
+                elif provider == "gog":
+                    creds = _extract_gog_inline(page, context, session)
+                else:  # pragma: no cover — gate above guarantees an inline provider
+                    raise RuntimeError(f"No inline handler for {provider}")
+                return creds
+        except ConnectBrowserClosed:
+            return None

--- a/auth/session_probe.py
+++ b/auth/session_probe.py
@@ -21,7 +21,7 @@ ProbeResult = Literal["ok", "auth_fail", "unreachable"]
 PROBEABLE_BROWSER = frozenset({"gog", "xbox_wishlist"})
 
 # Cheap/no-browser providers eligible for silent hourly health checks.
-PROBEABLE_QUIET = frozenset({"gog", "epic", "steam", "itch", "itad"})
+PROBEABLE_QUIET = frozenset({"gog", "epic", "steam", "itch", "itad", "psn"})
 
 # Providers whose headed sign-in is authoritative: the connect window confirms
 # the session via the live page before closing, so a headless probe miss must
@@ -148,6 +148,23 @@ def probe_itad_session_quiet() -> ProbeResult:
     return "unreachable"
 
 
+def probe_psn_session_quiet() -> ProbeResult:
+    """Tri-state PSN probe: validate NPSSO via online_id lookup only."""
+    from auth.manager import resolve_env
+    from clients.psn_client import PsnAuthError, PsnClient
+
+    npsso = resolve_env("PSN_NPSSO", provider="psn", allow_process_env=False)
+    if not npsso:
+        return "auth_fail"
+    try:
+        PsnClient(npsso).validate_session()
+        return "ok"
+    except PsnAuthError:
+        return "auth_fail"
+    except Exception:  # noqa: BLE001
+        return "unreachable"
+
+
 def probe_provider_quiet(provider: str) -> ProbeResult:
     """Run a silent tri-state probe for one cheap provider (never raises)."""
     from auth.manager import resolve_env
@@ -164,4 +181,6 @@ def probe_provider_quiet(provider: str) -> ProbeResult:
         return probe_itch_session_quiet()
     if provider == "itad":
         return probe_itad_session_quiet()
+    if provider == "psn":
+        return probe_psn_session_quiet()
     return "unreachable"

--- a/auth/session_probe.py
+++ b/auth/session_probe.py
@@ -13,6 +13,8 @@ from typing import Literal
 
 from clients.gog_client import GOG_AUTH_MESSAGE, GogAuthError, GogClient
 
+from auth.registry import PROVIDERS
+
 ProbeResult = Literal["ok", "auth_fail", "unreachable"]
 
 # Providers that have a probe implementation in this module.
@@ -25,7 +27,9 @@ PROBEABLE_QUIET = frozenset({"gog", "epic", "steam", "itch", "itad"})
 # the session via the live page before closing, so a headless probe miss must
 # never veto the connect (xbox.com serves signed-out SSR to headless Chrome
 # inconsistently). For these, the probe is advisory — logged, never blocking.
-ADVISORY_BROWSER_PROBE = frozenset({"xbox_wishlist"})
+ADVISORY_BROWSER_PROBE = frozenset(
+    k for k, s in PROVIDERS.items() if s.post_connect_probe == "advisory"
+)
 
 
 def probe_browser_session(provider: str, creds: dict[str, str]) -> str | None:

--- a/clients/ea_client.py
+++ b/clients/ea_client.py
@@ -18,9 +18,9 @@ from urllib.parse import quote
 import requests
 
 GRAPHQL_URL = "https://service-aggregation-layer.juno.ea.com/graphql"
-# Persisted-query identifiers used by the ea.com web app (see Playnite EaLibrary
-# 3.x). These are the website's own operation hashes, not desktop-only queries.
-OWNED_GAMES_HASH = "5de4178ee7e1f084ce9deca856c74a9e03547a67dfafc0cb844d532fb54ae73d"
+# Persisted-query identifiers used by the ea.com web app (Juno GraphQL APQ).
+# getPreloadedOwnedGames hash matches the live ea.com deals/library page (2025+).
+OWNED_GAMES_HASH = "779f1cd1355699752e20c0b3877847f4e3010ef5de131c248e98f8eff84f0718"
 PLAY_TIMES_HASH = "3f09b35e06b75c74d8ec3e520a598ebb5e2992b1e1268b6dd3b8ed99b9fafb29"
 
 REAL_OWNERSHIP = frozenset({
@@ -135,7 +135,7 @@ class EaClient:
                 "next": "0",
                 "type": ["DIGITAL_FULL_GAME", "PACKAGED_FULL_GAME"],
                 "entitlementEnabled": True,
-                "storefronts": ["EA"],
+                "storefronts": ["EA", "STEAM", "EPIC"],
                 "ownershipMethods": sorted(REAL_OWNERSHIP | EA_PLAY_OWNERSHIP | XGP_ONLY),
                 "platforms": ["PC"],
             },
@@ -157,7 +157,7 @@ class EaClient:
                     "next": offset,
                     "type": ["DIGITAL_FULL_GAME", "PACKAGED_FULL_GAME"],
                     "entitlementEnabled": True,
-                    "storefronts": ["EA"],
+                    "storefronts": ["EA", "STEAM", "EPIC"],
                     "ownershipMethods": sorted(REAL_OWNERSHIP | EA_PLAY_OWNERSHIP | XGP_ONLY),
                     "platforms": ["PC"],
                 },

--- a/clients/epic_client.py
+++ b/clients/epic_client.py
@@ -371,6 +371,10 @@ class EpicClient:
         self, namespace: str, catalog_id: str, country: str = "US", locale: str = "en-US"
     ) -> dict | None:
         """Catalog metadata for one item (legendary-compatible endpoint)."""
+        cache_key = f"{namespace}_{catalog_id}"
+        cached = self._read_catalog_cache(cache_key)
+        if cached is not None:
+            return cached
         self._throttle()
         resp = self.session.get(
             f"https://{CATALOG_HOST}/catalog/api/shared/namespace/{namespace}/bulk/items",
@@ -389,7 +393,32 @@ class EpicClient:
         if resp.status_code == 404:
             return None
         resp.raise_for_status()
-        return resp.json().get(catalog_id)
+        item = resp.json().get(catalog_id)
+        if item:
+            build = item.get("buildVersion") or item.get("buildVersionId") or ""
+            versioned_key = f"{namespace}_{catalog_id}_{build}" if build else cache_key
+            self._write_catalog_cache(versioned_key, item)
+            if versioned_key != cache_key:
+                self._write_catalog_cache(cache_key, item)
+        return item
+
+    def _catalog_cache_path(self, key: str) -> Path:
+        safe = re.sub(r"[^\w.-]", "_", key)
+        return self._cache_dir / "catalog" / f"{safe}.json"
+
+    def _read_catalog_cache(self, key: str) -> dict | None:
+        path = self._catalog_cache_path(key)
+        if not path.exists():
+            return None
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    def _write_catalog_cache(self, key: str, data: dict) -> None:
+        path = self._catalog_cache_path(key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
 
     def get_catalog_bulk(
         self, namespace: str, catalog_ids: list[str], country: str = "US",

--- a/clients/psn_client.py
+++ b/clients/psn_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 import unicodedata
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -392,6 +393,9 @@ class PsnClient:
     def __init__(self, npsso: str):
         self.last_dedupe_dropped = 0
         self.last_filtered_non_games = 0
+        self.last_title_stats_count = 0
+        self.last_trophy_count = 0
+        self.last_entitlement_count = 0
         try:
             self._psnawp = PSNAWP(npsso)
             self._client = self._psnawp.me()
@@ -470,25 +474,36 @@ class PsnClient:
             )
         return entries
 
-    def collect_library(self) -> list[PsnGameEntry]:
-        hb = HeartbeatTimer(interval=25.0)
-        heartbeat("PSN library: loading title stats")
+    def probe_library_fingerprint(self) -> tuple[int, str | None]:
+        """Cheap title-stats walk: count + newest last_played (for incremental skip)."""
+        count = 0
+        max_last: str | None = None
+        for stat in self._client.title_stats(limit=None):
+            count += 1
+            last = _iso(getattr(stat, "last_played_date_time", None))
+            if last and (max_last is None or last > max_last):
+                max_last = last
+        return count, max_last
+
+    def _walk_title_stats(self) -> tuple[dict[str, object], dict[str, object], dict, int]:
         stats_by_title_id: dict[str, object] = {}
         stats_by_name: dict[str, object] = {}
         stat_agg = _new_stat_agg()
-        for i, stat in enumerate(self._client.title_stats(limit=None), 1):
-            hb.tick_progress(i, 0, "PSN title stats")
+        count = 0
+        for stat in self._client.title_stats(limit=None):
+            count += 1
             if stat.title_id:
                 stats_by_title_id[stat.title_id] = stat
             if stat.name:
                 stats_by_name[_norm_name(stat.name)] = stat
             _accumulate_stat_into_agg(stat_agg, stat)
+        return stats_by_title_id, stats_by_name, stat_agg, count
 
+    def _walk_trophy_entries(self) -> tuple[dict[str, PsnGameEntry], int]:
         entries: dict[str, PsnGameEntry] = {}
-        heartbeat(progress_line(0, 0, "PSN title stats", f"{len(stats_by_title_id)} loaded"))
-
-        for i, trophy in enumerate(self._client.trophy_titles(limit=None), 1):
-            hb.tick_progress(i, 0, "PSN trophies")
+        count = 0
+        for trophy in self._client.trophy_titles(limit=None):
+            count += 1
             comm_id = trophy.np_communication_id
             if not comm_id:
                 continue
@@ -516,7 +531,30 @@ class PsnClient:
                 store_url=_store_url(None, comm_id),
             )
             entries[comm_id] = entry
+        return entries, count
 
+    def _walk_entitlements_raw(self) -> tuple[list, int]:
+        raw: list = []
+        count = 0
+        for entitlement in self._client.game_entitlements(limit=None):
+            count += 1
+            raw.append(entitlement)
+        return raw, count
+
+    def collect_library(self) -> list[PsnGameEntry]:
+        hb = HeartbeatTimer(interval=25.0)
+        heartbeat("PSN library: loading (parallel API walks)")
+        with ThreadPoolExecutor(max_workers=3) as ex:
+            f_stats = ex.submit(self._walk_title_stats)
+            f_trophy = ex.submit(self._walk_trophy_entries)
+            f_ent = ex.submit(self._walk_entitlements_raw)
+            stats_by_title_id, stats_by_name, stat_agg, title_stats_count = f_stats.result()
+            entries, trophy_count = f_trophy.result()
+            entitlements, entitlement_count = f_ent.result()
+        self.last_title_stats_count = title_stats_count
+        self.last_trophy_count = trophy_count
+        self.last_entitlement_count = entitlement_count
+        heartbeat(progress_line(0, 0, "PSN title stats", f"{title_stats_count} loaded"))
         heartbeat(progress_line(0, len(entries), "PSN trophies", f"{len(entries)} titles"))
 
         for entry in entries.values():
@@ -531,8 +569,8 @@ class PsnClient:
 
         seen_title_ids = {e.title_id for e in entries.values() if e.title_id}
 
-        for i, entitlement in enumerate(self._client.game_entitlements(limit=None), 1):
-            hb.tick_progress(i, 0, "PSN entitlements")
+        for entitlement in entitlements:
+            hb.tick_progress(0, 0, "PSN entitlements")
             if entitlement.get("isGame") is False or entitlement.get("isBeta") is True:
                 continue
             title_meta = entitlement.get("titleMeta") or {}

--- a/clients/steam_client.py
+++ b/clients/steam_client.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import requests
 
 STORE_DELAY_SEC = 1.5
+APP_DETAILS_BATCH_SIZE = 40
 _STORE_RETRY_BACKOFF = (2, 5, 10)
 _RETRYABLE_HTTP = frozenset({429, 500, 502, 503, 504})
 
@@ -115,6 +116,38 @@ class SteamClient:
 
         self._write_cache("appdetails", cache_key, result)
         return result
+
+    def get_app_details_batch(
+        self, appids: list[int], refresh: bool = False
+    ) -> dict[int, dict | None]:
+        """Fetch appdetails for many appids; one store throttle per chunk."""
+        results: dict[int, dict | None] = {}
+        pending: list[int] = []
+        for appid in appids:
+            cache_key = str(appid)
+            if not refresh:
+                cached = self._read_cache("appdetails", cache_key)
+                if cached is not None:
+                    results[appid] = cached
+                    continue
+            pending.append(appid)
+
+        for offset in range(0, len(pending), APP_DETAILS_BATCH_SIZE):
+            chunk = pending[offset : offset + APP_DETAILS_BATCH_SIZE]
+            self._throttle_store()
+            url = "https://store.steampowered.com/api/appdetails"
+            params = {"appids": ",".join(str(a) for a in chunk), "l": "english"}
+            resp = _get_with_retry(url, params)
+            raw = resp.json()
+            for appid in chunk:
+                entry = raw.get(str(appid), {})
+                if not entry.get("success"):
+                    result: dict = {"success": False, "data": None}
+                else:
+                    result = {"success": True, "data": entry.get("data")}
+                self._write_cache("appdetails", str(appid), result)
+                results[appid] = result
+        return results
 
     def get_review_summary(self, appid: int, refresh: bool = False) -> dict | None:
         cache_key = str(appid)

--- a/fetchers/_base.py
+++ b/fetchers/_base.py
@@ -55,13 +55,17 @@ def configure_stdout() -> None:
             pass
 
 
-def add_hltb_args(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--skip-hltb", action="store_true", help="Skip HowLongToBeat lookups")
+def add_only_new_arg(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--only-new",
         action="store_true",
-        help="Only HLTB-lookup games not already in the output file",
+        help="Skip per-row enrichment for titles already in the output file",
     )
+
+
+def add_hltb_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--skip-hltb", action="store_true", help="Skip HowLongToBeat lookups")
+    add_only_new_arg(parser)
 
 
 def add_dry_run_arg(parser: argparse.ArgumentParser) -> None:

--- a/fetchers/fetch_battlenet.py
+++ b/fetchers/fetch_battlenet.py
@@ -21,6 +21,7 @@ from fetchers._authoritative import BATTLENET
 from fetchers._base import (
     add_allow_empty_arg,
     add_no_carry_arg,
+    add_only_new_arg,
     apply_carry_forward,
     catalog_file,
     configure_stdout,
@@ -189,6 +190,7 @@ def _build_client(browser: str, env_cookie: str) -> BattleNetClient:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Fetch Battle.net library (unofficial)")
     parser.add_argument("--skip-hltb", action="store_true")
+    add_only_new_arg(parser)
     add_allow_empty_arg(parser)
     add_no_carry_arg(parser)
     load_dotenv()
@@ -289,8 +291,12 @@ def main() -> int:
     games_out: list[dict] = []
     for i, item in enumerate(deduped, 1):
         name = _name(item)
+        row_id = _id(item, name or "")
+        cached = existing.get(row_id)
+        if args.only_new and cached:
+            games_out.append(cached)
+            continue
         print(f"[{i}/{len(deduped)}] {name}")
-        cached = existing.get(_id(item, name or ""))
         hltb = None
         hltb_updated = False
         if not args.skip_hltb:

--- a/fetchers/fetch_ea.py
+++ b/fetchers/fetch_ea.py
@@ -85,6 +85,10 @@ def _resolve_session(
         if probe.get("ok"):
             debug["token_source"] = "stored"
             return stored, [], debug
+        err = (probe.get("error") or "")[:200]
+        if "PersistedQueryNotFound" in err:
+            debug["token_source"] = "stored_apq_stale"
+            return stored, [], debug
 
     profile = profile_dir("ea")
     if not profile.exists() or not any(profile.iterdir()):

--- a/fetchers/fetch_ea.py
+++ b/fetchers/fetch_ea.py
@@ -29,6 +29,7 @@ from fetchers._authoritative import EA
 from fetchers._base import (
     add_allow_empty_arg,
     add_no_carry_arg,
+    add_only_new_arg,
     apply_carry_forward,
     catalog_file,
     configure_stdout,
@@ -260,6 +261,7 @@ def main() -> int:
     add_allow_empty_arg(parser)
     add_no_carry_arg(parser)
     parser.add_argument("--skip-hltb", action="store_true")
+    add_only_new_arg(parser)
     parser.add_argument("--dump-raw", action="store_true")
     parser.add_argument(
         "--headed",
@@ -374,8 +376,11 @@ def main() -> int:
 
     for i, item in enumerate(sorted(deduped, key=_sort_key), 1):
         name = _clean_name(str((item.get("product") or {}).get("name") or ""))
-        print(f"[{i}/{len(deduped)}] {name}", flush=True)
         cached = existing.get(_row_id(item))
+        if args.only_new and cached:
+            games_out.append(cached)
+            continue
+        print(f"[{i}/{len(deduped)}] {name}", flush=True)
         hltb = None
         hltb_updated = False
         if not args.skip_hltb:

--- a/fetchers/fetch_epic.py
+++ b/fetchers/fetch_epic.py
@@ -3,6 +3,7 @@
 
 import argparse
 import concurrent.futures
+import hashlib
 import json
 import re
 import time
@@ -19,6 +20,7 @@ from fetchers._authoritative import EPIC
 from fetchers._base import (
     add_allow_empty_arg,
     add_no_carry_arg,
+    add_only_new_arg,
     apply_carry_forward,
     catalog_file,
     configure_stdout,
@@ -186,6 +188,11 @@ def _can_reuse_cached_epic_row(
 
 def _epic_row_id(rec: dict) -> str:
     return f"{rec['namespace']}:{rec['catalogItemId']}"
+
+
+def _entitlement_set_hash(apps: list[dict]) -> str:
+    ids = sorted(_epic_row_id(rec) for rec in apps)
+    return hashlib.sha256("\n".join(ids).encode()).hexdigest()[:16]
 
 
 def _needs_catalog_fetch(rec: dict, existing: dict[str, dict], args: argparse.Namespace) -> bool:
@@ -400,6 +407,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Fetch Epic library into games_epic.json")
     parser.add_argument("--refresh", action="store_true", help="Re-fetch all catalog metadata")
     parser.add_argument("--skip-hltb", action="store_true", help="Skip HowLongToBeat lookups")
+    add_only_new_arg(parser)
     parser.add_argument("--auth-help", action="store_true", help="Print Epic login instructions")
     add_allow_empty_arg(parser)
     add_no_carry_arg(parser)
@@ -473,10 +481,27 @@ def main() -> int:
         return stats.finish("fetch_epic", t0, exit_code=drift_exit)
 
     existing = load_existing()
-    apps_needing_catalog = apps if args.refresh else [
-        rec for rec in apps if _needs_catalog_fetch(rec, existing, args)
-    ]
-    catalog_skipped = len(apps) - len(apps_needing_catalog)
+    set_hash = _entitlement_set_hash(apps)
+    prev_hash: str | None = None
+    if catalog_file(GAMES_EPIC_JSON).exists():
+        try:
+            prev_hash = json.loads(
+                catalog_file(GAMES_EPIC_JSON).read_text(encoding="utf-8")
+            ).get("entitlement_set_hash")
+        except json.JSONDecodeError:
+            prev_hash = None
+    if args.only_new and not args.refresh and prev_hash and set_hash == prev_hash:
+        apps_needing_catalog: list[dict] = []
+        catalog_skipped = len(apps)
+        print(
+            f"  catalog: entitlement set unchanged ({len(apps)} titles, no API calls)",
+            flush=True,
+        )
+    else:
+        apps_needing_catalog = apps if args.refresh else [
+            rec for rec in apps if _needs_catalog_fetch(rec, existing, args)
+        ]
+        catalog_skipped = len(apps) - len(apps_needing_catalog)
     catalog: dict[tuple[str, str], dict] = {}
 
     if apps_needing_catalog:
@@ -543,6 +568,10 @@ def main() -> int:
         row_id = _epic_row_id(rec)
         item = catalog.get((ns, cid))
         name = (item or {}).get("title") or rec.get("sandboxName") or rec.get("appName") or cid
+
+        if args.only_new and row_id in existing and not args.refresh:
+            games_out.append(existing[row_id])
+            continue
 
         if not args.refresh and row_id in existing:
             cached_early = existing[row_id]
@@ -647,6 +676,7 @@ def main() -> int:
         "fetched_at": datetime.now(UTC).isoformat(),
         "store": "epic",
         "game_count": len(games_out),
+        "entitlement_set_hash": set_hash,
         "games": sorted(games_out, key=lambda g: g["name"].lower()),
     }
     write_catalog_text(GAMES_EPIC_JSON, json.dumps(payload, indent=2, ensure_ascii=False))

--- a/fetchers/fetch_epic_wishlist.py
+++ b/fetchers/fetch_epic_wishlist.py
@@ -40,6 +40,7 @@ from auth.secrets import profile_dir
 from clients.hltb_client import HltbClient
 from fetchers._base import (
     add_allow_empty_arg,
+    add_only_new_arg,
     catalog_file,
     configure_stdout,
     refuse_drift_result,
@@ -442,6 +443,7 @@ def _load_existing() -> dict[str, dict]:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Fetch Epic wishlist into games_wishlist_epic.json")
     parser.add_argument("--hltb", action="store_true", help="Look up HowLongToBeat hours (slow)")
+    add_only_new_arg(parser)
     parser.add_argument("--country", default="US", help="Storefront country code (default US)")
     parser.add_argument("--locale", default="en-US", help="Storefront locale (default en-US)")
     parser.add_argument(
@@ -516,6 +518,9 @@ def main() -> int:
         hltb = None
         row_id = f"epic-{el.get('namespace') or offer.get('namespace')}:{el.get('offerId') or offer.get('id')}"
         cached = existing.get(row_id)
+        if args.only_new and cached:
+            rows.append(cached)
+            continue
         if hltb_client and name:
             if cached and cached.get("hltb_main_hours") is not None:
                 hltb = {

--- a/fetchers/fetch_games.py
+++ b/fetchers/fetch_games.py
@@ -171,6 +171,7 @@ def _fetch_store_data(
     *,
     refresh: bool,
     cached_row: dict | None,
+    skip_reviews: bool = False,
 ) -> tuple[dict | None, dict | None]:
     """Return (details_data, reviews) from store APIs with cache fallback."""
     details_data: dict | None = None
@@ -179,7 +180,14 @@ def _fetch_store_data(
         app_result = steam.get_app_details(appid, refresh=refresh)
         if app_result and app_result.get("success"):
             details_data = app_result["data"]
-        reviews = steam.get_review_summary(appid, refresh=refresh)
+        if not skip_reviews:
+            reviews = steam.get_review_summary(appid, refresh=refresh)
+        elif cached_row:
+            reviews = {
+                "percent_positive": cached_row.get("steam_review_percent"),
+                "total_reviews": cached_row.get("steam_review_count"),
+                "review_score_desc": cached_row.get("steam_review_desc"),
+            }
     except requests.RequestException as exc:
         print(f"  Store API warning for {appid}: {exc}", flush=True)
         if cached_row:
@@ -264,6 +272,17 @@ def main() -> int:
     games_out: list[dict] = []
     skipped = 0
 
+    store_prefetch: list[int] = []
+    for owned in owned_games:
+        appid = owned["appid"]
+        if args.only_new and appid in existing and not args.refresh and not args.appid:
+            continue
+        cached_row = existing.get(appid)
+        if args.refresh or cached_row is None or args.appid:
+            store_prefetch.append(appid)
+    if store_prefetch:
+        steam.get_app_details_batch(store_prefetch, refresh=args.refresh)
+
     for i, owned in enumerate(owned_games, 1):
         appid = owned["appid"]
         name = owned.get("name", str(appid))
@@ -293,6 +312,7 @@ def main() -> int:
                 appid,
                 refresh=args.refresh,
                 cached_row=cached_row,
+                skip_reviews=args.only_new and not args.refresh and not args.appid,
             )
 
         hltb = None

--- a/fetchers/fetch_gog.py
+++ b/fetchers/fetch_gog.py
@@ -2,6 +2,7 @@
 """Fetch GOG library data and write games_gog.json for the dashboard."""
 
 import argparse
+import concurrent.futures
 import json
 import os
 import re
@@ -35,6 +36,7 @@ from fetchers._progress import EXIT_CODE_AUTH, RunStats, run_with_heartbeat, sta
 
 GAMES_GOG_JSON = Path("games_gog.json")
 HLTB_DELAY_SEC = 1.0
+GOG_WEB_DETAIL_WORKERS = 6
 LEGACY_ROW_SOURCE = "web"
 
 # Stable metadata that the other GOG source may have populated (web has release_date;
@@ -630,6 +632,33 @@ def main() -> int:
                 products = [{"id": args.gog_id, "title": f"GOG {args.gog_id}"}]
 
         skipped = 0
+        details_by_id: dict[int, dict | None] = {}
+        if source == "web":
+            detail_ids: list[int] = []
+            for product in products:
+                gog_id = int(product.get("id") or product.get("productId") or 0)
+                if args.only_new and gog_id in existing and not args.refresh and not args.gog_id:
+                    row = existing.get(gog_id)
+                    if row and _effective_row_source(row) == source:
+                        continue
+                cached_row = existing.get(gog_id)
+                if _needs_product_details(args, cached_row):
+                    detail_ids.append(gog_id)
+            if detail_ids:
+                def _fetch_detail(pid: int) -> tuple[int, dict | None]:
+                    try:
+                        return pid, gog.get_product_details(pid, refresh=args.refresh)
+                    except Exception:  # noqa: BLE001
+                        return pid, None
+
+                with concurrent.futures.ThreadPoolExecutor(
+                    max_workers=GOG_WEB_DETAIL_WORKERS
+                ) as ex:
+                    futures = [ex.submit(_fetch_detail, pid) for pid in detail_ids]
+                    for fut in concurrent.futures.as_completed(futures):
+                        pid, det = fut.result()
+                        details_by_id[pid] = det
+
         for i, product in enumerate(products, 1):
             gog_id = int(product.get("id") or product.get("productId") or 0)
             name = product.get("title") or product.get("name") or str(gog_id)
@@ -645,8 +674,13 @@ def main() -> int:
             cached_row = existing.get(gog_id)
 
             need_details = _needs_product_details(args, cached_row)
-            details = None
-            if need_details:
+            details = details_by_id.get(gog_id) if source == "web" else None
+            if need_details and details is None and source != "web":
+                try:
+                    details = gog.get_product_details(gog_id, refresh=args.refresh)
+                except Exception as e:
+                    print(f"  Details warning: {e}", flush=True)
+            elif need_details and source == "web" and gog_id not in details_by_id:
                 try:
                     details = gog.get_product_details(gog_id, refresh=args.refresh)
                 except Exception as e:

--- a/fetchers/fetch_gog_wishlist.py
+++ b/fetchers/fetch_gog_wishlist.py
@@ -25,7 +25,9 @@ from clients.gog_client import GogAuthError, GogClient
 from clients.hltb_client import HltbClient
 from fetchers._base import (
     add_allow_empty_arg,
+    add_only_new_arg,
     configure_stdout,
+    load_existing_games,
     refuse_drift_result,
     refuse_empty_result,
     write_catalog_text,
@@ -218,6 +220,7 @@ def main() -> int:
     parser.add_argument("--refresh", action="store_true", help="Ignore cached wishlist ID list")
     parser.add_argument("--country", default="US", help="GOG storefront country code (default US)")
     parser.add_argument("--hltb", action="store_true", help="Look up HLTB hours (slow)")
+    add_only_new_arg(parser)
     add_allow_empty_arg(parser)
     args = parser.parse_args()
     configure_stdout()
@@ -268,9 +271,14 @@ def main() -> int:
     session = requests.Session()
     session.headers["User-Agent"] = "steam-backlog/1.0"
     hltb = HltbClient() if args.hltb else None
+    existing = load_existing_games(GAMES_WISHLIST_GOG_JSON)
 
     rows: list[dict] = []
     for i, gog_id in enumerate(ids, 1):
+        cached = existing.get(str(gog_id))
+        if args.only_new and cached:
+            rows.append(cached)
+            continue
         print(f"[{i}/{len(ids)}] product {gog_id}", flush=True)
         product = _fetch_product(session, gog_id, args.country)
         time.sleep(GOG_PRODUCT_DELAY_SEC)

--- a/fetchers/fetch_humble.py
+++ b/fetchers/fetch_humble.py
@@ -31,6 +31,7 @@ from fetchers._authoritative import HUMBLE
 from fetchers._base import (
     add_allow_empty_arg,
     add_no_carry_arg,
+    add_only_new_arg,
     apply_carry_forward,
     catalog_file,
     configure_stdout,
@@ -324,6 +325,7 @@ def main() -> int:
         action="store_true",
         help="Accepted for manifest/dashboard parity; HLTB is off by default (use --hltb to enable)",
     )
+    add_only_new_arg(parser)
     parser.add_argument("--hltb", action="store_true", help="Look up HowLongToBeat hours (slow)")
     parser.add_argument(
         "--include-nongames",
@@ -381,10 +383,13 @@ def main() -> int:
     existing = _load_existing_by_machine()
     rows: list[dict] = []
     for i, item in enumerate(items, 1):
+        cached = existing.get(item.machine_name)
+        if args.only_new and cached:
+            rows.append(cached)
+            continue
         print(f"[{i}/{len(items)}] {item.name}", flush=True)
         hltb = None
         hltb_updated = False
-        cached = existing.get(item.machine_name)
         if hltb_client and item.name:
             if cached and cached.get("hltb_main_hours") is not None:
                 hltb = {

--- a/fetchers/fetch_humble_wishlist.py
+++ b/fetchers/fetch_humble_wishlist.py
@@ -29,6 +29,7 @@ from auth.secrets import profile_dir
 from clients.hltb_client import HltbClient
 from fetchers._base import (
     add_allow_empty_arg,
+    add_only_new_arg,
     catalog_file,
     configure_stdout,
     refuse_drift_result,
@@ -295,6 +296,7 @@ def main() -> int:
         description="Fetch Humble Store wishlist into games_wishlist_humble.json",
     )
     parser.add_argument("--hltb", action="store_true", help="Look up HowLongToBeat hours (slow)")
+    add_only_new_arg(parser)
     parser.add_argument(
         "--dump",
         action="store_true",
@@ -354,9 +356,12 @@ def main() -> int:
     rows: list[dict] = []
     for i, item in enumerate(items, 1):
         row_id = f"humble-{item.product_id}"
+        cached = existing.get(row_id)
+        if args.only_new and cached:
+            rows.append(cached)
+            continue
         print(f"[{i}/{len(items)}] {item.title}", flush=True)
         hltb = None
-        cached = existing.get(row_id)
         if hltb_client and item.title:
             if cached and cached.get("hltb_main_hours") is not None:
                 hltb = {

--- a/fetchers/fetch_nintendo.py
+++ b/fetchers/fetch_nintendo.py
@@ -26,6 +26,7 @@ from fetchers._authoritative import NINTENDO
 from fetchers._base import (
     add_allow_empty_arg,
     add_no_carry_arg,
+    add_only_new_arg,
     apply_carry_forward,
     catalog_file,
     configure_stdout,
@@ -185,6 +186,7 @@ def _nintendo_connected() -> bool:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Fetch Nintendo eShop purchase history")
     parser.add_argument("--skip-hltb", action="store_true")
+    add_only_new_arg(parser)
     add_allow_empty_arg(parser)
     add_no_carry_arg(parser)
     parser.add_argument(
@@ -270,8 +272,11 @@ def main() -> int:
     existing = load_existing()
     games_out: list[dict] = []
     for i, item in enumerate(merged, 1):
-        print(f"[{i}/{len(merged)}] {item['name']}")
         cached = existing.get(str(item["id"]))
+        if args.only_new and cached:
+            games_out.append(cached)
+            continue
+        print(f"[{i}/{len(merged)}] {item['name']}")
         hltb = None
         hltb_updated = False
         if not args.skip_hltb:

--- a/fetchers/fetch_nintendo_wishlist.py
+++ b/fetchers/fetch_nintendo_wishlist.py
@@ -34,6 +34,7 @@ from auth.secrets import profile_dir
 from clients.hltb_client import HltbClient
 from fetchers._base import (
     add_allow_empty_arg,
+    add_only_new_arg,
     catalog_file,
     configure_stdout,
     refuse_drift_result,
@@ -1085,6 +1086,7 @@ def main() -> int:
         description="Fetch Nintendo.com wish list into games_wishlist_nintendo.json",
     )
     parser.add_argument("--hltb", action="store_true", help="Look up HowLongToBeat hours (slow)")
+    add_only_new_arg(parser)
     parser.add_argument(
         "--dump",
         action="store_true",
@@ -1209,9 +1211,12 @@ def main() -> int:
 
     for i, item in enumerate(items, 1):
         row_id = f"nintendo-{item.product_id}"
+        cached = existing.get(row_id)
+        if args.only_new and cached:
+            rows.append(cached)
+            continue
         print(f"[{i}/{len(items)}] {item.title}", flush=True)
         hltb = None
-        cached = existing.get(row_id)
         if hltb_client and item.title:
             if cached and cached.get("hltb_main_hours") is not None:
                 hltb = {

--- a/fetchers/fetch_psn.py
+++ b/fetchers/fetch_psn.py
@@ -125,20 +125,68 @@ def main() -> int:
 
     hltb_client = HltbClient()
     existing = load_existing()
+    prev_meta: dict = {}
+    if catalog_file(GAMES_PSN_JSON).exists():
+        try:
+            prev_meta = json.loads(catalog_file(GAMES_PSN_JSON).read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            prev_meta = {}
 
     print(f"Fetching PSN library for {online_id}...")
-    try:
-        library = psn.collect_library()
-    except PsnAuthError as exc:
-        mark_invalid("psn", error=str(exc))
-        stats.error(str(exc))
-        return stats.finish("fetch_psn", t0, exit_code=EXIT_CODE_AUTH)
+    library: list | None = None
+    if (
+        args.only_new
+        and not args.refresh
+        and not args.psn_id
+        and existing
+        and prev_meta.get("title_stats_count") is not None
+    ):
+        try:
+            probe_count, probe_max = psn.probe_library_fingerprint()
+        except PsnAuthError as exc:
+            mark_invalid("psn", error=str(exc))
+            stats.error(str(exc))
+            return stats.finish("fetch_psn", t0, exit_code=EXIT_CODE_AUTH)
+        if (
+            probe_count == prev_meta.get("title_stats_count")
+            and probe_max == prev_meta.get("max_last_played")
+        ):
+            print(
+                "PSN library fingerprint unchanged — skipping full collect.",
+                flush=True,
+            )
+            library = []
+
+    if library is None:
+        try:
+            library = psn.collect_library()
+        except PsnAuthError as exc:
+            mark_invalid("psn", error=str(exc))
+            stats.error(str(exc))
+            return stats.finish("fetch_psn", t0, exit_code=EXIT_CODE_AUTH)
 
     if args.psn_id:
         library = [entry for entry in library if entry.id == args.psn_id]
         if not library:
             stats.error(f"No PSN title found with id {args.psn_id!r}.")
             return stats.finish("fetch_psn", t0, exit_code=1)
+    elif not library and args.only_new and not args.refresh and existing:
+        games_out = sorted(existing.values(), key=lambda g: g["name"].lower())
+        payload = {
+            "fetched_at": datetime.now(UTC).isoformat(),
+            "store": "psn",
+            "online_id": online_id,
+            "game_count": len(games_out),
+            "title_stats_count": prev_meta.get("title_stats_count"),
+            "trophy_count": prev_meta.get("trophy_count"),
+            "entitlement_count": prev_meta.get("entitlement_count"),
+            "max_last_played": prev_meta.get("max_last_played"),
+            "games": games_out,
+        }
+        write_catalog_text(GAMES_PSN_JSON, json.dumps(payload, indent=2, ensure_ascii=False))
+        print(f"\nWrote {len(games_out)} games to {GAMES_PSN_JSON} (unchanged).", flush=True)
+        stats.ok = len(games_out)
+        return stats.finish("fetch_psn", t0, exit_code=0, extra=f"{len(games_out)} games")
     else:
         empty_exit = refuse_empty_result(
             library,
@@ -229,6 +277,13 @@ def main() -> int:
         "store": "psn",
         "online_id": online_id,
         "game_count": len(games_out),
+        "title_stats_count": getattr(psn, "last_title_stats_count", None),
+        "trophy_count": getattr(psn, "last_trophy_count", None),
+        "entitlement_count": getattr(psn, "last_entitlement_count", None),
+        "max_last_played": max(
+            (g.get("last_played") for g in games_out if g.get("last_played")),
+            default=None,
+        ),
         "games": sorted(games_out, key=lambda g: g["name"].lower()),
     }
 

--- a/fetchers/fetch_psn_wishlist.py
+++ b/fetchers/fetch_psn_wishlist.py
@@ -26,6 +26,7 @@ from clients.hltb_client import HltbClient
 from clients.psn_client import PsnAuthError, PsnClient, PsnWishlistEntry
 from fetchers._base import (
     add_allow_empty_arg,
+    add_only_new_arg,
     catalog_file,
     configure_stdout,
     refuse_drift_result,
@@ -100,6 +101,7 @@ def _load_existing() -> dict[str, dict]:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Fetch PSN wishlist into games_wishlist_psn.json")
     parser.add_argument("--hltb", action="store_true", help="Look up HowLongToBeat hours (slow)")
+    add_only_new_arg(parser)
     add_allow_empty_arg(parser)
     args = parser.parse_args()
     configure_stdout()
@@ -161,9 +163,12 @@ def main() -> int:
 
     for i, entry in enumerate(items, 1):
         row_id = f"psn-{entry.id}"
+        cached = existing.get(row_id)
+        if args.only_new and cached:
+            rows.append(cached)
+            continue
         print(f"[{i}/{len(items)}] {entry.name}")
         hltb = None
-        cached = existing.get(row_id)
         if hltb_client:
             if cached and cached.get("hltb_main_hours") is not None:
                 hltb = {

--- a/fetchers/fetch_ubisoft.py
+++ b/fetchers/fetch_ubisoft.py
@@ -19,6 +19,7 @@ from fetchers._authoritative import UBISOFT
 from fetchers._base import (
     add_allow_empty_arg,
     add_no_carry_arg,
+    add_only_new_arg,
     apply_carry_forward,
     catalog_file,
     configure_stdout,
@@ -271,6 +272,7 @@ def _build_row(item: dict, hltb: dict | None) -> dict:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Fetch Ubisoft Connect library (unofficial)")
     parser.add_argument("--skip-hltb", action="store_true")
+    add_only_new_arg(parser)
     add_allow_empty_arg(parser)
     add_no_carry_arg(parser)
     parser.add_argument(
@@ -344,8 +346,12 @@ def main() -> int:
     games_out: list[dict] = []
     for i, item in enumerate(deduped, 1):
         name = _name_of(item)
+        row_id = _id_of(item, name or "")
+        cached = existing.get(row_id)
+        if args.only_new and cached:
+            games_out.append(cached)
+            continue
         print(f"[{i}/{len(deduped)}] {name}")
-        cached = existing.get(_id_of(item, name or ""))
         hltb = None
         hltb_updated = False
         if not args.skip_hltb:

--- a/fetchers/fetch_ubisoft_wishlist.py
+++ b/fetchers/fetch_ubisoft_wishlist.py
@@ -33,6 +33,7 @@ from auth.secrets import profile_dir
 from clients.hltb_client import HltbClient
 from fetchers._base import (
     add_allow_empty_arg,
+    add_only_new_arg,
     catalog_file,
     configure_stdout,
     refuse_drift_result,
@@ -318,6 +319,7 @@ def main() -> int:
         description="Fetch Ubisoft Store wishlist into games_wishlist_ubisoft.json",
     )
     parser.add_argument("--hltb", action="store_true", help="Look up HowLongToBeat hours (slow)")
+    add_only_new_arg(parser)
     parser.add_argument(
         "--include-dlc",
         action="store_true",
@@ -388,9 +390,12 @@ def main() -> int:
 
     for i, item in enumerate(kept, 1):
         row_id = f"ubisoft-{item.store_id}"
+        cached = existing.get(row_id)
+        if args.only_new and cached:
+            rows.append(cached)
+            continue
         print(f"[{i}/{len(kept)}] {item.name}", flush=True)
         hltb = None
-        cached = existing.get(row_id)
         if hltb_client and item.name:
             if cached and cached.get("hltb_main_hours") is not None:
                 hltb = {

--- a/fetchers/fetch_wishlist.py
+++ b/fetchers/fetch_wishlist.py
@@ -16,7 +16,9 @@ from clients.steam_client import SteamClient
 from fetchers._base import (
     STEAM_CREDENTIALS_HINT,
     add_allow_empty_arg,
+    add_only_new_arg,
     configure_stdout,
+    load_existing_games,
     refuse_drift_result,
     refuse_empty_result,
     write_catalog_text,
@@ -44,6 +46,7 @@ def fetch_wishlist_items(api_key: str, steam_id: str) -> list[dict]:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Fetch Steam wishlist")
     parser.add_argument("--skip-hltb", action="store_true")
+    add_only_new_arg(parser)
     add_allow_empty_arg(parser)
     args = parser.parse_args()
     configure_stdout()
@@ -80,11 +83,15 @@ def main() -> int:
     print(f"Found {len(items)} wishlist items.")
     steam = SteamClient(api_key, steam_id)
     hltb = HltbClient()
+    existing = load_existing_games(GAMES_WISHLIST_JSON)
     games_out: list[dict] = []
 
     for i, item in enumerate(items, 1):
         appid = int(item.get("appid") or item.get("app_id") or 0)
         if not appid:
+            continue
+        if args.only_new and str(appid) in existing:
+            games_out.append(existing[str(appid)])
             continue
         print(f"[{i}/{len(items)}] appid {appid}")
 

--- a/fetchers/fetch_xbox.py
+++ b/fetchers/fetch_xbox.py
@@ -19,6 +19,7 @@ from fetchers._authoritative import XBOX
 from fetchers._base import (
     add_allow_empty_arg,
     add_no_carry_arg,
+    add_only_new_arg,
     apply_carry_forward,
     catalog_file,
     configure_stdout,
@@ -116,6 +117,7 @@ def _build_row(title: dict, hltb: dict | None) -> dict:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Fetch Xbox library via OpenXBL")
     parser.add_argument("--skip-hltb", action="store_true")
+    add_only_new_arg(parser)
     add_allow_empty_arg(parser)
     add_no_carry_arg(parser)
     args = parser.parse_args()
@@ -172,8 +174,12 @@ def main() -> int:
     for i, title in enumerate(games, 1):
         name = title.get("name") or tid_placeholder(title)
         tid = str(title.get("titleId") or title.get("modernTitleId") or "")
-        print(f"[{i}/{len(games)}] {name}", flush=True)
         cached = existing.get(tid)
+        if args.only_new and cached:
+            games_out.append(cached)
+            stats.ok += 1
+            continue
+        print(f"[{i}/{len(games)}] {name}", flush=True)
         hltb = None
         hltb_updated = False
         if not args.skip_hltb:

--- a/fetchers/fetch_xbox_wishlist.py
+++ b/fetchers/fetch_xbox_wishlist.py
@@ -45,6 +45,7 @@ from auth.xbox_wishlist_session import (
 from clients.hltb_client import HltbClient
 from fetchers._base import (
     add_allow_empty_arg,
+    add_only_new_arg,
     catalog_file,
     configure_stdout,
     refuse_drift_result,
@@ -405,6 +406,7 @@ def main() -> int:
         description="Fetch Xbox Store wishlist into games_wishlist_xbox.json",
     )
     parser.add_argument("--hltb", action="store_true", help="Look up HowLongToBeat hours (slow)")
+    add_only_new_arg(parser)
     parser.add_argument(
         "--dump-state",
         action="store_true",
@@ -523,9 +525,12 @@ def main() -> int:
 
     for i, item in enumerate(items, 1):
         row_id = f"xbox-{item.product_id}"
+        cached = existing.get(row_id)
+        if args.only_new and cached:
+            rows.append(cached)
+            continue
         print(f"[{i}/{len(items)}] {item.title}", flush=True)
         hltb = None
-        cached = existing.get(row_id)
         if hltb_client and item.title:
             if cached and cached.get("hltb_main_hours") is not None:
                 hltb = {

--- a/fetchers/manifest.json
+++ b/fetchers/manifest.json
@@ -6,7 +6,8 @@
       "group": "library",
       "script": "fetchers/fetch_games.py",
       "args": [
-        "--skip-hltb"
+        "--skip-hltb",
+        "--only-new"
       ],
       "refreshArgs": [
         "--refresh"
@@ -30,7 +31,8 @@
       "group": "library",
       "script": "fetchers/fetch_gog.py",
       "args": [
-        "--skip-hltb"
+        "--skip-hltb",
+        "--only-new"
       ],
       "refreshArgs": [
         "--refresh"
@@ -45,7 +47,8 @@
       "group": "library",
       "script": "fetchers/fetch_psn.py",
       "args": [
-        "--skip-hltb"
+        "--skip-hltb",
+        "--only-new"
       ],
       "refreshArgs": [
         "--refresh"
@@ -65,7 +68,8 @@
       "group": "library",
       "script": "fetchers/fetch_epic.py",
       "args": [
-        "--skip-hltb"
+        "--skip-hltb",
+        "--only-new"
       ],
       "refreshArgs": [
         "--refresh"
@@ -85,7 +89,8 @@
       "group": "library",
       "script": "fetchers/fetch_amazon.py",
       "args": [
-        "--skip-hltb"
+        "--skip-hltb",
+        "--only-new"
       ],
       "metaKey": "amazon",
       "color": "#c2410c",
@@ -97,7 +102,8 @@
       "group": "library",
       "script": "fetchers/fetch_xbox.py",
       "args": [
-        "--skip-hltb"
+        "--skip-hltb",
+        "--only-new"
       ],
       "metaKey": "xbox",
       "color": "#107C10",
@@ -114,7 +120,8 @@
       "group": "library",
       "script": "fetchers/fetch_battlenet.py",
       "args": [
-        "--skip-hltb"
+        "--skip-hltb",
+        "--only-new"
       ],
       "metaKey": "battlenet",
       "color": "#148EFF",
@@ -131,7 +138,8 @@
       "group": "library",
       "script": "fetchers/fetch_ubisoft.py",
       "args": [
-        "--skip-hltb"
+        "--skip-hltb",
+        "--only-new"
       ],
       "metaKey": "ubisoft",
       "color": "#FFD200",
@@ -152,7 +160,8 @@
       "group": "library",
       "script": "fetchers/fetch_nintendo.py",
       "args": [
-        "--skip-hltb"
+        "--skip-hltb",
+        "--only-new"
       ],
       "metaKey": "nintendo",
       "color": "#E60012",
@@ -169,7 +178,8 @@
       "group": "library",
       "script": "fetchers/fetch_itch.py",
       "args": [
-        "--skip-hltb"
+        "--skip-hltb",
+        "--only-new"
       ],
       "metaKey": "itch",
       "color": "#fa5c5c",
@@ -186,7 +196,8 @@
       "group": "library",
       "script": "fetchers/fetch_humble.py",
       "args": [
-        "--skip-hltb"
+        "--skip-hltb",
+        "--only-new"
       ],
       "metaKey": "humble",
       "color": "#cc2929",
@@ -202,7 +213,8 @@
       "group": "library",
       "script": "fetchers/fetch_ea.py",
       "args": [
-        "--skip-hltb"
+        "--skip-hltb",
+        "--only-new"
       ],
       "metaKey": "ea",
       "color": "#FF4747",
@@ -218,7 +230,8 @@
       "group": "wishlist",
       "script": "fetchers/fetch_wishlist.py",
       "args": [
-        "--skip-hltb"
+        "--skip-hltb",
+        "--only-new"
       ],
       "metaKey": "wishlist",
       "color": "#ea580c",
@@ -238,6 +251,9 @@
       "label": "WL GOG",
       "group": "wishlist",
       "script": "fetchers/fetch_gog_wishlist.py",
+      "args": [
+        "--only-new"
+      ],
       "refreshArgs": [
         "--refresh"
       ],
@@ -255,6 +271,9 @@
       "label": "WL Epic",
       "group": "wishlist",
       "script": "fetchers/fetch_epic_wishlist.py",
+      "args": [
+        "--only-new"
+      ],
       "metaKey": "wishlistEpic",
       "color": "#64748b",
       "requires": [
@@ -268,6 +287,9 @@
       "label": "WL PSN",
       "group": "wishlist",
       "script": "fetchers/fetch_psn_wishlist.py",
+      "args": [
+        "--only-new"
+      ],
       "metaKey": "wishlistPsn",
       "color": "#003791",
       "requires": [
@@ -282,6 +304,9 @@
       "label": "WL Ubisoft",
       "group": "wishlist",
       "script": "fetchers/fetch_ubisoft_wishlist.py",
+      "args": [
+        "--only-new"
+      ],
       "metaKey": "wishlistUbisoft",
       "color": "#FFD200",
       "requires": [
@@ -295,6 +320,9 @@
       "label": "WL Xbox",
       "group": "wishlist",
       "script": "fetchers/fetch_xbox_wishlist.py",
+      "args": [
+        "--only-new"
+      ],
       "metaKey": "wishlistXbox",
       "color": "#107C10",
       "requires": [
@@ -308,6 +336,9 @@
       "label": "WL Nintendo",
       "group": "wishlist",
       "script": "fetchers/fetch_nintendo_wishlist.py",
+      "args": [
+        "--only-new"
+      ],
       "metaKey": "wishlistNintendo",
       "color": "#E60012",
       "requires": [
@@ -321,6 +352,9 @@
       "label": "WL Humble",
       "group": "wishlist",
       "script": "fetchers/fetch_humble_wishlist.py",
+      "args": [
+        "--only-new"
+      ],
       "metaKey": "wishlistHumble",
       "color": "#cc2929",
       "requires": [

--- a/guide/troubleshooting.md
+++ b/guide/troubleshooting.md
@@ -14,6 +14,25 @@ Common problems when connecting stores, running fetchers, or launching BAKLOG.
 
 Sessions expire on different schedules per store. Epic wishlist, Nintendo, and cookie-based stores tend to need refresh more often than API-key stores like Steam.
 
+## Connect saved, fetch still fails
+
+**Symptom:** Connections shows **Connected**, but the fetcher exits `4` or logs auth/capture errors.
+
+**Cause:** Connect and fetch use different checks. Connect saves cookies or a Bearer token from the sign-in browser; fetch replays that session against the store API. A connect can succeed while the token is missing, stale, or rejected on the first library call.
+
+**Fix by store:**
+
+| Store | After Connect | If fetch still fails |
+|-------|---------------|----------------------|
+| **EA App** | Stay on **ea.com/sales/deals** until the window closes on its own | **Reconnect** (do not close early). Run `fetch_ea.py --headed --dump-debug` and check `cache/ea/fetch_debug.json` for token capture. |
+| **GOG (web)** | Sign in at gog.com; wait for auto-close | Reconnect, or use `fetch_gog.py --source local` with Galaxy on Windows/macOS. |
+| **Battle.net** | Open **account.battle.net/games** until your library list loads | Reconnect; on Windows Edge v127+ use Connect (not `--browser edge` jar read) or paste `BATTLENET_COOKIE` in `.env`. |
+| **Humble** | Complete sign-in and any CAPTCHA on the library page | Reconnect with the library URL open. |
+| **Epic wishlist** | Finish Epic login; use manual code paste if the redirect fails | Reconnect with **Fresh** if the profile is stuck. |
+| **Xbox wishlist** | Complete Microsoft login in the headed window | Reconnect; advisory probe may show connected before wishlist fetch works. |
+
+**General:** Use **Reconnect** (fresh profile clear when the store allows it), complete the full headed flow, then retry from Fetcher health.
+
 ## Suspicious empty result (exit code 2)
 
 **Symptom:** Fetcher refuses to write an empty file; log mentions exit `2`.

--- a/js/auth-gate.js
+++ b/js/auth-gate.js
@@ -32,6 +32,7 @@ let _accountProfileId = '';
 let _localProfiles = false;
 let _plan = 'free';
 let _licenseActivation = false;
+let _proCheckoutEnabled = false;
 let _proCheckout = { monthly: '', yearly: '' };
 
 const DEBUG_PRO_STORAGE_KEY = 'baklog-debug-pro';
@@ -148,6 +149,7 @@ function applyConfigEntitlement(config) {
   if (!config || typeof config !== 'object') return;
   if (typeof config.plan === 'string' && config.plan) _plan = config.plan;
   _licenseActivation = !!config.licenseActivation;
+  _proCheckoutEnabled = !!config.proCheckoutEnabled;
   const checkout = config.proCheckout;
   _proCheckout = {
     monthly: checkout?.monthly || '',
@@ -159,6 +161,10 @@ export function licenseActivationEnabled() {
   return _licenseActivation;
 }
 
+export function proCheckoutEnabled() {
+  return _proCheckoutEnabled;
+}
+
 export function proCheckoutUrls() {
   return { ..._proCheckout };
 }
@@ -167,6 +173,7 @@ export function proCheckoutUrls() {
 export async function refreshAccountPlan() {
   try {
     if (_authRequired && _accessToken) {
+      await refreshAccessToken();
       const res = await fetch('/api/auth/session', {
         headers: { Authorization: `Bearer ${_accessToken}` },
       });

--- a/js/connections-status.js
+++ b/js/connections-status.js
@@ -61,13 +61,20 @@ export function isItchSetup() {
   return providerStatus('itch_local') === 'connected';
 }
 
-/** itch.io tab: show once API key is saved or local app is enabled on this profile. */
+/** True when a previously fetched itch catalog is still on disk in this profile. */
+export function hasCachedItchLibrary() {
+  const rows = state.itchGames;
+  if (Array.isArray(rows) && rows.length > 0) return true;
+  const cached = state.libraryMeta?.itch?.games;
+  return Array.isArray(cached) && cached.length > 0;
+}
+
+/** itch.io tab: connected setup or a cached library worth browsing. */
 export function isItchTabAvailable() {
-  return isItchSetup();
+  return isItchSetup() || hasCachedItchLibrary();
 }
 
 /** itch rows surfaced in tables, summary chips, and dashboard recap. */
 export function visibleItchGames() {
-  if (!isItchSetup()) return [];
   return Array.isArray(state.itchGames) ? state.itchGames : [];
 }

--- a/js/connections.js
+++ b/js/connections.js
@@ -37,15 +37,15 @@ let _chromiumAvailable = true;
 const LOCAL_PROVIDER_FOOTER = {
   amazon: {
     connected: 'Auto-detected from Amazon Games launcher',
-    disconnected: 'Launcher library hidden - Connect to use it again, or use Prime web',
+    disconnected: 'Disconnected - cached library stays visible. Connect to refresh, or use Prime web',
   },
   gog_galaxy: {
     connected: 'Auto-detected from GOG Galaxy on this PC',
-    disconnected: 'Galaxy library hidden - Connect to use it again, or use GOG (web)',
+    disconnected: 'Disconnected - cached library stays visible. Connect to refresh, or use GOG (web)',
   },
   itch_local: {
     connected: 'Auto-detected from the itch desktop app',
-    disconnected: 'Local itch library hidden - Connect to use it again, or use an API key',
+    disconnected: 'Disconnected - cached library stays visible. Connect to refresh, or use an API key',
   },
 };
 

--- a/js/fetcher-health.js
+++ b/js/fetcher-health.js
@@ -394,6 +394,29 @@ async function handleFetcherAuthOutcome(key, data, logText) {
 
 const FRESH_THRESHOLDS = { fresh: 7 * 86400000, recent: 30 * 86400000 };
 // ITAD is a deal feed — library-style 7d/30d thresholds are misleading.
+const STALE_SWEEP_ORDER = {
+  itch: 10,
+  gog: 20,
+  xbox: 30,
+  amazon: 40,
+  epic: 50,
+  psn: 60,
+  steam: 70,
+  humble: 80,
+  battlenet: 90,
+  ubisoft: 100,
+  nintendo: 110,
+  ea: 120,
+  hltb: 200,
+  steamReviews: 210,
+  steamCovers: 220,
+  steamTags: 230,
+  protondb: 240,
+};
+
+function staleSweepRank(key) {
+  return STALE_SWEEP_ORDER[key] ?? 150;
+}
 const STALE_OVERRIDES = {
   itad: { fresh: 60 * 60_000, recent: 6 * 60 * 60_000 },
   claims: { fresh: 60 * 60_000, recent: 6 * 60 * 60_000 },
@@ -1251,6 +1274,8 @@ export const fetcherRunner = (() => {
   let inFlightPollTimer = null;
   /** True when the last /api/runs snapshot had active or queued rows (server truth). */
   let lastServerInFlight = false;
+  let lastFetcherLaneInFlight = false;
+  let lastEnrichLaneInFlight = false;
   /** Signature (active run id + line count + queue depth) of the last in-flight snapshot. */
   let lastInFlightSig = '';
   /**
@@ -1333,12 +1358,17 @@ export const fetcherRunner = (() => {
   function applyServerSnapshotInFlight(snap) {
     const blockingActive = runBlocksQueueSlot(snap?.active) ? snap.active : null;
     const blockingQueue = (snap?.queue || []).filter(runBlocksQueueSlot);
-    lastServerInFlight = !!(blockingActive || blockingQueue.length);
-    const queueLen = blockingQueue.length;
+    const enrichActive = runBlocksQueueSlot(snap?.enrich_active) ? snap.enrich_active : null;
+    const enrichQueue = (snap?.enrich_queue || []).filter(runBlocksQueueSlot);
+    lastFetcherLaneInFlight = !!(blockingActive || blockingQueue.length);
+    lastEnrichLaneInFlight = !!(enrichActive || enrichQueue.length);
+    lastServerInFlight = lastFetcherLaneInFlight || lastEnrichLaneInFlight;
+    const queueLen = blockingQueue.length + enrichQueue.length;
+    const blockingRun = blockingActive || enrichActive;
     // line_count grows on every emitted line (heartbeats included), so the
     // signature changes while a run is alive; a frozen run keeps it stable.
-    const sig = blockingActive
-      ? `${blockingActive.id || blockingActive.key || 'run'}:${blockingActive.line_count ?? 0}:${queueLen}`
+    const sig = blockingRun
+      ? `${blockingRun.id || blockingRun.key || 'run'}:${blockingRun.line_count ?? 0}:${queueLen}`
       : (lastServerInFlight ? `q:${queueLen}` : '');
     if (sig && sig !== lastInFlightSig) {
       inFlightProgressAt = Date.now();
@@ -1870,16 +1900,29 @@ export const fetcherRunner = (() => {
   function inFlightCount() {
     return runStateByKey.size;
   }
+  function isEnrichKey(key) {
+    return source(key)?.group === 'enrich';
+  }
+  function isQueueFullForKey(key) {
+    const enrich = isEnrichKey(key);
+    const laneBusy = enrich ? lastEnrichLaneInFlight : lastFetcherLaneInFlight;
+    if (laneBusy) return true;
+    for (const [k] of runStateByKey) {
+      if (isEnrichKey(k) === enrich) return true;
+    }
+    return false;
+  }
   function isQueueFull() {
     return inFlightCount() >= MAX_IN_FLIGHT || lastServerInFlight;
   }
   const WAIT_QUEUE_SNAPSHOT_POLL_MS = 2000;
-  function waitForQueueSlot({ batchEpoch } = {}) {
+  function waitForQueueSlot({ batchEpoch, key } = {}) {
     if (batchEpoch !== undefined && getCancelEpoch() !== batchEpoch) {
       return Promise.reject(new Error('cancelled'));
     }
     if (cancelInFlight) return Promise.reject(new Error('cancelled'));
-    if (!isQueueFull()) return Promise.resolve();
+    if (key && !isQueueFullForKey(key)) return Promise.resolve();
+    if (!key && !isQueueFull()) return Promise.resolve();
     // Deadline base is the later of wait-start and the last observed progress;
     // it slides forward as the active run advances (see inFlightProgressAt).
     let progressDeadlineBase = Date.now();
@@ -1895,7 +1938,7 @@ export const fetcherRunner = (() => {
           reject(new Error('cancelled'));
           return;
         }
-        if (!isQueueFull()) {
+        if (key ? !isQueueFullForKey(key) : !isQueueFull()) {
           resolve();
           return;
         }
@@ -1912,7 +1955,7 @@ export const fetcherRunner = (() => {
           void fetchRunsSnapshot({ force: true })
             .then((snap) => {
               if (snap) applyServerSnapshotInFlight(snap);
-              if (!isQueueFull()) resolve();
+              if (key ? !isQueueFullForKey(key) : !isQueueFull()) resolve();
               else schedule(200);
             })
             .catch(() => schedule(200));
@@ -2468,7 +2511,7 @@ export const fetcherRunner = (() => {
     // Hard cap mirrors server-side enforcement (max 1 active run, no queuing).
     // Without this guard a fast double-click could land two POSTs before the
     // server's lock saw the first one as pending.
-    if (isQueueFull()) {
+    if (isQueueFullForKey(key)) {
       if (!auto) {
         ensurePanel(src);
         logEvent(
@@ -2529,7 +2572,7 @@ export const fetcherRunner = (() => {
         attempt === 0
         && !cancelInFlight
         && !runStateByKey.has(key)
-        && !isQueueFull();
+        && !isQueueFullForKey(key);
       if (!canRetry) return false;
       await new Promise(r => setTimeout(r, 600));
       }
@@ -2582,7 +2625,8 @@ export const fetcherRunner = (() => {
         cooldownMs: authCooldownRemainingMs(src.key),
         disconnected: isFetcherDisconnected(src.key),
       }))
-      .map(src => src.key);
+      .map(src => src.key)
+      .sort((a, b) => staleSweepRank(a) - staleSweepRank(b));
     if (!staleKeys.length) return;
     const batchEpoch = getCancelEpoch();
     // Respect the global cap. Wait for an open slot between submits so we
@@ -2594,7 +2638,7 @@ export const fetcherRunner = (() => {
         break;
       }
       try {
-        await waitForQueueSlot({ batchEpoch });
+        await waitForQueueSlot({ batchEpoch, key });
         if (getCancelEpoch() !== batchEpoch) {
           logEvent('info', '[run stale aborted: cancelled]');
           break;
@@ -2951,6 +2995,7 @@ export const fetcherRunner = (() => {
     stateFor,
     inFlightCount,
     isQueueFull,
+    isQueueFullForKey,
     waitForQueueSlot,
     run,
     runAllStale,
@@ -3281,7 +3326,7 @@ export function renderDashboardFetcherHealth() {
           configHint ? `Note:${configHint}` : '',
           'Server is offline - start `python server.py` to run fetchers from the UI.',
         ].filter(Boolean);
-    const queueFullElsewhere = fetcherRunner.isQueueFull() && !runState;
+    const queueFullElsewhere = fetcherRunner.isQueueFullForKey(src.key) && !runState;
     if (queueFullElsewhere) {
       titleLines.push('Queue full - a fetch is already running. Wait for it to finish.');
     }

--- a/js/fetcher-health.js
+++ b/js/fetcher-health.js
@@ -2079,7 +2079,7 @@ export const fetcherRunner = (() => {
     } else {
       btn.disabled = !show;
       btn.textContent = 'Cancel';
-      btn.title = 'Stop all queued and running fetchers (Shift+click: force reset queue)';
+      btn.title = 'Stop all queued and running fetchers and enrichers (Shift+click: force reset queue)';
     }
   }
 
@@ -2110,7 +2110,9 @@ export const fetcherRunner = (() => {
       for (const id of [...pending]) {
         const onActive = snap.active?.id === id;
         const onQueue = (snap.queue || []).some(r => r.id === id);
-        if (!onActive && !onQueue) {
+        const onEnrichActive = snap.enrich_active?.id === id;
+        const onEnrichQueue = (snap.enrich_queue || []).some(r => r.id === id);
+        if (!onActive && !onQueue && !onEnrichActive && !onEnrichQueue) {
           const hist = (snap.history || []).find(r => r.id === id);
           if (hist && ['done', 'failed', 'cancelled'].includes(hist.status)) {
             pending.delete(id);
@@ -2129,6 +2131,8 @@ export const fetcherRunner = (() => {
     for (const key of [...runStateByKey.keys()]) markChipState(key, null);
     liveRunId = null;
     lastServerInFlight = false;
+    lastFetcherLaneInFlight = false;
+    lastEnrichLaneInFlight = false;
     logEvent(
       'info',
       force ? '[force reset - queue cleared locally]' : '[cancelled]',
@@ -2140,28 +2144,43 @@ export const fetcherRunner = (() => {
     updateCancelButton();
   }
 
+  async function cancelServerLane(lane, { force = false } = {}) {
+    const qs = force ? `?lane=${lane}&force=1` : `?lane=${lane}`;
+    try {
+      const res = await fetchWithTimeoutAndProbe(
+        `/api/runs/cancel${qs}`,
+        { method: 'POST' },
+        CANCEL_HTTP_MS,
+      );
+      if (!res.ok) return 0;
+      const data = await res.json();
+      return data.cancelled?.length ?? 0;
+    } catch (_) {
+      return 0;
+    }
+  }
+
   function reconcileCancelInBackground(ids, { force = false } = {}) {
     void (async () => {
-      // Dashboard Cancel is fetcher-lane only — never kill admin (internal)
-      // jobs like buildClaims/claimSources running in parallel.
-      const cancelUrl = force
-        ? '/api/runs/cancel?lane=fetcher&force=1'
-        : '/api/runs/cancel?lane=fetcher';
+      // Dashboard Cancel clears fetcher + enrich lanes only — never kill admin
+      // (internal) jobs like buildClaims/claimSources running in parallel.
       let bulkOk = false;
-      try {
-        const res = await fetchWithTimeoutAndProbe(cancelUrl, { method: 'POST' }, CANCEL_HTTP_MS);
-        if (res.ok) {
+      let cancelledTotal = 0;
+      for (const lane of ['fetcher', 'enrich']) {
+        const n = await cancelServerLane(lane, { force });
+        if (n > 0) {
           bulkOk = true;
-          const data = await res.json();
-          const n = data.cancelled?.length ?? 0;
-          if (n) {
-            logEvent(
-              'info',
-              force ? `[server force reset: ${n} run(s)]` : `[server cancelled ${n} run(s)]`,
-            );
-          }
+          cancelledTotal += n;
         }
-      } catch (_) {}
+      }
+      if (cancelledTotal) {
+        logEvent(
+          'info',
+          force
+            ? `[server force reset: ${cancelledTotal} run(s)]`
+            : `[server cancelled ${cancelledTotal} run(s)]`,
+        );
+      }
       if (!bulkOk && ids.length) {
         for (const id of ids) {
           await cancelOneRun(id);
@@ -2200,6 +2219,8 @@ export const fetcherRunner = (() => {
       applyServerSnapshotInFlight(snap);
       if (snap?.active) ids.push(snap.active.id);
       for (const q of snap?.queue || []) ids.push(q.id);
+      if (snap?.enrich_active) ids.push(snap.enrich_active.id);
+      for (const q of snap?.enrich_queue || []) ids.push(q.id);
       const clientStale = inFlightCount() > 0;
       if (!ids.length && !force && !clientStale && !lastServerInFlight) {
         return;
@@ -2220,6 +2241,10 @@ export const fetcherRunner = (() => {
     const inFlightKeys = new Set();
     if (snap.active?.key) inFlightKeys.add(snap.active.key);
     for (const q of snap.queue || []) {
+      if (q.key) inFlightKeys.add(q.key);
+    }
+    if (snap.enrich_active?.key) inFlightKeys.add(snap.enrich_active.key);
+    for (const q of snap.enrich_queue || []) {
       if (q.key) inFlightKeys.add(q.key);
     }
     const historyByKey = new Map();

--- a/js/library-load.js
+++ b/js/library-load.js
@@ -390,6 +390,11 @@ export async function fetchLibraryJson(path) {
   return res.json();
 }
 
+/** Keep the in-memory catalog when a reload misses (never wipe on a failed fetch). */
+function preserveLibraryMeta(metaKey, fetched) {
+  return fetched ?? state.libraryMeta[metaKey] ?? null;
+}
+
 export { LIBRARY_STORE_JSON };
 
 export function rebuildAllGamesFromMetas() {
@@ -441,7 +446,8 @@ export async function reloadAllLibraryStoreFiles() {
   const entries = await Promise.all(
     Object.entries(LIBRARY_STORE_JSON).map(async ([metaKey, file]) => {
       try {
-        return [metaKey, await fetchLibraryJson(file)];
+        const data = await fetchLibraryJson(file);
+        return [metaKey, preserveLibraryMeta(metaKey, data)];
       } catch {
         return [metaKey, state.libraryMeta[metaKey] ?? null];
       }
@@ -499,11 +505,14 @@ export async function reloadAfterFetcher(key) {
     refreshClaimableUi();
   } else if (WISHLIST_FETCHER_JSON[key]) {
     const metaKey = WISHLIST_FETCHER_META_KEY[key];
-    state.libraryMeta[metaKey] = await fetchLibraryJson(WISHLIST_FETCHER_JSON[key]);
+    state.libraryMeta[metaKey] = preserveLibraryMeta(
+      metaKey,
+      await fetchLibraryJson(WISHLIST_FETCHER_JSON[key]),
+    );
     rebuildWishlistFromMetas();
   } else if (LIBRARY_STORE_JSON[key]) {
     captureLibraryKeysBeforeMerge();
-    state.libraryMeta[key] = await fetchLibraryJson(LIBRARY_STORE_JSON[key]);
+    state.libraryMeta[key] = preserveLibraryMeta(key, await fetchLibraryJson(LIBRARY_STORE_JSON[key]));
     rebuildAllGamesFromMetas();
   } else {
     await reloadGames();
@@ -564,28 +573,28 @@ export async function reloadGames() {
     fetchLibraryJson("games_wishlist_humble.json"),
   ]);
   if (!steam && !gog && !psn && !epic && !amazon && !nintendo && !itch && !xbox && !battlenet && !ubisoft && !humble && !ea) throw new Error("No library files found");
-  state.libraryMeta.steam = steam;
-  state.libraryMeta.gog = gog;
-  state.libraryMeta.psn = psn;
-  state.libraryMeta.epic = epic;
-  state.libraryMeta.amazon = amazon;
-  state.libraryMeta.nintendo = nintendo;
-  state.libraryMeta.itch = itch;
-  state.libraryMeta.xbox = xbox;
-  state.libraryMeta.battlenet = battlenet;
-  state.libraryMeta.ubisoft = ubisoft;
-  state.libraryMeta.humble = humble;
-  state.libraryMeta.ea = ea;
+  state.libraryMeta.steam = preserveLibraryMeta('steam', steam);
+  state.libraryMeta.gog = preserveLibraryMeta('gog', gog);
+  state.libraryMeta.psn = preserveLibraryMeta('psn', psn);
+  state.libraryMeta.epic = preserveLibraryMeta('epic', epic);
+  state.libraryMeta.amazon = preserveLibraryMeta('amazon', amazon);
+  state.libraryMeta.nintendo = preserveLibraryMeta('nintendo', nintendo);
+  state.libraryMeta.itch = preserveLibraryMeta('itch', itch);
+  state.libraryMeta.xbox = preserveLibraryMeta('xbox', xbox);
+  state.libraryMeta.battlenet = preserveLibraryMeta('battlenet', battlenet);
+  state.libraryMeta.ubisoft = preserveLibraryMeta('ubisoft', ubisoft);
+  state.libraryMeta.humble = preserveLibraryMeta('humble', humble);
+  state.libraryMeta.ea = preserveLibraryMeta('ea', ea);
   captureLibraryKeysBeforeMerge();
   rebuildAllGamesFromMetas();
-  state.libraryMeta.wishlist = wishlist;
-  state.libraryMeta.wishlistGog = wishlistGog;
-  state.libraryMeta.wishlistEpic = wishlistEpic;
-  state.libraryMeta.wishlistPsn = wishlistPsn;
-  state.libraryMeta.wishlistUbisoft = wishlistUbisoft;
-  state.libraryMeta.wishlistXbox = wishlistXbox;
-  state.libraryMeta.wishlistNintendo = wishlistNintendo;
-  state.libraryMeta.wishlistHumble = wishlistHumble;
+  state.libraryMeta.wishlist = preserveLibraryMeta('wishlist', wishlist);
+  state.libraryMeta.wishlistGog = preserveLibraryMeta('wishlistGog', wishlistGog);
+  state.libraryMeta.wishlistEpic = preserveLibraryMeta('wishlistEpic', wishlistEpic);
+  state.libraryMeta.wishlistPsn = preserveLibraryMeta('wishlistPsn', wishlistPsn);
+  state.libraryMeta.wishlistUbisoft = preserveLibraryMeta('wishlistUbisoft', wishlistUbisoft);
+  state.libraryMeta.wishlistXbox = preserveLibraryMeta('wishlistXbox', wishlistXbox);
+  state.libraryMeta.wishlistNintendo = preserveLibraryMeta('wishlistNintendo', wishlistNintendo);
+  state.libraryMeta.wishlistHumble = preserveLibraryMeta('wishlistHumble', wishlistHumble);
   rebuildWishlistFromMetas();
   await Promise.all([
     loadItadPrices(),

--- a/js/pro-view.js
+++ b/js/pro-view.js
@@ -10,6 +10,8 @@ import {
   getAccountProfileId,
   isAccountAuthMode,
   isPro,
+  licenseActivationEnabled,
+  proCheckoutEnabled,
   proCheckoutUrls,
   refreshAccountPlan,
 } from './auth-gate.js';
@@ -140,6 +142,11 @@ function proTrustHtml() {
 }
 
 function proPricingHtml() {
+  if (!proCheckoutEnabled()) {
+    return `<div class="pro-view-pricing pro-view-pricing--beta">
+    <p class="pro-view-founder">Checkout is closed during beta. Pro perks will roll out to beta testers before public launch.</p>
+  </div>`;
+  }
   const monthly = escapeAttr(proCheckoutLink('monthly'));
   const yearly = escapeAttr(proCheckoutLink('yearly'));
   const monthlyPressed = selectedProPlan === 'monthly' ? 'true' : 'false';
@@ -163,10 +170,23 @@ function proActivationHtml() {
     const emailNote = email
       ? `Checkout with <strong>${escapeHtml(email)}</strong> so Pro links to this account.`
       : 'Use the same email as your BAKLOG account at checkout.';
+    const checkoutNote = proCheckoutEnabled()
+      ? 'After payment, click refresh - or sign out and back in.'
+      : 'During beta, Pro is granted on the server side. Use refresh after perks are enabled for your account.';
     return `
       <div class="pro-view-activate">
         <h3 class="pro-view-section-title">After checkout</h3>
-        <p class="pro-view-note">${emailNote} After payment, click refresh - or sign out and back in.</p>
+        <p class="pro-view-note">${emailNote} ${checkoutNote}</p>
+        <div class="pro-view-actions">
+          <button type="button" class="pro-view-btn pro-view-btn--ghost" data-pro-refresh>Refresh Pro status</button>
+        </div>
+      </div>`;
+  }
+  if (!licenseActivationEnabled()) {
+    return `
+      <div class="pro-view-activate">
+        <h3 class="pro-view-section-title">After checkout</h3>
+        <p class="pro-view-note">License activation is not configured on this install. Set <code>BAKLOG_POLAR_ORG_ID</code> in your environment, then restart the server.</p>
         <div class="pro-view-actions">
           <button type="button" class="pro-view-btn pro-view-btn--ghost" data-pro-refresh>Refresh Pro status</button>
         </div>
@@ -347,9 +367,11 @@ async function submitProLicense(form) {
       body: JSON.stringify({ key }),
     });
     const data = await res.json().catch(() => ({}));
+    const errMsg = [data.message, data.error].find((v) => typeof v === 'string' && v.trim())
+      || (res.ok ? 'Activation failed.' : `Activation failed (HTTP ${res.status}).`);
     if (!res.ok || !data.ok) {
       licenseActivating = false;
-      setProStatus(data.message || data.error || 'Activation failed.', false);
+      setProStatus(errMsg, false);
       return;
     }
     completeProActivation({
@@ -374,7 +396,11 @@ export async function handleCheckoutSuccessReturn() {
       completeProActivation();
       return;
     }
-    setProStatus('Payment received. Pro may take a moment - click Refresh Pro status, or paste your license key below.', false);
+    setProStatus('Payment received. Pro may take a moment - click Refresh Pro status.', false);
+    return;
+  }
+  if (!licenseActivationEnabled()) {
+    setProStatus('Payment received. License activation is not configured on this install.', false);
     return;
   }
   setProStatus('Paste the license key from your Polar receipt email to finish activation.', true);

--- a/js/sponsored-deals.js
+++ b/js/sponsored-deals.js
@@ -36,7 +36,7 @@
  *   Sync pairs: HOUSE_DEFAULTS (below) <-> curated/sponsors.json <-> landing/sponsors.json
  *   <-> scripts/migrate_sponsors_v2.py HOUSE_DEFAULTS <-> admin/admin.js HOUSE_MIGRATION_DEFAULTS.
  *   NOTE: hardcoded banners (proPromoBannerHtml, the wishlist house banner here, and
- *   js/pro-view.js renderConnectionsProLink) are NOT feed-driven -- they update by
+ *   js/pro-view.js Support tab funnel) are NOT feed-driven -- they update by
  *   editing js/ source + reload (dev raw ESM) or `npm run build` (frozen/built mode).
  */
 import { state } from './state.js';

--- a/landing/README.md
+++ b/landing/README.md
@@ -83,6 +83,8 @@ Run `sql/polar_entitlement.sql` once in the Supabase SQL editor (`get_user_id_by
 
 Local app: set `BAKLOG_POLAR_ORG_ID` to your Polar organization id (Settings → General) so `POST /api/license/activate` can validate license keys against Polar.
 
+**Checkout rollout (beta vs public):** set `BAKLOG_PRO_CHECKOUT=1` on Vercel **and** on the local server env when Polar checkout should be live. Default is off during beta. The marketing site loads `pro-checkout-gate.js`, which reads `GET /api/pro-config` and hides checkout CTAs when disabled. Grant beta-wide Pro on hosted accounts with `python scripts/grant_beta_pro.py` (dry-run by default; pass `--apply`).
+
 **Checkout link success URL (both monthly and yearly links):** set Polar → Checkout Links → Success URL to:
 
 `http://127.0.0.1:8765/?checkout=success&checkout_id={CHECKOUT_ID}`

--- a/landing/api/pro-config.js
+++ b/landing/api/pro-config.js
@@ -1,0 +1,30 @@
+// Public Pro rollout config for the marketing site + local app parity.
+// Set BAKLOG_PRO_CHECKOUT=1 on Vercel when Polar checkout should be live.
+// Sync checkout URLs with shared/pro_checkout.py + js/pro-checkout.js.
+
+const PRO_CHECKOUT_MONTHLY =
+  "https://buy.polar.sh/polar_cl_1BV0qvxl87f2YEGmZo36HvXdmTf4GHthbIjh92P2yNw";
+const PRO_CHECKOUT_YEARLY =
+  "https://buy.polar.sh/polar_cl_EluZmAQP7KUeeSQfnVfEwML7NdbrW3ruDy4SB364dE3";
+
+function proCheckoutEnabled() {
+  const raw = String(process.env.BAKLOG_PRO_CHECKOUT || "0").trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
+export default {
+  async fetch() {
+    const enabled = proCheckoutEnabled();
+    return Response.json(
+      {
+        proCheckoutEnabled: enabled,
+        proCheckout: enabled
+          ? { monthly: PRO_CHECKOUT_MONTHLY, yearly: PRO_CHECKOUT_YEARLY }
+          : { monthly: "", yearly: "" },
+      },
+      {
+        headers: { "Cache-Control": "no-store" },
+      },
+    );
+  },
+};

--- a/landing/api/report.js
+++ b/landing/api/report.js
@@ -70,7 +70,9 @@ function topErrorSummary(bundle) {
   const session = bundle.errors?.session || [];
   const persisted = bundle.errors?.persisted || [];
   const latest = session[session.length - 1] || persisted[persisted.length - 1];
-  if (!latest) return { message: "(no errors captured)", stack: "" };
+  if (!latest) {
+    return { message: "(no errors captured)", stack: "", name: "ManualReport" };
+  }
   return {
     message: String(latest.message || "(no message)").slice(0, 500),
     stack: String(latest.stack || "").slice(0, 2000),

--- a/landing/index.html
+++ b/landing/index.html
@@ -40,6 +40,7 @@
   <script src="vendor/chart.umd.min.js" defer></script>
   <script src="marquee-speed.js" defer></script>
   <script src="demo.js" defer></script>
+  <script src="pro-checkout-gate.js" defer></script>
   <script src="main.js" defer></script>
 
   <!-- Structured data: inline. The src attribute is ignored on ld+json blocks,
@@ -488,6 +489,17 @@
       background: var(--accent);
       box-shadow: 0 10px 26px rgba(56, 189, 248, 0.42);
     }
+    .pro-checkout-beta-note,
+    .pro-checkout-beta-inline {
+      color: var(--text-mute);
+      font-size: 0.95rem;
+      line-height: 1.5;
+      margin: 0;
+    }
+    .pro-checkout-beta-inline {
+      font-weight: 600;
+      color: var(--text);
+    }
     @media (max-width: 599px) {
       .tier-compare { display: block; overflow-x: auto; }
       .pro-checkout .btn { width: 100%; }
@@ -853,9 +865,9 @@
             <li>Never miss a free game again - deal &amp; watchlist alerts (coming soon)</li>
             <li>Bonus claimables feed: the DLC, add-ons, and in-game bonuses we filter out of the free feed, surfaced just for paid members</li>
           </ul>
-          <div class="pro-checkout">
-            <a class="btn" href="https://buy.polar.sh/polar_cl_1BV0qvxl87f2YEGmZo36HvXdmTf4GHthbIjh92P2yNw" target="_blank" rel="noopener noreferrer">Support BAKLOG</a>
-            <a class="btn btn--secondary" href="https://buy.polar.sh/polar_cl_EluZmAQP7KUeeSQfnVfEwML7NdbrW3ruDy4SB364dE3" target="_blank" rel="noopener noreferrer">Support BAKLOG (yearly)</a>
+          <div class="pro-checkout" data-pro-checkout>
+            <a class="btn pro-checkout-link" href="https://buy.polar.sh/polar_cl_1BV0qvxl87f2YEGmZo36HvXdmTf4GHthbIjh92P2yNw" target="_blank" rel="noopener noreferrer">Support BAKLOG</a>
+            <a class="btn btn--secondary pro-checkout-link" href="https://buy.polar.sh/polar_cl_EluZmAQP7KUeeSQfnVfEwML7NdbrW3ruDy4SB364dE3" target="_blank" rel="noopener noreferrer">Support BAKLOG (yearly)</a>
           </div>
         </article>
 
@@ -1015,11 +1027,11 @@
         </details>
         <details>
           <summary>Is it free?</summary>
-          <p>Yes. Importing your library across every store is free forever: auto-fetch on connect, full dashboard, ownership-aware deals (with sponsored slots in deal cards on the free tier), cached trophy summary % (no on-demand deep re-pull), and <strong>Claimable Now</strong> for full-game giveaways. Store refresh on the free tier is one store at a time, on demand; auto-refresh quietly updates one stale store every ~30 min while the app is open. An optional paid tier adds more - see <a href="https://buy.polar.sh/polar_cl_1BV0qvxl87f2YEGmZo36HvXdmTf4GHthbIjh92P2yNw" target="_blank" rel="noopener noreferrer">Support BAKLOG</a>. Nothing you use free today moves behind paywall.</p>
+          <p>Yes. Importing your library across every store is free forever: auto-fetch on connect, full dashboard, ownership-aware deals (with sponsored slots in deal cards on the free tier), cached trophy summary % (no on-demand deep re-pull), and <strong>Claimable Now</strong> for full-game giveaways. Store refresh on the free tier is one store at a time, on demand; auto-refresh quietly updates one stale store every ~30 min while the app is open. An optional paid tier adds more - see <a class="pro-checkout-link" href="https://buy.polar.sh/polar_cl_1BV0qvxl87f2YEGmZo36HvXdmTf4GHthbIjh92P2yNw" target="_blank" rel="noopener noreferrer">Support BAKLOG</a>. Nothing you use free today moves behind paywall.</p>
         </details>
         <details>
           <summary>What's in the paid tier?</summary>
-          <p>Pro perks live today: no sponsored deal cards, scheduled stale-store refresh without keeping the app open, deep achievement/trophy sync (full on-demand re-pull; free tier shows cached % only), and a bonus claimables feed for DLC, add-ons, and in-game bonuses filtered out of the free feed. Coming soon: cloud sync across machines, <strong>queued bulk refresh</strong> (queue every stale store and let them run back-to-back instead of babysitting one at a time), and never miss a free game again - deal/watchlist alerts. <a href="https://buy.polar.sh/polar_cl_1BV0qvxl87f2YEGmZo36HvXdmTf4GHthbIjh92P2yNw" target="_blank" rel="noopener noreferrer">Support BAKLOG</a> or <a href="https://buy.polar.sh/polar_cl_EluZmAQP7KUeeSQfnVfEwML7NdbrW3ruDy4SB364dE3" target="_blank" rel="noopener noreferrer">Support BAKLOG (yearly)</a>. The free tier keeps everything you need to import, browse, and decide what to play next.</p>
+          <p>Pro perks live today: no sponsored deal cards, scheduled stale-store refresh without keeping the app open, deep achievement/trophy sync (full on-demand re-pull; free tier shows cached % only), and a bonus claimables feed for DLC, add-ons, and in-game bonuses filtered out of the free feed. Coming soon: cloud sync across machines, <strong>queued bulk refresh</strong> (queue every stale store and let them run back-to-back instead of babysitting one at a time), and never miss a free game again - deal/watchlist alerts. <a class="pro-checkout-link" href="https://buy.polar.sh/polar_cl_1BV0qvxl87f2YEGmZo36HvXdmTf4GHthbIjh92P2yNw" target="_blank" rel="noopener noreferrer">Support BAKLOG</a> or <a class="pro-checkout-link" href="https://buy.polar.sh/polar_cl_EluZmAQP7KUeeSQfnVfEwML7NdbrW3ruDy4SB364dE3" target="_blank" rel="noopener noreferrer">Support BAKLOG (yearly)</a>. The free tier keeps everything you need to import, browse, and decide what to play next.</p>
         </details>
         <details>
           <summary>What's the difference between free and paid refresh?</summary>

--- a/landing/pro-checkout-gate.js
+++ b/landing/pro-checkout-gate.js
@@ -1,0 +1,45 @@
+/**
+ * Hide Polar checkout CTAs on baklog.app when BAKLOG_PRO_CHECKOUT is not set on Vercel.
+ * Fetches GET /api/pro-config (landing/api/pro-config.js).
+ */
+(function proCheckoutGate() {
+  const BETA_NOTE =
+    "Checkout is closed during beta. Pro perks will roll out to beta testers before public launch.";
+
+  function stripCheckoutLinks(root) {
+    root.querySelectorAll("a.pro-checkout-link").forEach((a) => {
+      const span = document.createElement("span");
+      span.className = "pro-checkout-beta-inline";
+      span.textContent = a.textContent || "Support BAKLOG";
+      a.replaceWith(span);
+    });
+  }
+
+  function apply(enabled) {
+    if (enabled) return;
+    document.querySelectorAll("[data-pro-checkout]").forEach((el) => {
+      el.innerHTML = `<p class="pro-checkout-beta-note">${BETA_NOTE}</p>`;
+    });
+    stripCheckoutLinks(document);
+  }
+
+  async function init() {
+    let enabled = false;
+    try {
+      const res = await fetch("/api/pro-config", { cache: "no-store" });
+      if (res.ok) {
+        const data = await res.json();
+        enabled = !!data.proCheckoutEnabled;
+      }
+    } catch (_) {
+      /* offline preview: treat as beta (checkout off) */
+    }
+    apply(enabled);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/landing/vercel.json
+++ b/landing/vercel.json
@@ -41,7 +41,7 @@
       ]
     },
     {
-      "source": "/(main|demo)\\.js|demo\\.css",
+      "source": "/(main|demo|pro-checkout-gate)\\.js|demo\\.css",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=86400" }
       ]

--- a/scripts/grant_beta_pro.py
+++ b/scripts/grant_beta_pro.py
@@ -1,0 +1,178 @@
+"""Grant or revoke BAKLOG Pro on hosted Supabase accounts (maintainer one-off).
+
+Uses the GoTrue admin API to set ``app_metadata.plan`` on each user. Safe by
+default: prints the plan and exits unless ``--apply`` is passed.
+
+Env (shell or landing/.env):
+  SUPABASE_URL
+  SUPABASE_SERVICE_ROLE_KEY
+
+Examples:
+  .\\.venv\\Scripts\\python.exe scripts\\grant_beta_pro.py
+  .\\.venv\\Scripts\\python.exe scripts\\grant_beta_pro.py --email you@example.com --apply
+  .\\.venv\\Scripts\\python.exe scripts\\grant_beta_pro.py --before 2026-07-01 --apply
+  .\\.venv\\Scripts\\python.exe scripts\\grant_beta_pro.py --plan free --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PRO_ALIASES = frozenset({"pro", "paid", "premium"})
+
+
+def _load_dotenv() -> None:
+    for rel in ("landing/.env", ".env"):
+        path = ROOT / rel
+        if not path.is_file():
+            continue
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, val = line.partition("=")
+            key = key.strip()
+            if key and key not in os.environ:
+                os.environ[key] = val.strip().strip('"').strip("'")
+
+
+def _request(
+    method: str,
+    url: str,
+    *,
+    key: str,
+    body: dict | None = None,
+) -> dict | list:
+    data = None
+    headers = {
+        "apikey": key,
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+    }
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            raw = resp.read().decode("utf-8")
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"{method} {url} -> HTTP {exc.code}: {detail}") from exc
+
+
+def _list_users(base: str, key: str) -> list[dict]:
+    users: list[dict] = []
+    page = 1
+    while True:
+        qs = urllib.parse.urlencode({"page": page, "per_page": 200})
+        batch = _request("GET", f"{base}/auth/v1/admin/users?{qs}", key=key)
+        if not isinstance(batch, dict):
+            break
+        chunk = batch.get("users") or []
+        if not chunk:
+            break
+        users.extend(chunk)
+        if len(chunk) < 200:
+            break
+        page += 1
+    return users
+
+
+def _normalize_plan(raw: str) -> str:
+    val = (raw or "").strip().lower()
+    if val in PRO_ALIASES:
+        return "pro"
+    return "free"
+
+
+def _created_before(user: dict, cutoff: datetime | None) -> bool:
+    if cutoff is None:
+        return True
+    created_raw = user.get("created_at") or user.get("createdAt") or ""
+    try:
+        created = datetime.fromisoformat(str(created_raw).replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return created <= cutoff
+
+
+def main(argv: list[str] | None = None) -> int:
+    _load_dotenv()
+    parser = argparse.ArgumentParser(description="Grant or revoke hosted BAKLOG Pro via Supabase admin.")
+    parser.add_argument("--apply", action="store_true", help="Write changes (default is dry-run).")
+    parser.add_argument("--plan", default="pro", choices=("pro", "free"), help="Plan to set (default: pro).")
+    parser.add_argument("--email", help="Only touch this account email (case-insensitive).")
+    parser.add_argument(
+        "--before",
+        metavar="ISO-DATE",
+        help="Only users created on or before this UTC date (YYYY-MM-DD).",
+    )
+    parser.add_argument("--limit", type=int, default=0, help="Max users to touch (0 = no cap).")
+    args = parser.parse_args(argv)
+
+    url = (os.environ.get("SUPABASE_URL") or "").strip().rstrip("/")
+    key = (os.environ.get("SUPABASE_SERVICE_ROLE_KEY") or "").strip()
+    if not url or not key:
+        print("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY.", file=sys.stderr)
+        return 2
+
+    cutoff = None
+    if args.before:
+        cutoff = datetime.fromisoformat(args.before).replace(tzinfo=timezone.utc)
+
+    target_plan = _normalize_plan(args.plan)
+    users = _list_users(url, key)
+    email_filter = (args.email or "").strip().lower()
+    selected: list[dict] = []
+    for user in users:
+        mail = str(user.get("email") or "").strip().lower()
+        if email_filter and mail != email_filter:
+            continue
+        if not _created_before(user, cutoff):
+            continue
+        selected.append(user)
+        if args.limit and len(selected) >= args.limit:
+            break
+
+    if not selected:
+        print("No matching users.")
+        return 0
+
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    print(f"{mode}: set plan={target_plan!r} on {len(selected)} user(s)")
+    changed = 0
+    for user in selected:
+        uid = user.get("id") or user.get("user_id")
+        mail = user.get("email") or "(no email)"
+        meta = dict(user.get("app_metadata") or {})
+        prev = meta.get("plan", "free")
+        meta["plan"] = target_plan
+        print(f"  {mail}  {prev!r} -> {target_plan!r}  ({uid})")
+        if args.apply and uid:
+            _request(
+                "PUT",
+                f"{url}/auth/v1/admin/users/{uid}",
+                key=key,
+                body={"app_metadata": meta},
+            )
+            changed += 1
+
+    if args.apply:
+        print(f"Updated {changed} user(s). Ask them to Refresh Pro status or sign in again.")
+    else:
+        print("Dry-run only. Re-run with --apply to write.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hooks/cursor-hooks.project.json
+++ b/scripts/hooks/cursor-hooks.project.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "hooks": {
+    "stop": [
+      {
+        "command": ".venv/Scripts/python.exe scripts/hooks/remind-tracker.py",
+        "loop_limit": 1
+      },
+      {
+        "command": ".venv/Scripts/python.exe scripts/hooks/cleanup-baklog-strays.py",
+        "loop_limit": 1
+      }
+    ]
+  }
+}

--- a/scripts/install-cursor-hooks.ps1
+++ b/scripts/install-cursor-hooks.ps1
@@ -1,0 +1,12 @@
+# Copy project Cursor hooks into .cursor/hooks.json (session-end tracker reminder + stray dedupe).
+$ErrorActionPreference = "Stop"
+$root = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+$src = Join-Path $root "scripts\hooks\cursor-hooks.project.json"
+$dest = Join-Path $root ".cursor\hooks.json"
+if (-not (Test-Path $src)) {
+    Write-Error "Missing template: $src"
+}
+New-Item -ItemType Directory -Force -Path (Split-Path $dest) | Out-Null
+Copy-Item -Force $src $dest
+Write-Host "Installed $dest"
+Write-Host "Restart Cursor or reload hooks if the session-end reminder still does not appear."

--- a/server.py
+++ b/server.py
@@ -3146,7 +3146,7 @@ class Handler(SimpleHTTPRequestHandler):
     def _handle_config_get(self) -> None:
         from shared.entitlement import current_plan, maybe_refresh_local_license
         from shared.polar_license import polar_configured
-        from shared.pro_checkout import public_checkout_urls
+        from shared.pro_checkout import pro_checkout_enabled, public_checkout_urls
         from shared.supabase_auth import auth_enabled, public_auth_config
 
         maybe_refresh_local_license()
@@ -3155,6 +3155,7 @@ class Handler(SimpleHTTPRequestHandler):
         # local license file / BAKLOG_PLAN override. Defaults to "free".
         config["plan"] = current_plan(self.headers.get("Authorization"))
         config["licenseActivation"] = polar_configured() and not auth_enabled()
+        config["proCheckoutEnabled"] = pro_checkout_enabled()
         config["proCheckout"] = public_checkout_urls()
         config["frozen"] = is_frozen()
         config["version"] = _app_version()

--- a/server.py
+++ b/server.py
@@ -858,11 +858,17 @@ def _run_id_active_on_disk(run_id: str) -> bool:
     return any(entry.get("id") == run_id for entry in _read_active_runs())
 
 
+def _fetcher_is_enrich(key: str) -> bool:
+    return FETCHERS.get(key, {}).get("group") == "enrich"
+
+
 def _filter_runs_by_lane(runs: list[Run], lane: str | None) -> list[Run]:
-    """Restrict a run list to one lane. lane="fetcher" drops internal (admin)
-    runs; lane="internal" keeps only them; None passes everything through."""
+    """Restrict a run list to one lane. lane="fetcher" drops internal/enrich runs;
+    lane="enrich" keeps enrich only; lane="internal" keeps admin jobs; None = all."""
     if lane == "fetcher":
-        return [r for r in runs if not r._internal]
+        return [r for r in runs if not r._internal and not r._enrich]
+    if lane == "enrich":
+        return [r for r in runs if r._enrich]
     if lane == "internal":
         return [r for r in runs if r._internal]
     return list(runs)
@@ -906,7 +912,7 @@ class Run:
         "lines", "_lock", "_listeners", "_finished", "_proc", "cancelled", "refresh",
         "_log_path", "_runs_dir", "profile_id", "_cancelling_since", "_no_proc_since",
         "_history_note", "_next_seq", "_total_lines", "_finalized",
-        "_internal", "_internal_extra_args",
+        "_internal", "_internal_extra_args", "_enrich",
     )
 
     def __init__(
@@ -917,6 +923,7 @@ class Run:
         runs_dir: Path = RUNS_DIR,
         profile_id: str | None = None,
         internal: bool = False,
+        enrich: bool = False,
         extra_args: list[str] | None = None,
     ) -> None:
         if internal:
@@ -931,6 +938,7 @@ class Run:
         self.label: str = spec["label"]
         self.refresh: bool = refresh
         self._internal = internal
+        self._enrich = enrich and not internal
         self._internal_extra_args = list(extra_args or [])
         self.status: str = "queued"  # queued | launching | running | cancelling | done | failed | cancelled
         self.started_at: float | None = None
@@ -996,6 +1004,14 @@ class Run:
         if self._history_note:
             summary["note"] = self._history_note
         summary["profile_id"] = self.profile_id
+        if self._enrich:
+            summary["lane"] = "enrich"
+        elif self._internal:
+            summary["lane"] = "internal"
+        else:
+            summary["lane"] = "fetcher"
+        if not self._internal:
+            summary["group"] = FETCHERS.get(self.key, {}).get("group")
         return summary
 
     def add_line(self, stream: str, text: str) -> None:
@@ -1161,20 +1177,18 @@ class RunManager:
         self._runs_dir = runs_dir or RUNS_DIR
         self._runs_dir.mkdir(parents=True, exist_ok=True)
         self._lock = threading.Lock()
-        # Two parallel lanes, each cap=1: the fetcher lane serializes library/
-        # wishlist/enrich runs (they share auth sessions), while the internal
-        # lane runs admin jobs (buildClaims, claimSources) so a Publish/Enrich
-        # never blocks — or is blocked by — a Steam library fetch. Internal jobs
-        # still serialize among themselves because claimSources writes the auto
-        # feed that buildClaims reads.
+        # Three parallel lanes, each cap=1: fetcher (library/wishlist/prices),
+        # enrich (HLTB/reviews/covers/tags), and internal (admin jobs).
         self._queue: queue.Queue[Run] = queue.Queue()
+        self._enrich_queue: queue.Queue[Run] = queue.Queue()
         self._internal_queue: queue.Queue[Run] = queue.Queue()
-        self._pending: list[Run] = []  # queued + active (both lanes), submission order
+        self._pending: list[Run] = []  # queued + active (all lanes), submission order
         self._history: deque[dict[str, Any]] = deque(
             _load_run_history_from(self._runs_dir / "history.json")[-MAX_HISTORY:],
             maxlen=MAX_HISTORY,
         )
         self._active: Run | None = None
+        self._enrich_active: Run | None = None
         self._internal_active: Run | None = None
         self._runs_by_id: dict[str, Run] = {}
         self._last_queue_kick_at = 0.0
@@ -1198,27 +1212,38 @@ class RunManager:
 
     def _start_worker_thread(self) -> None:
         self._worker_thread = threading.Thread(
-            target=self._worker_loop, args=(False,), name="run-worker", daemon=True
+            target=self._worker_loop, args=("fetcher",), name="run-worker", daemon=True
         )
         self._worker_thread.start()
+        self._enrich_worker_thread = threading.Thread(
+            target=self._worker_loop, args=("enrich",), name="run-worker-enrich", daemon=True
+        )
+        self._enrich_worker_thread.start()
         self._internal_worker_thread = threading.Thread(
-            target=self._worker_loop, args=(True,), name="run-worker-internal", daemon=True
+            target=self._worker_loop, args=("internal",), name="run-worker-internal", daemon=True
         )
         self._internal_worker_thread.start()
 
     def _ensure_worker_thread(self) -> None:
-        """Restart either lane worker if its daemon thread died (leaves runs stuck queued)."""
+        """Restart any lane worker if its daemon thread died."""
         if not self._worker_thread.is_alive():
             print("[runs] fetcher worker thread died — restarting", file=sys.stderr, flush=True)
             self._worker_thread = threading.Thread(
-                target=self._worker_loop, args=(False,), name="run-worker", daemon=True
+                target=self._worker_loop, args=("fetcher",), name="run-worker", daemon=True
             )
             self._worker_thread.start()
+        enrich = getattr(self, "_enrich_worker_thread", None)
+        if enrich is None or not enrich.is_alive():
+            print("[runs] enrich worker thread died — restarting", file=sys.stderr, flush=True)
+            self._enrich_worker_thread = threading.Thread(
+                target=self._worker_loop, args=("enrich",), name="run-worker-enrich", daemon=True
+            )
+            self._enrich_worker_thread.start()
         internal = getattr(self, "_internal_worker_thread", None)
         if internal is None or not internal.is_alive():
             print("[runs] internal worker thread died — restarting", file=sys.stderr, flush=True)
             self._internal_worker_thread = threading.Thread(
-                target=self._worker_loop, args=(True,), name="run-worker-internal", daemon=True
+                target=self._worker_loop, args=("internal",), name="run-worker-internal", daemon=True
             )
             self._internal_worker_thread.start()
 
@@ -1229,25 +1254,55 @@ class RunManager:
         but were never handed to ``_queue.get()`` (typically after the worker thread
         exited while the queue was empty). Runs both lanes independently.
         """
-        return self._resync_lane(internal=False) + self._resync_lane(internal=True)
+        return (
+            self._resync_lane("fetcher")
+            + self._resync_lane("enrich")
+            + self._resync_lane("internal")
+        )
 
-    def _resync_lane(self, *, internal: bool) -> int:
-        lane_queue = self._internal_queue if internal else self._queue
+    def _lane_queue(self, lane: str) -> queue.Queue[Run]:
+        if lane == "internal":
+            return self._internal_queue
+        if lane == "enrich":
+            return self._enrich_queue
+        return self._queue
+
+    def _lane_active(self, lane: str) -> Run | None:
+        if lane == "internal":
+            return self._internal_active
+        if lane == "enrich":
+            return self._enrich_active
+        return self._active
+
+    def _set_lane_active(self, lane: str, run: Run | None) -> None:
+        if lane == "internal":
+            self._internal_active = run
+        elif lane == "enrich":
+            self._enrich_active = run
+        else:
+            self._active = run
+
+    def _run_in_lane(self, run: Run, lane: str) -> bool:
+        if lane == "internal":
+            return run._internal
+        if lane == "enrich":
+            return run._enrich
+        return not run._internal and not run._enrich
+
+    def _resync_lane(self, lane: str) -> int:
+        lane_queue = self._lane_queue(lane)
         to_put: list[Run] = []
         with self._lock:
-            active = self._internal_active if internal else self._active
+            active = self._lane_active(lane)
             if active is not None and active._finished.is_set():
-                if internal:
-                    self._internal_active = None
-                else:
-                    self._active = None
+                self._set_lane_active(lane, None)
                 active = None
             if active is not None:
                 return 0
             if lane_queue.qsize() > 0:
                 return 0
             for r in self._pending:
-                if bool(r._internal) != internal:
+                if not self._run_in_lane(r, lane):
                     continue
                 if r.status == "queued" and not r._finished.is_set():
                     to_put.append(r)
@@ -1255,7 +1310,6 @@ class RunManager:
             lane_queue.put(r)
         if to_put:
             keys = ", ".join(r.key for r in to_put)
-            lane = "internal" if internal else "fetcher"
             print(
                 f"[runs] re-queued {len(to_put)} stalled {lane} run(s): {keys}",
                 file=sys.stderr,
@@ -1294,7 +1348,7 @@ class RunManager:
                     and now - r._cancelling_since > CANCEL_STUCK_GRACE_SEC
                 ):
                     stuck.append(r)
-            for active in (self._active, self._internal_active):
+            for active in (self._active, self._enrich_active, self._internal_active):
                 if (
                     active
                     and active.status == "cancelling"
@@ -1342,7 +1396,7 @@ class RunManager:
         stuck: list[Run] = []
         with self._lock:
             candidates: list[Run] = []
-            for active in (self._active, self._internal_active):
+            for active in (self._active, self._enrich_active, self._internal_active):
                 if (
                     active
                     and active.status in ("launching", "running")
@@ -1469,6 +1523,11 @@ class RunManager:
             if self._active is not None and self._active.profile_id != active_pid:
                 self._active = None
             if (
+                self._enrich_active is not None
+                and self._enrich_active.profile_id != active_pid
+            ):
+                self._enrich_active = None
+            if (
                 self._internal_active is not None
                 and self._internal_active.profile_id != active_pid
             ):
@@ -1583,7 +1642,7 @@ class RunManager:
         self._watchdog_stop.set()
         with self._lock:
             pending = list(self._pending)
-            actives = [self._active, self._internal_active]
+            actives = [self._active, self._enrich_active, self._internal_active]
         kill_pids: list[int] = []
         for run in pending:
             changed, pids = run.cancel()
@@ -1602,7 +1661,7 @@ class RunManager:
         # Wake both worker lanes so their blocking queue.get() returns and the
         # threads exit, letting join_threads() finish immediately rather than
         # waiting out each 5s join timeout.
-        for lane_queue in (self._queue, self._internal_queue):
+        for lane_queue in (self._queue, self._enrich_queue, self._internal_queue):
             try:
                 lane_queue.put_nowait(None)
             except Exception:  # noqa: BLE001 - best-effort wakeup
@@ -1617,6 +1676,9 @@ class RunManager:
             wt.join(timeout=timeout)
         if self._worker_thread.is_alive():
             self._worker_thread.join(timeout=timeout)
+        enrich = getattr(self, "_enrich_worker_thread", None)
+        if enrich is not None and enrich.is_alive():
+            enrich.join(timeout=timeout)
         internal = getattr(self, "_internal_worker_thread", None)
         if internal is not None and internal.is_alive():
             internal.join(timeout=timeout)
@@ -1624,22 +1686,25 @@ class RunManager:
     def submit(self, key: str, *, refresh: bool = False) -> Run:
         if key not in FETCHERS:
             raise KeyError(key)
+        is_enrich = _fetcher_is_enrich(key)
+
+        def _in_lane(r: Run) -> bool:
+            if is_enrich:
+                return r._enrich
+            return not r._internal and not r._enrich
+
         with self._lock:
-            active = self._active
+            active = self._enrich_active if is_enrich else self._active
             if active and active.key == key and active.status in _IN_FLIGHT_STATUSES:
                 raise ValueError(f"{key} already queued or running")
             if any(
-                not r._internal and r.key == key and r.status in _IN_FLIGHT_STATUSES
+                _in_lane(r) and r.key == key and r.status in _IN_FLIGHT_STATUSES
                 for r in self._pending
             ):
                 raise ValueError(f"{key} already queued or running")
-            # Only the fetcher lane gates fetcher submits; admin/internal jobs
-            # run in their own lane and must not count toward "queue full".
             in_flight = sum(
-                1 for r in self._pending if not r._internal and r.status in _IN_FLIGHT_STATUSES
+                1 for r in self._pending if _in_lane(r) and r.status in _IN_FLIGHT_STATUSES
             )
-            # cancel() drops a run from _pending while the worker is still
-            # finishing it on _active — count that slot so the queue can't wedge.
             if (
                 active
                 and active.status in _IN_FLIGHT_STATUSES
@@ -1647,8 +1712,9 @@ class RunManager:
             ):
                 in_flight += 1
             if in_flight >= 1:
+                lane_label = "enrich" if is_enrich else "fetch"
                 raise ValueError(
-                    "queue full — a fetch is already running; "
+                    f"queue full — a {lane_label} is already running; "
                     "wait for it to finish before starting another"
                 )
             profile_id = get_active_profile_id()
@@ -1657,10 +1723,11 @@ class RunManager:
                 refresh=refresh,
                 runs_dir=runs_dir(profile_id=profile_id),
                 profile_id=profile_id,
+                enrich=is_enrich,
             )
             self._pending.append(run)
             self._runs_by_id[run.id] = run
-            self._queue.put(run)
+            (self._enrich_queue if is_enrich else self._queue).put(run)
         self._register_pending_run(run)
         self._persist_queue()
         self._ensure_worker_thread()
@@ -1768,7 +1835,7 @@ class RunManager:
             targets = [
                 r for r in self._pending if r.status in _IN_FLIGHT_STATUSES
             ]
-            for active in (self._active, self._internal_active):
+            for active in (self._active, self._enrich_active, self._internal_active):
                 if (
                     active
                     and active.status in _IN_FLIGHT_STATUSES
@@ -1819,7 +1886,7 @@ class RunManager:
             targets = [
                 r for r in self._pending if r.status in _IN_FLIGHT_STATUSES
             ]
-            for active in (self._active, self._internal_active):
+            for active in (self._active, self._enrich_active, self._internal_active):
                 if (
                     active
                     and active.status in _IN_FLIGHT_STATUSES
@@ -1850,6 +1917,8 @@ class RunManager:
         drains: list[queue.Queue] = []
         if lane in (None, "fetcher"):
             drains.append(self._queue)
+        if lane in (None, "enrich"):
+            drains.append(self._enrich_queue)
         if lane in (None, "internal"):
             drains.append(self._internal_queue)
         for drain in drains:
@@ -1862,11 +1931,14 @@ class RunManager:
             if lane is None:
                 self._pending.clear()
                 self._active = None
+                self._enrich_active = None
                 self._internal_active = None
             else:
                 self._pending = [r for r in self._pending if r not in targets]
                 if lane == "fetcher":
                     self._active = None
+                elif lane == "enrich":
+                    self._enrich_active = None
                 elif lane == "internal":
                     self._internal_active = None
         if lane is None:
@@ -1902,7 +1974,7 @@ class RunManager:
             targets = [
                 r for r in self._pending if r.status in _IN_FLIGHT_STATUSES
             ]
-            for active in (self._active, self._internal_active):
+            for active in (self._active, self._enrich_active, self._internal_active):
                 if (
                     active
                     and active.status in _IN_FLIGHT_STATUSES
@@ -1953,9 +2025,7 @@ class RunManager:
     def snapshot(self) -> dict[str, Any]:
         self._kick_queue_if_stalled_throttled()
         with self._lock:
-            # active/queue cover the fetcher lane only so the dashboard fetcher
-            # chips stay independent of admin jobs; the internal lane is exposed
-            # separately under internal_active/internal_queue.
+            # active/queue cover the fetcher lane; enrich and internal are separate.
             active = (
                 self._active.to_summary()
                 if self._active and self._active.status in _IN_FLIGHT_STATUSES
@@ -1964,7 +2034,21 @@ class RunManager:
             queued = [
                 r.to_summary()
                 for r in self._pending
-                if not r._internal and r.status == "queued" and r is not self._active
+                if not r._internal
+                and not r._enrich
+                and r.status == "queued"
+                and r is not self._active
+            ]
+            enrich_active = (
+                self._enrich_active.to_summary()
+                if self._enrich_active
+                and self._enrich_active.status in _IN_FLIGHT_STATUSES
+                else None
+            )
+            enrich_queue = [
+                r.to_summary()
+                for r in self._pending
+                if r._enrich and r.status == "queued" and r is not self._enrich_active
             ]
             internal_active = (
                 self._internal_active.to_summary()
@@ -1981,6 +2065,8 @@ class RunManager:
         return {
             "active": active,
             "queue": queued,
+            "enrich_active": enrich_active,
+            "enrich_queue": enrich_queue,
             "internal_active": internal_active,
             "internal_queue": internal_queue,
             "history": history,
@@ -2007,6 +2093,8 @@ class RunManager:
         with self._lock:
             if self._active is run:
                 self._active = None
+            if self._enrich_active is run:
+                self._enrich_active = None
             if self._internal_active is run:
                 self._internal_active = None
             if run in self._pending:
@@ -2016,36 +2104,29 @@ class RunManager:
         self._persist_queue()
         self._prune_runs_by_id()
 
-    def _worker_loop(self, internal: bool = False) -> None:
-        lane_queue = self._internal_queue if internal else self._queue
+    def _worker_loop(self, lane: str = "fetcher") -> None:
+        lane_queue = self._lane_queue(lane)
         while True:
             try:
                 run = lane_queue.get()
-                # Shutdown sentinel: unblocks a worker parked on get() so
-                # join_threads() returns promptly instead of waiting out the
-                # full join timeout (the dominant cost in run-manager tests and
-                # in graceful tray/server quit).
                 if run is None:
                     return
                 if not run._finished.is_set():
                     with self._lock:
-                        if internal:
-                            self._internal_active = run
-                        else:
-                            self._active = run
+                        self._set_lane_active(lane, run)
                         if run.status == "queued":
                             run.status = "launching"
                     self._persist_queue()
                     try:
                         if run.status != "cancelled":
                             self._execute(run)
-                    except Exception as exc:  # noqa: BLE001 - surface anything the subprocess plumbing might raise.
+                    except Exception as exc:  # noqa: BLE001
                         if not run.cancelled:
                             run.status = "failed"
                             run.exit_code = -1
                             run.add_line("stderr", f"[server] worker error: {exc!r}")
                 self._finalize_run(run)
-            except Exception as exc:  # noqa: BLE001 - keep the worker alive
+            except Exception as exc:  # noqa: BLE001
                 print(f"[runs] worker loop error: {exc!r}", file=sys.stderr, flush=True)
                 time.sleep(0.5)
 

--- a/shared/pro_checkout.py
+++ b/shared/pro_checkout.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 PRO_CHECKOUT_MONTHLY = (
     "https://buy.polar.sh/polar_cl_1BV0qvxl87f2YEGmZo36HvXdmTf4GHthbIjh92P2yNw"
 )
@@ -10,5 +12,13 @@ PRO_CHECKOUT_YEARLY = (
 )
 
 
+def pro_checkout_enabled() -> bool:
+    """True when Polar checkout CTAs should be live (set BAKLOG_PRO_CHECKOUT=1)."""
+    raw = os.environ.get("BAKLOG_PRO_CHECKOUT", "0").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
 def public_checkout_urls() -> dict[str, str]:
+    if not pro_checkout_enabled():
+        return {"monthly": "", "yearly": ""}
     return {"monthly": PRO_CHECKOUT_MONTHLY, "yearly": PRO_CHECKOUT_YEARLY}

--- a/tests/cancel-in-flight.test.js
+++ b/tests/cancel-in-flight.test.js
@@ -214,7 +214,8 @@ describe('cancelInFlightRuns server truth', () => {
     const bulkCancels = fetchMock.mock.calls
       .map(c => String(c[0]))
       .filter(u => u.includes('/api/runs/cancel'));
-    expect(bulkCancels.every(u => u.includes('lane=fetcher'))).toBe(true);
+    expect(bulkCancels.some(u => u.includes('lane=fetcher'))).toBe(true);
+    expect(bulkCancels.some(u => u.includes('lane=enrich'))).toBe(true);
   });
 
   it('bumps cancel epoch when user cancels', async () => {

--- a/tests/connections-status-itch-cache.test.js
+++ b/tests/connections-status-itch-cache.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { state } from '../js/state.js';
+import {
+  setAuthStatusSnapshot,
+  visibleItchGames,
+  isItchTabAvailable,
+  hasCachedItchLibrary,
+} from '../js/connections-status.js';
+
+describe('connections-status itch cache', () => {
+  beforeEach(() => {
+    state.itchGames = [];
+    state.libraryMeta = state.libraryMeta || {};
+    state.libraryMeta.itch = null;
+    setAuthStatusSnapshot([
+      { key: 'itch', status: 'disconnected' },
+      { key: 'itch_local', status: 'disconnected' },
+    ]);
+  });
+
+  it('keeps cached itch rows visible when disconnected', () => {
+    state.itchGames = [{ store: 'itch', id: '1', name: 'Cached Game' }];
+    expect(hasCachedItchLibrary()).toBe(true);
+    expect(isItchTabAvailable()).toBe(true);
+    expect(visibleItchGames()).toHaveLength(1);
+  });
+
+  it('hides itch tab when disconnected and no cached library', () => {
+    expect(hasCachedItchLibrary()).toBe(false);
+    expect(isItchTabAvailable()).toBe(false);
+    expect(visibleItchGames()).toHaveLength(0);
+  });
+});

--- a/tests/dashboard-picks-row.test.js
+++ b/tests/dashboard-picks-row.test.js
@@ -111,7 +111,7 @@ describe('dashboard picks row', () => {
     expect(recap.querySelector('.itch-onboard-cta--primary')?.getAttribute('href')).toContain('itch.io/games/free');
   });
 
-  it('renders onboarding when a stale itch catalog exists but itch is not set up', async () => {
+  it('renders cached itch recap when disconnected but library data remains', async () => {
     const { setAuthStatusSnapshot } = await import('../js/connections-status.js');
     const { renderDashboardItchRecap } = await import('../js/dashboard-cards.js');
     setAuthStatusSnapshot([
@@ -124,8 +124,8 @@ describe('dashboard picks row', () => {
     document.getElementById('dashItchRecap').innerHTML = '';
     renderDashboardItchRecap();
     const recap = document.getElementById('dashItchRecap');
-    expect(recap.textContent).toContain('Start collecting free games on itch.io');
-    expect(recap.querySelector('.itch-value-block')).toBeFalsy();
+    expect(recap.textContent).not.toContain('Start collecting free games on itch.io');
+    expect(recap.querySelector('.itch-value-block')).toBeTruthy();
   });
 
   it('renders library value block when itch videogames exist', async () => {

--- a/tests/fetcher-health.test.js
+++ b/tests/fetcher-health.test.js
@@ -860,6 +860,144 @@ describe('reconcileRunStateFromSnapshot', () => {
     });
     expect(fetcherRunner.stateFor('hltb')).toBeNull();
   });
+
+  it('tracks enrich lane runs in inFlightKeys', () => {
+    fetcherRunner.markChipStateForTest('hltb', 'running', 'run-hltb-1');
+    fetcherRunner.reconcileRunStateFromSnapshot({
+      active: null,
+      queue: [],
+      enrich_active: { key: 'hltb', id: 'run-hltb-1', status: 'running' },
+      enrich_queue: [],
+      history: [],
+    });
+    expect(fetcherRunner.stateFor('hltb')).toBe('running');
+    fetcherRunner.markChipStateForTest('hltb', null);
+  });
+});
+
+describe('lane-aware queue slots', () => {
+  const stubFetchers = () => {
+    vi.stubGlobal('fetch', vi.fn(async (url) => {
+      const u = String(url);
+      if (u.includes('/api/runs')) {
+        return { ok: true, json: async () => ({ active: null, queue: [], history: [] }) };
+      }
+      if (u.includes('/api/fetchers')) {
+        return {
+          ok: true,
+          json: async () => ({
+            fetchers: [
+              { key: 'steam', label: 'Steam', group: 'library', metaKey: 'steam', available: true },
+              { key: 'hltb', label: 'HLTB', group: 'enrich', metaKey: 'hltb', available: true },
+            ],
+          }),
+        };
+      }
+      return { ok: false };
+    }));
+  };
+
+  beforeEach(async () => {
+    stubFetchers();
+    fetcherRunner.invalidateApiProbe();
+    await fetcherRunner.probeApi(true);
+    fetcherRunner.applyServerSnapshotInFlight({});
+    fetcherRunner.markChipStateForTest('steam', null);
+    fetcherRunner.markChipStateForTest('hltb', null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    fetcherRunner.applyServerSnapshotInFlight({});
+    fetcherRunner.markChipStateForTest('steam', null);
+    fetcherRunner.markChipStateForTest('hltb', null);
+  });
+
+  it('fetcher lane busy blocks library keys only', () => {
+    fetcherRunner.applyServerSnapshotInFlight({
+      active: { key: 'steam', id: 'r1', status: 'running' },
+    });
+    expect(fetcherRunner.isQueueFullForKey('steam')).toBe(true);
+    expect(fetcherRunner.isQueueFullForKey('hltb')).toBe(false);
+    expect(fetcherRunner.getLastServerInFlight()).toBe(true);
+  });
+
+  it('enrich lane busy blocks enrich keys only', () => {
+    fetcherRunner.applyServerSnapshotInFlight({
+      enrich_active: { key: 'hltb', id: 'r2', status: 'running' },
+    });
+    expect(fetcherRunner.isQueueFullForKey('hltb')).toBe(true);
+    expect(fetcherRunner.isQueueFullForKey('steam')).toBe(false);
+  });
+
+  it('both lanes busy block both key types', () => {
+    fetcherRunner.applyServerSnapshotInFlight({
+      active: { key: 'steam', id: 'r1', status: 'running' },
+      enrich_active: { key: 'hltb', id: 'r2', status: 'running' },
+    });
+    expect(fetcherRunner.isQueueFullForKey('steam')).toBe(true);
+    expect(fetcherRunner.isQueueFullForKey('hltb')).toBe(true);
+  });
+
+  it('client-side running state is lane-scoped', () => {
+    fetcherRunner.markChipStateForTest('steam', 'running', 'run-steam-1');
+    expect(fetcherRunner.isQueueFullForKey('steam')).toBe(true);
+    expect(fetcherRunner.isQueueFullForKey('hltb')).toBe(false);
+    fetcherRunner.markChipStateForTest('steam', null);
+    fetcherRunner.markChipStateForTest('hltb', 'running', 'run-hltb-1');
+    expect(fetcherRunner.isQueueFullForKey('hltb')).toBe(true);
+    expect(fetcherRunner.isQueueFullForKey('steam')).toBe(false);
+    fetcherRunner.markChipStateForTest('hltb', null);
+  });
+});
+
+describe('cancel enrich lane', () => {
+  beforeEach(async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url, opts = {}) => {
+      const u = String(url);
+      if (u.includes('/api/runs') && !u.includes('/cancel')) {
+        return {
+          ok: true,
+          json: async () => ({
+            active: null,
+            queue: [],
+            enrich_active: { id: 'enrich-1', key: 'hltb', status: 'running' },
+            enrich_queue: [],
+            history: [],
+          }),
+        };
+      }
+      if (u.includes('/api/runs/cancel')) {
+        return { ok: true, json: async () => ({ cancelled: [{ id: 'enrich-1' }] }) };
+      }
+      if (u.includes('/api/fetchers') || u.includes('manifest.json')) {
+        return { ok: true, json: async () => ({ fetchers: [] }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    }));
+    fetcherRunner.invalidateApiProbe();
+    fetcherRunner.setCancelInFlightForTest(false);
+    await fetcherRunner.probeApi(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    fetcherRunner.applyServerSnapshotInFlight({});
+  });
+
+  it('posts cancel for fetcher and enrich lanes', async () => {
+    await fetcherRunner.cancelInFlightRuns();
+    const fetchMock = /** @type {import('vitest').Mock} */ (globalThis.fetch);
+    await vi.waitFor(() => {
+      const cancelUrls = fetchMock.mock.calls
+        .map(([url]) => String(url))
+        .filter(u => u.includes('/api/runs/cancel'));
+      expect(cancelUrls.some(u => u.includes('lane=fetcher'))).toBe(true);
+      expect(cancelUrls.some(u => u.includes('lane=enrich'))).toBe(true);
+    });
+  });
 });
 
 describe('syncLogHeightToCard', () => {

--- a/tests/itch-tab-visibility.test.js
+++ b/tests/itch-tab-visibility.test.js
@@ -54,14 +54,14 @@ describe('isItchTabAvailable', () => {
     expect(isItchTabAvailable()).toBe(true);
   });
 
-  it('is false when disconnected even if a stale itch catalog is on disk', async () => {
+  it('stays available when disconnected but a cached itch catalog exists', async () => {
     mockAuthStatus([
       { key: 'itch', status: 'disconnected' },
       { key: 'itch_local', status: 'disconnected' },
     ]);
     state.itchGames = [{ store: 'itch', id: 'a', name: 'Demo Game' }];
     await refreshConnections();
-    expect(isItchTabAvailable()).toBe(false);
+    expect(isItchTabAvailable()).toBe(true);
   });
 });
 
@@ -114,7 +114,7 @@ describe('applyItchTabVisibility', () => {
     expect(loadActiveView()).toBe('itch');
   });
 
-  it('redirects from itch to dashboard once auth and library data are known', async () => {
+  it('redirects from itch to dashboard when disconnected and library is empty', async () => {
     state.activeView = 'itch';
     saveActiveView('itch');
     state.dashboardDataReady = true;
@@ -122,5 +122,19 @@ describe('applyItchTabVisibility', () => {
     await refreshConnections();
     applyItchTabVisibility();
     expect(loadActiveView()).toBe('dashboard');
+  });
+
+  it('keeps itch view when disconnected but cached library exists', async () => {
+    state.activeView = 'itch';
+    saveActiveView('itch');
+    state.dashboardDataReady = true;
+    state.itchGames = [{ store: 'itch', id: 'a', name: 'Demo Game' }];
+    mockAuthStatus([
+      { key: 'itch', status: 'disconnected' },
+      { key: 'itch_local', status: 'disconnected' },
+    ]);
+    await refreshConnections();
+    applyItchTabVisibility();
+    expect(loadActiveView()).toBe('itch');
   });
 });

--- a/tests/landing-pro-config.test.js
+++ b/tests/landing-pro-config.test.js
@@ -1,0 +1,31 @@
+/* @vitest-environment node */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import proConfigHandler from "../landing/api/pro-config.js";
+
+const { fetch: handleProConfig } = proConfigHandler;
+
+describe("landing/api/pro-config.js", () => {
+  beforeEach(() => {
+    delete process.env.BAKLOG_PRO_CHECKOUT;
+  });
+
+  afterEach(() => {
+    delete process.env.BAKLOG_PRO_CHECKOUT;
+  });
+
+  it("defaults checkout off during beta", async () => {
+    const res = await handleProConfig();
+    const json = await res.json();
+    expect(json.proCheckoutEnabled).toBe(false);
+    expect(json.proCheckout).toEqual({ monthly: "", yearly: "" });
+  });
+
+  it("enables checkout URLs when BAKLOG_PRO_CHECKOUT=1", async () => {
+    process.env.BAKLOG_PRO_CHECKOUT = "1";
+    const res = await handleProConfig();
+    const json = await res.json();
+    expect(json.proCheckoutEnabled).toBe(true);
+    expect(json.proCheckout.monthly).toContain("buy.polar.sh");
+    expect(json.proCheckout.yearly).toContain("buy.polar.sh");
+  });
+});

--- a/tests/landing-report.test.js
+++ b/tests/landing-report.test.js
@@ -156,4 +156,20 @@ describe("landing/api/report.js", () => {
     expect(payload.reply_to).toBe("tester@example.com");
     expect(payload.subject).toContain("BAKLOG bug report");
   });
+
+  it("uses ManualReport subject when the bundle has no captured errors", async () => {
+    const res = await handleReport(makeRequest({
+      bundle: {
+        ...validBundle(),
+        errors: { session: [], persisted: [] },
+      },
+      note: "Pro activation failed",
+    }, { ip: "10.0.0.88" }));
+    expect(res.status).toBe(200);
+    const [, opts] = fetchMock.mock.calls[0];
+    const payload = JSON.parse(opts.body);
+    expect(payload.subject).toContain("ManualReport");
+    expect(payload.text).toContain("ManualReport: (no errors captured)");
+    expect(payload.text).not.toContain("undefined:");
+  });
 });

--- a/tests/polar-webhook.test.js
+++ b/tests/polar-webhook.test.js
@@ -99,4 +99,119 @@ describe('polar-webhook', () => {
     }));
     expect(res.status).toBe(403);
   });
+
+  it('returns 500 when webhook env is missing', async () => {
+    vi.resetModules();
+    delete process.env.POLAR_WEBHOOK_SECRET;
+    process.env.SUPABASE_URL = SUPABASE_URL;
+    process.env.SUPABASE_SERVICE_ROLE_KEY = SERVICE_KEY;
+    const mod = await import('../landing/api/polar-webhook.js');
+    const res = await mod.default.fetch(new Request('https://baklog.app/api/polar-webhook', { method: 'POST', body: '{}' }));
+    expect(res.status).toBe(500);
+  });
+
+  it('sets pro via external_customer_id without email lookup', async () => {
+    const userId = '22222222-2222-4222-8222-222222222222';
+    const { res, json, fetchMock } = await postWebhook({
+      type: 'order.paid',
+      data: {
+        product: { metadata: { plan: 'pro' } },
+        customer: { external_id: userId, email: 'buyer@example.com' },
+      },
+    });
+    expect(res.status).toBe(202);
+    expect(json.plan).toBe('pro');
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/rpc/get_user_id_by_email'))).toBe(false);
+    const adminCall = fetchMock.mock.calls.find(([url]) => String(url).includes('/auth/v1/admin/users/'));
+    expect(adminCall?.[1]?.body).toContain('"plan":"pro"');
+  });
+
+  it('downgrades to free on subscription.revoked', async () => {
+    const { res, json, fetchMock } = await postWebhook({
+      type: 'subscription.revoked',
+      data: {
+        product: { metadata: { plan: 'pro' } },
+        customer: { email: 'buyer@example.com' },
+      },
+    });
+    expect(res.status).toBe(202);
+    expect(json.plan).toBe('free');
+    const adminCall = fetchMock.mock.calls.find(([url]) => String(url).includes('/auth/v1/admin/users/'));
+    expect(adminCall?.[1]?.body).toContain('"plan":"free"');
+  });
+
+  it('acknowledges unmatched buyers without updating Supabase', async () => {
+    vi.resetModules();
+    process.env.POLAR_WEBHOOK_SECRET = WEBHOOK_SECRET;
+    process.env.SUPABASE_URL = SUPABASE_URL;
+    process.env.SUPABASE_SERVICE_ROLE_KEY = SERVICE_KEY;
+    const body = JSON.stringify({
+      type: 'subscription.active',
+      data: { product: {}, customer: { email: 'unknown@example.com' } },
+    });
+    const sig = signBody(body);
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).includes('/rpc/get_user_id_by_email')) {
+        return { ok: true, json: async () => null };
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const mod = await import('../landing/api/polar-webhook.js');
+    const res = await mod.default.fetch(new Request('https://baklog.app/api/polar-webhook', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'webhook-id': sig.id,
+        'webhook-timestamp': sig.timestamp,
+        'webhook-signature': sig.signature,
+      },
+      body,
+    }));
+    const json = await res.json();
+    expect(res.status).toBe(202);
+    expect(json.matched).toBe(false);
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/auth/v1/admin/users/'))).toBe(false);
+  });
+
+  it('accepts whsec_ prefixed signing secrets', async () => {
+    const whsecBody = JSON.stringify({
+      type: 'subscription.active',
+      data: {
+        product: { metadata: { plan: 'pro' } },
+        customer: { email: 'buyer@example.com' },
+      },
+    });
+    const id = 'msg_whsec_1';
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const rawSecret = 'polar_test_secret';
+    const keyBytes = Buffer.from(rawSecret, 'utf8');
+    const mac = createHmac('sha256', keyBytes).update(`${id}.${timestamp}.${whsecBody}`).digest('base64');
+    vi.resetModules();
+    process.env.POLAR_WEBHOOK_SECRET = `whsec_${Buffer.from(rawSecret).toString('base64')}`;
+    process.env.SUPABASE_URL = SUPABASE_URL;
+    process.env.SUPABASE_SERVICE_ROLE_KEY = SERVICE_KEY;
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).includes('/rpc/get_user_id_by_email')) {
+        return { ok: true, json: async () => '11111111-1111-4111-8111-111111111111' };
+      }
+      if (String(url).includes('/auth/v1/admin/users/')) {
+        return { ok: true, json: async () => ({}) };
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const mod = await import('../landing/api/polar-webhook.js');
+    const res = await mod.default.fetch(new Request('https://baklog.app/api/polar-webhook', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'webhook-id': id,
+        'webhook-timestamp': timestamp,
+        'webhook-signature': `v1,${mac}`,
+      },
+      body: whsecBody,
+    }));
+    expect(res.status).toBe(202);
+  });
 });

--- a/tests/pro-view.test.js
+++ b/tests/pro-view.test.js
@@ -6,6 +6,7 @@ vi.mock('../js/auth-gate.js', () => ({
   isAccountAuthMode: vi.fn(() => false),
   isLocalProfilesEnabled: vi.fn(() => false),
   licenseActivationEnabled: vi.fn(() => true),
+  proCheckoutEnabled: vi.fn(() => true),
   proCheckoutUrls: vi.fn(() => ({})),
   getAccountEmail: vi.fn(() => ''),
   getAccountProfileId: vi.fn(() => ''),
@@ -38,8 +39,11 @@ describe('proPromoBannerHtml', () => {
 });
 
 describe('renderProView', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     document.body.innerHTML = '<div id="proContainer"><div id="proViewRoot"></div></div>';
+    const authGate = await import('../js/auth-gate.js');
+    authGate.licenseActivationEnabled.mockReturnValue(true);
+    authGate.proCheckoutEnabled.mockReturnValue(true);
   });
 
   it('renders conversion funnel with hero banner, toggle, six perks, and license field', async () => {
@@ -65,12 +69,23 @@ describe('renderProView', () => {
   it('shows license field and refresh even when license activation is disabled in config', async () => {
     const authGate = await import('../js/auth-gate.js');
     authGate.licenseActivationEnabled.mockReturnValue(false);
+    authGate.proCheckoutEnabled.mockReturnValue(false);
     const { renderProView } = await import('../js/pro-view.js');
     renderProView();
     const root = document.getElementById('proViewRoot');
-    expect(root.querySelector('[data-pro-license-form]')).toBeTruthy();
+    expect(root.querySelector('[data-pro-license-form]')).toBeNull();
     expect(root.querySelector('[data-pro-refresh]')).toBeTruthy();
-    expect(root.innerHTML).not.toContain('BAKLOG_POLAR_ORG_ID');
+    expect(root.innerHTML).toContain('BAKLOG_POLAR_ORG_ID');
+  });
+
+  it('hides checkout CTAs when proCheckoutEnabled is false', async () => {
+    const authGate = await import('../js/auth-gate.js');
+    authGate.proCheckoutEnabled.mockReturnValue(false);
+    const { renderProView } = await import('../js/pro-view.js');
+    renderProView();
+    const root = document.getElementById('proViewRoot');
+    expect(root.querySelector('[data-pro-checkout]')).toBeNull();
+    expect(root.innerHTML).toContain('Checkout is closed during beta');
   });
 
   it('switches checkout label and hero banner when monthly plan is selected', async () => {
@@ -158,6 +173,7 @@ describe('post-checkout return', () => {
   it('handleCheckoutSuccessReturn focuses license key for local-only users', async () => {
     const authGate = await import('../js/auth-gate.js');
     authGate.isAccountAuthMode.mockReturnValue(false);
+    authGate.licenseActivationEnabled.mockReturnValue(true);
     const input = document.getElementById('proViewLicenseKey');
     const focusSpy = vi.spyOn(input, 'focus');
     const { markCheckoutSuccessPending, handleCheckoutSuccessReturn } = await import('../js/pro-view.js');

--- a/tests/test_auth_manager_profile.py
+++ b/tests/test_auth_manager_profile.py
@@ -100,3 +100,26 @@ def test_clear_browser_session_removes_profile_dir(
 
     auth_manager.clear_browser_session("xbox_wishlist")
     assert not prof.exists()
+
+
+def test_start_browser_auth_rejects_overlapping_provider_session(
+    profile_env: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow_run(_provider: str, _session: object) -> dict[str, str]:
+        started.set()
+        release.wait(timeout=5.0)
+        return {"token": "x"}
+
+    monkeypatch.setattr(auth_manager, "run_browser_auth", slow_run)
+    monkeypatch.setattr(auth_manager, "mark_connected", lambda _p, _c: None)
+
+    auth_manager.start_browser_auth("steam")
+    assert started.wait(timeout=3.0)
+
+    with pytest.raises(ValueError, match="already open"):
+        auth_manager.start_browser_auth("steam")
+
+    release.set()

--- a/tests/test_cdp_browser.py
+++ b/tests/test_cdp_browser.py
@@ -24,6 +24,8 @@ from auth.cdp_browser import (
     _BROWSER_LAUNCH_HINT,
     CdpContext,
     CdpPage,
+    CdpRequest,
+    CdpResponse,
     _cdp_websocket_error,
     _chromium_executable_candidates,
     _should_preserve_popup,
@@ -63,7 +65,7 @@ class TestCookieHeader:
 class TestBlankUrl:
     @pytest.mark.parametrize(
         "url",
-        ["", "about:blank", "chrome://newtab/"],
+        ["", "about:blank", "chrome://newtab/", "chrome://new-tab-page/"],
     )
     def test_blank_urls(self, url: str) -> None:
         assert is_blank_browser_url(url)
@@ -110,6 +112,28 @@ class TestRegisterPageDebugger:
         assert not any(m.startswith("Debugger.") for m, _ in calls)
         assert ("Page.enable", "SESSION-1") in calls
         assert ("Network.enable", "SESSION-1") in calls
+
+
+class TestCdpContextResponseHandlers:
+    def test_dispatch_response_invokes_context_handlers(self) -> None:
+        ctx = _bare_context()
+        ctx._request_handlers = []
+        ctx._response_handlers = []
+        page = CdpPage(ctx, "TARGET-1", "SESSION-1")
+        seen: list[str] = []
+
+        ctx.on("response", lambda _resp: seen.append("ctx"))
+        req = CdpRequest(url="https://example.com/gql", headers={})
+        resp = CdpResponse(
+            url=req.url,
+            status=200,
+            request=req,
+            headers={},
+            _page=page,
+            _request_id="req-1",
+        )
+        page._dispatch_response(resp)
+        assert seen == ["ctx"]
 
 
 class TestCdpErrors:

--- a/tests/test_connect_extractors_sniffers.py
+++ b/tests/test_connect_extractors_sniffers.py
@@ -1,0 +1,32 @@
+"""Unit tests for shared connect extractor sniffers."""
+
+from __future__ import annotations
+
+from auth.connect_extractors import DeferredGraphqlResponseSniffer, build_epic_wishlist_graphql_sniffer
+
+
+class _FakeResponse:
+    def __init__(self, url: str, payload: dict, *, status: int = 200) -> None:
+        self.url = url
+        self.status = status
+        self._payload = payload
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def test_deferred_graphql_sniffer_parses_on_drain() -> None:
+    sniffer = DeferredGraphqlResponseSniffer(
+        url_match=lambda u: "graphql" in u,
+        accept=lambda p: bool(p.get("ok")),
+    )
+    sniffer._pending.append(_FakeResponse("https://x/graphql", {"ok": True}))
+    assert sniffer.drain() is True
+    assert sniffer.success is True
+
+
+def test_epic_wishlist_sniffer_accepts_wishlist_payload() -> None:
+    sniffer = build_epic_wishlist_graphql_sniffer()
+    payload = {"data": {"Wishlist": {"wishlistItems": {"elements": []}}}}
+    sniffer._pending.append(_FakeResponse("https://store.epicgames.com/graphql", payload))
+    assert sniffer.drain() is True

--- a/tests/test_connect_loop.py
+++ b/tests/test_connect_loop.py
@@ -1,0 +1,68 @@
+"""Unit tests for auth.connect_loop.run_connect_poll."""
+
+from __future__ import annotations
+
+import pytest
+
+from auth.connect_loop import run_connect_poll
+
+
+class _FakeTime:
+    def __init__(self, step_s: float = 1.0) -> None:
+        self.t = 0.0
+        self.step_s = step_s
+
+    def time(self) -> float:
+        self.t += self.step_s
+        return self.t
+
+
+class _FakePage:
+    def wait_for_timeout(self, _ms: int) -> None:
+        return None
+
+
+class _FakeContext:
+    def __init__(self) -> None:
+        self.pages = [_FakePage()]
+
+
+def test_run_connect_poll_returns_when_check_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    clock = _FakeTime(step_s=1.0)
+    monkeypatch.setattr("auth.connect_loop.time", clock)
+    monkeypatch.setattr("auth.connect_loop.abort_if_browser_closed", lambda _ctx: None)
+
+    calls = {"n": 0}
+
+    def check() -> dict[str, str] | None:
+        calls["n"] += 1
+        if calls["n"] >= 2:
+            return {"TOKEN": "ok"}
+        return None
+
+    creds = run_connect_poll(
+        context=_FakeContext(),
+        session=None,
+        deadline=clock.time() + 60,
+        poll_sec=0.1,
+        check=check,
+        timeout_message="timed out",
+    )
+    assert creds == {"TOKEN": "ok"}
+    assert calls["n"] == 2
+
+
+def test_run_connect_poll_raises_on_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    clock = _FakeTime(step_s=5.0)
+    monkeypatch.setattr("auth.connect_loop.time", clock)
+    monkeypatch.setattr("auth.connect_loop.abort_if_browser_closed", lambda _ctx: None)
+
+    with pytest.raises(RuntimeError, match="no session"):
+        run_connect_poll(
+            context=_FakeContext(),
+            session=None,
+            deadline=clock.time() + 10,
+            poll_sec=0.1,
+            check=lambda: None,
+            timeout_message="no session",
+        )

--- a/tests/test_ea_bearer_probe.py
+++ b/tests/test_ea_bearer_probe.py
@@ -1,0 +1,25 @@
+"""EA connect bearer probe edge cases."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from auth.connect_extractors import HeaderSniffer, extract_ea_bearer_session
+from clients.ea_session import EA_GRAPHQL_HOST, normalize_bearer
+
+
+def test_extract_ea_accepts_sniffed_bearer_when_apq_stale(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "clients.ea_session.probe_ea_token",
+        lambda _t, _c: {"ok": False, "error": "EA GraphQL HTTP 400: PersistedQueryNotFound"},
+    )
+    sniffer = HeaderSniffer(
+        url_substr=EA_GRAPHQL_HOST,
+        fields={"authorization": "EA_BEARER_TOKEN"},
+        normalize=normalize_bearer,
+    )
+    sniffer.captured["EA_BEARER_TOKEN"] = "live-token"
+    ctx = MagicMock()
+    ctx.cookies.return_value = []
+    creds = extract_ea_bearer_session(ctx, sniffer=sniffer)
+    assert creds == {"EA_PROFILE": "ready", "EA_BEARER_TOKEN": "live-token"}

--- a/tests/test_ea_connect_loop.py
+++ b/tests/test_ea_connect_loop.py
@@ -1,4 +1,4 @@
-"""Tests for EA Connections session validation."""
+"""Fake-CDP loop test: EA connect sniffs Bearer and probes before saving."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from auth.runner import _extract_ea
+import auth.runner as runner
 
 
 class _FakeTime:
@@ -33,11 +33,11 @@ class _FakePage:
         pass
 
 
-def test_extract_ea_returns_bearer_token(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_extract_ea_uses_header_sniffer(monkeypatch: pytest.MonkeyPatch) -> None:
     clock = _FakeTime(step_s=5.0)
-    monkeypatch.setattr("auth.runner.time", clock)
+    monkeypatch.setattr(runner, "time", clock)
     monkeypatch.setattr("auth.connect_loop.time", clock)
-    monkeypatch.setattr("auth.runner.abort_if_browser_closed", lambda _ctx: None)
+    monkeypatch.setattr(runner, "abort_if_browser_closed", lambda _ctx: None)
     monkeypatch.setattr("clients.ea_session.probe_ea_token", lambda _t, _c: {"ok": True})
 
     handlers: list = []
@@ -52,17 +52,19 @@ def test_extract_ea_returns_bearer_token(monkeypatch: pytest.MonkeyPatch) -> Non
         def cookies(self) -> list:
             return []
 
-    def _inject_token(_self, _ms: int) -> None:
+    ctx = Ctx()
+    page = _FakePage()
+
+    def _inject_token() -> None:
         for h in handlers:
             h(
                 MagicMock(
                     url="https://service-aggregation-layer.juno.ea.com/graphql",
-                    headers={"Authorization": "Bearer connect-token"},
+                    headers={"Authorization": "Bearer loop-token"},
                 )
             )
 
-    monkeypatch.setattr(_FakePage, "wait_for_timeout", _inject_token)
+    monkeypatch.setattr(_FakePage, "wait_for_timeout", lambda _self, _ms: _inject_token())
 
-    creds = _extract_ea(_FakePage(), Ctx())
-    assert creds["EA_PROFILE"] == "ready"
-    assert creds["EA_BEARER_TOKEN"] == "connect-token"
+    creds = runner._extract_ea(page, ctx, session=None)
+    assert creds == {"EA_PROFILE": "ready", "EA_BEARER_TOKEN": "loop-token"}

--- a/tests/test_fetch_ea.py
+++ b/tests/test_fetch_ea.py
@@ -50,3 +50,26 @@ def test_stored_token_skips_sniff(monkeypatch) -> None:
     assert token == "stored-tok"
     assert cookies == []
     assert dbg.get("token_source") == "stored"
+
+
+def test_stored_token_apq_stale_skips_sniff(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "fetchers.fetch_ea.resolve_env",
+        lambda key, **_k: "stored-tok" if key == "EA_BEARER_TOKEN" else "",
+    )
+    monkeypatch.setattr(
+        "fetchers.fetch_ea.probe_ea_token",
+        lambda *_a, **_k: {
+            "ok": False,
+            "error": 'EA GraphQL HTTP 400: {"errors":[{"message":"PersistedQueryNotFound"}]}',
+        },
+    )
+
+    with patch("auth.cdp_browser.launch_persistent_profile") as mock_launch:
+        import fetchers.fetch_ea as fetch_ea
+
+        token, cookies, dbg = fetch_ea._resolve_session(headless=True)
+        mock_launch.assert_not_called()
+
+    assert token == "stored-tok"
+    assert dbg.get("token_source") == "stored_apq_stale"

--- a/tests/test_fetcher_argparse.py
+++ b/tests/test_fetcher_argparse.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+from fetchers.registry import MANIFEST_PATH
+
 ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_ENTRIES = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))["fetchers"]
 
 
 def _run_help(script: str) -> subprocess.CompletedProcess[str]:
@@ -63,3 +69,29 @@ def test_fetch_humble_accepts_skip_hltb_flag() -> None:
     proc = _run_help("fetch_humble.py")
     assert proc.returncode == 0, proc.stderr or proc.stdout
     assert "--skip-hltb" in (proc.stdout or "")
+
+
+def test_manifest_has_27_fetchers() -> None:
+    assert len(MANIFEST_ENTRIES) == 27
+
+
+@pytest.mark.parametrize("entry", MANIFEST_ENTRIES, ids=[e["key"] for e in MANIFEST_ENTRIES])
+def test_every_manifest_fetcher_help_exits_zero(entry: dict) -> None:
+    """Each registered source must parse --help without argparse conflicts."""
+    proc = _run_help(entry["script"])
+    combined = (proc.stdout or "") + (proc.stderr or "")
+    assert proc.returncode == 0, f"{entry['key']}: {combined}"
+    assert "conflicting option" not in combined.lower()
+
+
+@pytest.mark.parametrize("entry", MANIFEST_ENTRIES, ids=[e["key"] for e in MANIFEST_ENTRIES])
+def test_manifest_default_args_advertised_in_help(entry: dict) -> None:
+    """Dashboard default args must appear in each script's --help output."""
+    args = entry.get("args") or []
+    if not args:
+        return
+    proc = _run_help(entry["script"])
+    combined = (proc.stdout or "") + (proc.stderr or "")
+    assert proc.returncode == 0, combined
+    for arg in args:
+        assert arg in combined, f"{entry['key']}: {arg} missing from --help"

--- a/tests/test_fetcher_manifest_audit.py
+++ b/tests/test_fetcher_manifest_audit.py
@@ -83,6 +83,20 @@ def test_manifest_keys_unique() -> None:
     assert len(keys) == len(set(keys))
 
 
+def test_manifest_has_27_fetchers() -> None:
+    assert len(ENTRIES) == 27
+
+
+@pytest.mark.parametrize("entry", ENTRIES, ids=[e["key"] for e in ENTRIES])
+def test_manifest_entry_has_required_fields(entry: dict) -> None:
+    assert entry.get("key")
+    assert entry.get("label")
+    assert entry.get("group") in ("library", "wishlist", "prices", "enrich")
+    assert entry.get("script")
+    script = ROOT / entry["script"]
+    assert script.is_file(), f"{entry['key']}: missing {entry['script']}"
+
+
 def test_all_library_manifest_keys_in_app_js() -> None:
     lib_keys = {e["key"] for e in ENTRIES if e.get("group") == "library"}
     assert lib_keys == set(LIBRARY_STORE_JSON.keys())

--- a/tests/test_fetcher_manifest_audit.py
+++ b/tests/test_fetcher_manifest_audit.py
@@ -35,7 +35,7 @@ def _script_flags(script: str) -> set[str]:
     flags: set[str] = set()
     for m in re.finditer(r'add_argument\(\s*["\'](--[\w-]+)', text):
         flags.add(m.group(1))
-    if "add_hltb_args" in text:
+    if "add_hltb_args" in text or "add_only_new_arg" in text:
         base = (ROOT / "fetchers/_base.py").read_text(encoding="utf-8")
         for m in re.finditer(r'add_argument\(\s*["\'](--[\w-]+)', base):
             flags.add(m.group(1))
@@ -160,6 +160,16 @@ def test_manual_empty_guard(script: str) -> None:
 def test_documented_no_standard_empty_guard(script: str) -> None:
     """Enrichers mutate in place; Steam/PSN trust non-zero library from API."""
     assert script in NO_EMPTY_GUARD_SCRIPTS
+
+
+def test_library_wishlist_default_only_new() -> None:
+    """Incremental sync: library and wishlist fetchers default to --only-new."""
+    for entry in ENTRIES:
+        group = entry.get("group")
+        if group not in ("library", "wishlist"):
+            continue
+        args = entry.get("args") or []
+        assert "--only-new" in args, f"{entry['key']}: missing --only-new in manifest args"
 
 
 def test_registry_validate_manifest() -> None:

--- a/tests/test_gog_connect_loop.py
+++ b/tests/test_gog_connect_loop.py
@@ -1,0 +1,52 @@
+"""Fake-CDP loop test: GOG inline connect uses shared poll + cookie extract."""
+
+from __future__ import annotations
+
+import pytest
+
+import auth.runner as runner
+from auth.connect_extractors import pick_gog_al_from_cookies
+
+
+class _FakeTime:
+    def __init__(self, step_s: float = 1.0) -> None:
+        self.t = 0.0
+        self.step_s = step_s
+
+    def time(self) -> float:
+        self.t += self.step_s
+        return self.t
+
+
+class _FakePage:
+    url = "https://www.gog.com/"
+
+    def goto(self, *_a, **_k) -> None:
+        return None
+
+    def wait_for_timeout(self, _ms: int) -> None:
+        return None
+
+
+class _FakeContext:
+    def __init__(self, cookies: list[dict]) -> None:
+        self._cookies = cookies
+        self.pages = [_FakePage()]
+
+    def cookies(self) -> list[dict]:
+        return list(self._cookies)
+
+
+def test_gog_inline_connect_returns_gog_al(monkeypatch: pytest.MonkeyPatch) -> None:
+    clock = _FakeTime(step_s=5.0)
+    monkeypatch.setattr(runner, "time", clock)
+    monkeypatch.setattr("auth.connect_loop.time", clock)
+    monkeypatch.setattr("auth.connect_loop.abort_if_browser_closed", lambda _ctx: None)
+
+    cookies = [{"name": "gog-al", "value": "inline-token", "domain": ".gog.com"}]
+    ctx = _FakeContext(cookies)
+    page = _FakePage()
+
+    creds = runner._extract_gog_inline(page, ctx, session=None)
+    assert creds == {"GOG_AL": "inline-token"}
+    assert pick_gog_al_from_cookies(cookies) == "inline-token"

--- a/tests/test_grant_beta_pro.py
+++ b/tests/test_grant_beta_pro.py
@@ -1,0 +1,62 @@
+"""Tests for scripts/grant_beta_pro.py (hosted Pro bulk grant)."""
+
+from __future__ import annotations
+
+import scripts.grant_beta_pro as grant
+
+
+def test_main_dry_run_lists_users(monkeypatch, capsys) -> None:
+    monkeypatch.setenv("SUPABASE_URL", "https://demo.supabase.co")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "service-key")
+
+    def fake_list(_base: str, _key: str) -> list[dict]:
+        return [
+            {
+                "id": "11111111-1111-4111-8111-111111111111",
+                "email": "beta@example.com",
+                "app_metadata": {"plan": "free"},
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+        ]
+
+    monkeypatch.setattr(grant, "_list_users", fake_list)
+    monkeypatch.setattr(grant, "_request", lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not write")))
+
+    rc = grant.main(["--email", "beta@example.com"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "DRY-RUN" in out
+    assert "beta@example.com" in out
+    assert "'free' -> 'pro'" in out
+
+
+def test_main_apply_updates_user(monkeypatch, capsys) -> None:
+    monkeypatch.setenv("SUPABASE_URL", "https://demo.supabase.co")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "service-key")
+    writes: list[tuple] = []
+
+    def fake_list(_base: str, _key: str) -> list[dict]:
+        return [
+            {
+                "id": "11111111-1111-4111-8111-111111111111",
+                "email": "beta@example.com",
+                "app_metadata": {"plan": "free", "beta": True},
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+        ]
+
+    def fake_request(method, url, *, key, body=None):
+        writes.append((method, url, body))
+        return {}
+
+    monkeypatch.setattr(grant, "_list_users", fake_list)
+    monkeypatch.setattr(grant, "_request", fake_request)
+
+    rc = grant.main(["--email", "beta@example.com", "--apply"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "APPLY" in out
+    assert len(writes) == 1
+    assert writes[0][0] == "PUT"
+    assert writes[0][2]["app_metadata"]["plan"] == "pro"
+    assert writes[0][2]["app_metadata"]["beta"] is True

--- a/tests/test_nintendo_connect_loop.py
+++ b/tests/test_nintendo_connect_loop.py
@@ -79,11 +79,10 @@ def test_nintendo_connect_drives_non_blank_tab(monkeypatch: pytest.MonkeyPatch) 
 
     login.goto = _goto  # type: ignore[method-assign]
 
-    monkeypatch.setattr(runner, "_nintendo_has_session", lambda _ctx: True)
-    monkeypatch.setattr(runner, "_nintendo_session_has_id_token", lambda _ctx: True)
+    monkeypatch.setattr("auth.connect_extractors.nintendo_has_session", lambda _ctx: True)
+    monkeypatch.setattr("auth.connect_extractors.nintendo_session_has_id_token", lambda _ctx: True)
     monkeypatch.setattr(
-        runner,
-        "_cookie_header",
+        "auth.connect_extractors._cookie_header",
         lambda _cookies, _domains: "NASID=abc; idToken=tok",
     )
 

--- a/tests/test_pro_checkout.py
+++ b/tests/test_pro_checkout.py
@@ -1,0 +1,42 @@
+"""Polar checkout URL gating (beta vs public rollout)."""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.pro_checkout import (
+    PRO_CHECKOUT_MONTHLY,
+    pro_checkout_enabled,
+    public_checkout_urls,
+)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("0", False),
+        ("1", True),
+        ("true", True),
+        ("yes", True),
+        ("on", True),
+        ("", False),
+    ],
+)
+def test_pro_checkout_enabled_env(monkeypatch: pytest.MonkeyPatch, value: str, expected: bool) -> None:
+    if value:
+        monkeypatch.setenv("BAKLOG_PRO_CHECKOUT", value)
+    else:
+        monkeypatch.delenv("BAKLOG_PRO_CHECKOUT", raising=False)
+    assert pro_checkout_enabled() is expected
+
+
+def test_public_checkout_urls_empty_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BAKLOG_PRO_CHECKOUT", raising=False)
+    assert public_checkout_urls() == {"monthly": "", "yearly": ""}
+
+
+def test_public_checkout_urls_populated_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BAKLOG_PRO_CHECKOUT", "1")
+    urls = public_checkout_urls()
+    assert urls["monthly"] == PRO_CHECKOUT_MONTHLY
+    assert urls["yearly"]

--- a/tests/test_psn_client.py
+++ b/tests/test_psn_client.py
@@ -80,6 +80,46 @@ class _FakePsnMe:
         yield from self._entitlements
 
 
+def test_parallel_collect_walks_run_concurrently() -> None:
+    """title_stats, trophy_titles, and entitlements walks start in parallel."""
+    import threading
+    import time
+
+    lock = threading.Lock()
+    active: set[str] = set()
+    peak = 0
+
+    def track(name: str):
+        with lock:
+            active.add(name)
+            nonlocal peak
+            peak = max(peak, len(active))
+        time.sleep(0.05)
+        with lock:
+            active.discard(name)
+
+    class _SlowMe:
+        def title_stats(self, limit=None):
+            track("stats")
+            yield from [_stat(title_id="T1", name="Game A")]
+
+        def trophy_titles(self, limit=None):
+            track("trophy")
+            yield from [_trophy()]
+
+        def game_entitlements(self, limit=None):
+            track("ent")
+            yield from []
+
+    client = object.__new__(PsnClient)
+    client._client = _SlowMe()
+    client.last_dedupe_dropped = 0
+    client.last_filtered_non_games = 0
+    games = client.collect_library()
+    assert peak >= 2
+    assert len(games) >= 1
+
+
 def test_cross_gen_playtime_summed() -> None:
     ps4_min = int(timedelta(hours=2304, minutes=16).total_seconds() // 60)
     ps5_min = int(timedelta(hours=168).total_seconds() // 60)

--- a/tests/test_psn_connect.py
+++ b/tests/test_psn_connect.py
@@ -1,0 +1,40 @@
+"""PSN connect helpers — stale cookie must not block ssocookie API."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from auth.runner import _fetch_npsso_background
+
+
+def test_ssocookie_api_used_when_cookie_jar_empty() -> None:
+    page = MagicMock()
+    page.evaluate.return_value = "fresh-from-ssocookie-token-value"
+    context = MagicMock()
+    context.cookies.return_value = []
+
+    token, source = _fetch_npsso_background(page, context)
+    assert source == "ssocookie"
+    assert token == "fresh-from-ssocookie-token-value"
+
+
+def test_ssocookie_api_preferred_over_stale_cookie_jar() -> None:
+    page = MagicMock()
+    page.evaluate.return_value = "fresh-from-ssocookie"
+    context = MagicMock()
+    context.cookies.return_value = [{"name": "npsso", "value": "stale-jar-token"}]
+
+    token, source = _fetch_npsso_background(page, context)
+    assert source == "ssocookie"
+    assert token == "fresh-from-ssocookie"
+
+
+def test_cookie_jar_used_when_ssocookie_empty() -> None:
+    page = MagicMock()
+    page.evaluate.return_value = ""
+    context = MagicMock()
+    context.cookies.return_value = [{"name": "npsso", "value": "jar-only-token"}]
+
+    token, source = _fetch_npsso_background(page, context)
+    assert source == "cookie"
+    assert token == "jar-only-token"

--- a/tests/test_run_manager.py
+++ b/tests/test_run_manager.py
@@ -1159,3 +1159,40 @@ def test_force_reset_lane_fetcher_spares_internal(runs_env, internal_jobs) -> No
     assert not internal._finished.is_set()
     assert mgr._active is None
     assert mgr._internal_active is internal
+
+
+def _seed_fetcher_and_enrich_running(mgr, runs_dir):
+    fetcher = server.Run("demo", runs_dir=runs_dir)
+    fetcher.status = "running"
+    enrich = server.Run("hltb", runs_dir=runs_dir, enrich=True)
+    enrich.status = "running"
+    with mgr._lock:
+        mgr._active = fetcher
+        mgr._enrich_active = enrich
+        mgr._runs_by_id[fetcher.id] = fetcher
+        mgr._runs_by_id[enrich.id] = enrich
+    return fetcher, enrich
+
+
+def test_cancel_all_lane_fetcher_spares_enrich(runs_env) -> None:
+    mgr, runs_dir = runs_env
+    fetcher, enrich = _seed_fetcher_and_enrich_running(mgr, runs_dir)
+
+    cancelled = mgr.cancel_all(lane="fetcher")
+
+    assert {c["id"] for c in cancelled} == {fetcher.id}
+    assert fetcher._finished.is_set()
+    assert not enrich._finished.is_set()
+    assert mgr._enrich_active is enrich
+
+
+def test_cancel_all_lane_enrich_spares_fetcher(runs_env) -> None:
+    mgr, runs_dir = runs_env
+    fetcher, enrich = _seed_fetcher_and_enrich_running(mgr, runs_dir)
+
+    cancelled = mgr.cancel_all(lane="enrich")
+
+    assert {c["id"] for c in cancelled} == {enrich.id}
+    assert enrich._finished.is_set()
+    assert not fetcher._finished.is_set()
+    assert mgr._active is fetcher

--- a/tests/test_run_manager.py
+++ b/tests/test_run_manager.py
@@ -1054,6 +1054,35 @@ def test_fetcher_lane_parallel_to_internal(runs_env, internal_jobs) -> None:
     assert snap["active"]["key"] == "demo"
 
 
+def test_enrich_lane_parallel_to_fetcher(runs_env) -> None:
+    mgr, runs_dir = runs_env
+    monkeypatch_item = {
+        "label": "Enrich demo",
+        "argv": [server.sys.executable, "-c", "print('enrich')"],
+        "refreshArgs": [],
+        "metaKey": "enrich_demo",
+        "group": "enrich",
+        "color": "#fff",
+        "requires": [],
+    }
+    server.FETCHERS["enrich_demo"] = monkeypatch_item
+    try:
+        running = server.Run("demo", runs_dir=runs_dir)
+        running.status = "running"
+        with mgr._lock:
+            mgr._pending.append(running)
+            mgr._runs_by_id[running.id] = running
+            mgr._active = running
+
+        enrich = mgr.submit("enrich_demo")
+        assert enrich._enrich
+        snap = mgr.snapshot()
+        assert snap["active"]["key"] == "demo"
+        assert snap["enrich_active"]["key"] == "enrich_demo"
+    finally:
+        server.FETCHERS.pop("enrich_demo", None)
+
+
 def test_internal_lane_still_serializes_among_itself(runs_env, internal_jobs) -> None:
     mgr, runs_dir = runs_env
     running = server.Run(

--- a/tests/test_session_probe.py
+++ b/tests/test_session_probe.py
@@ -87,7 +87,7 @@ class TestProbeXboxWishlistSession:
 
 class TestQuietProbes:
     def test_probeable_quiet_set(self) -> None:
-        assert PROBEABLE_QUIET == frozenset({"gog", "epic", "steam", "itch", "itad"})
+        assert PROBEABLE_QUIET == frozenset({"gog", "epic", "steam", "itch", "itad", "psn"})
 
     def test_gog_quiet_ok(self) -> None:
         with patch("auth.session_probe.GogClient") as cls:

--- a/tests/test_steam_client_batch.py
+++ b/tests/test_steam_client_batch.py
@@ -1,0 +1,53 @@
+"""Steam store batch appdetails client tests."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from clients.steam_client import APP_DETAILS_BATCH_SIZE, SteamClient
+
+
+@pytest.fixture()
+def steam_client(tmp_path: Path) -> SteamClient:
+    return SteamClient("key", "76561198000000000", cache_dir=tmp_path / "steam")
+
+
+def test_get_app_details_batch_chunks_and_caches(steam_client: SteamClient) -> None:
+    appids = list(range(1, APP_DETAILS_BATCH_SIZE + 5))
+    calls: list[str] = []
+
+    def fake_get(url, params, **kwargs):
+        calls.append(str(params.get("appids")))
+        raw = {}
+        for part in str(params["appids"]).split(","):
+            aid = int(part)
+            raw[str(aid)] = {"success": True, "data": {"name": f"Game {aid}", "type": "game"}}
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = raw
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    with patch("clients.steam_client._get_with_retry", side_effect=fake_get):
+        with patch.object(steam_client, "_throttle_store"):
+            out = steam_client.get_app_details_batch(appids)
+
+    assert len(out) == len(appids)
+    assert out[1]["data"]["name"] == "Game 1"
+    assert len(calls) == 2
+    assert len(calls[0].split(",")) == APP_DETAILS_BATCH_SIZE
+    cache_path = steam_client._cache_path("appdetails", "42")
+    assert cache_path.exists()
+    cached = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert cached["success"] is True
+
+
+def test_get_app_details_batch_uses_cache(steam_client: SteamClient) -> None:
+    steam_client._write_cache("appdetails", "7", {"success": True, "data": {"name": "Cached"}})
+    with patch("clients.steam_client._get_with_retry") as mock_get:
+        out = steam_client.get_app_details_batch([7])
+    mock_get.assert_not_called()
+    assert out[7]["data"]["name"] == "Cached"

--- a/tests/test_ubisoft_connect_loop.py
+++ b/tests/test_ubisoft_connect_loop.py
@@ -1,0 +1,56 @@
+"""Fake-CDP loop test: Ubisoft connect captures API headers via HeaderSniffer."""
+
+from __future__ import annotations
+
+from auth.connect_extractors import (
+    build_ubisoft_header_sniffer,
+    extract_ubisoft_session,
+    ubisoft_session_captured,
+)
+
+
+class _FakeRequest:
+    def __init__(self, url: str, headers: dict[str, str]) -> None:
+        self.url = url
+        self.headers = headers
+
+
+class _FakeContext:
+    def __init__(self) -> None:
+        self._handlers: list = []
+
+    def on(self, event: str, handler) -> None:
+        if event == "request":
+            self._handlers.append(handler)
+
+    def emit_request(self, request: _FakeRequest) -> None:
+        for handler in self._handlers:
+            handler(request)
+
+
+def test_ubisoft_header_sniffer_captures_api_headers() -> None:
+    ctx = _FakeContext()
+    sniffer = build_ubisoft_header_sniffer()
+    sniffer.attach(ctx)
+    ctx.emit_request(
+        _FakeRequest(
+            "https://public-ubiservices.ubi.com/v1/profiles/me/games",
+            {
+                "authorization": "Ubi_v1 t=abc",
+                "ubi-sessionid": "sess-1",
+                "ubi-appid": "app-1",
+            },
+        )
+    )
+    assert ubisoft_session_captured(sniffer) is True
+    assert extract_ubisoft_session(sniffer) == {
+        "UBISOFT_AUTH": "Ubi_v1 t=abc",
+        "UBISOFT_SESSION_ID": "sess-1",
+        "UBISOFT_APP_ID": "app-1",
+    }
+
+
+def test_ubisoft_header_sniffer_does_not_require_app_id() -> None:
+    sniffer = build_ubisoft_header_sniffer()
+    sniffer.captured = {"UBISOFT_AUTH": "x", "UBISOFT_SESSION_ID": "y"}
+    assert extract_ubisoft_session(sniffer) == {"UBISOFT_AUTH": "x", "UBISOFT_SESSION_ID": "y"}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -17,6 +17,12 @@ const adminOnlyTests = [
 export default defineConfig({
   test: {
     environment: 'happy-dom',
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        execArgv: ['--no-experimental-webstorage'],
+      },
+    },
     include: ['tests/**/*.test.js'],
     // admin/ is gitignored (baklog-internal); skip its unit tests on public CI.
     exclude: adminPresent ? [] : adminOnlyTests,


### PR DESCRIPTION
## Summary
- **Fetch speed (Tiers 1–3):** `--only-new` defaults on library/wishlist fetchers, Steam batch appdetails, PSN parallel collect + fingerprint skip, GOG parallel web details, Epic entitlement-set diff + catalog cache, enrich run lane (server + UI), stale sweep ordering, Steam skip reviews on incremental.
- **Auth/connect:** Shared connect loop and extractors for smoother CDP sign-in (EA, GOG, PSN, Ubisoft, Nintendo, etc.).
- **Follow-ups:** Dashboard Cancel clears fetcher **and** enrich lanes (internal jobs untouched); lane-aware `isQueueFullForKey` Vitest coverage; pytest audit runs `--help` + default-arg checks on all **27** manifest fetchers; Vitest fork pool fix for Node 25 broken `localStorage`.

## Test plan
- [x] `pytest tests/test_fetcher_manifest_audit.py tests/test_fetcher_argparse.py` (231 parametrized checks incl. all 27 `--help`)
- [x] `pytest tests/test_run_manager.py` enrich lane + cancel lane tests
- [x] `npm test -- tests/fetcher-health.test.js tests/cancel-in-flight.test.js` (lane queue + dual-lane cancel)
- [ ] Manual: stale sweep with library + HLTB in parallel; PSN incremental fingerprint skip; Cancel during enrich run