### PR TITLE
fix: ruff lint for Nintendo VGC merge

### DIFF
--- a/fetchers/fetch_nintendo.py
+++ b/fetchers/fetch_nintendo.py
@@ -45,14 +45,14 @@ from fetchers._base import (
 )
 from fetchers._progress import EXIT_CODE_AUTH, RunStats, run_with_heartbeat, started
 from fetchers.nintendo_hybrid import (
-    find_existing_row,
     finalize_nintendo_library_rows,
+    find_existing_row,
     index_existing_rows,
     is_nintendo_playable_game,
     match_nintendo_title_key,
     merge_vgc_with_transactions,
-    norm_nintendo_title,
     nintendo_store_url,
+    norm_nintendo_title,
 )
 from shared.profile_paths import personal_path
 from shared.raw_dumps import profile_raw_dump_path

--- a/tests/test_nintendo_hybrid.py
+++ b/tests/test_nintendo_hybrid.py
@@ -6,8 +6,8 @@ from fetchers.nintendo_hybrid import (
     find_existing_row,
     index_existing_rows,
     is_nintendo_playable_game,
-    merge_vgc_with_transactions,
     match_nintendo_title_key,
+    merge_vgc_with_transactions,
     nintendo_store_url,
 )
 

--- a/tests/test_nintendo_legacy_carry.py
+++ b/tests/test_nintendo_legacy_carry.py
@@ -8,12 +8,12 @@ from pathlib import Path
 from fetchers._base import LAST_SEEN_FIELD, STALE_FIELD, STALE_SINCE_FIELD, row_key_by_id
 from fetchers.fetch_nintendo import (
     NINTENDO_LEGACY_FIELD,
+    _nintendo_drift_baseline,
     carry_forward_nintendo_legacy,
     load_nintendo_dropped_ids,
     maybe_repair_nintendo_catalog_on_disk,
     refuse_nintendo_drift_result,
     repair_nintendo_stale_catalog,
-    _nintendo_drift_baseline,
 )
 
 

--- a/tests/test_nintendo_vgc.py
+++ b/tests/test_nintendo_vgc.py
@@ -2,29 +2,27 @@
 
 from __future__ import annotations
 
-import json
-
 import pytest
 
 from clients.nintendo_vgc import (
     NintendoVgcAuthError,
     NintendoVgcCaptureError,
+    _merge_vgc_payload,
+    _portal_html_has_vgc_data,
+    _portal_html_looks_unsigned,
     fetch_vgc_portal_html,
     map_vgc_view,
     parse_vgc_embedded_json,
     region_from_vgc_state,
     resolve_nintendo_icon_url,
-    _merge_vgc_payload,
-    _portal_html_has_vgc_data,
-    _portal_html_looks_unsigned,
 )
 from scripts.probe_nintendo_vgc import diff_vgc_vs_catalog
-
 
 SAMPLE_PORTAL_HTML = """
 <html><body>
 <div id="data" data-json="{&quot;idToken&quot;:&quot;tok-abc&quot;,&quot;savannaClientId&quot;:&quot;client-1&quot;,&quot;shopGraphQLApiUrl&quot;:&quot;https://example.test/graphql&quot;}"></div>
-<div id="state" data-json="{&quot;lang&quot;:&quot;en-US&quot;,&quot;user&quot;:{&quot;country&quot;:&quot;US&quot;}}"></div>
+<div id="state" data-json="{&quot;lang&quot;:&quot;en-US&quot;,&quot;user&quot;:{&quot;country&quot;:&quot;US&quot;}}">
+</div>
 </body></html>
 """
 


### PR DESCRIPTION
Fixes CI ruff failures from #82 (import sort, unused import, E501 in test fixture).

Made with [Cursor](https://cursor.com)