### PR TITLE
fix: restore viewPicksLimits, animation tests, and ruff CI blockers

### DIFF
--- a/auth/registry.py
+++ b/auth/registry.py
@@ -341,10 +341,13 @@ PROVIDERS: dict[str, ProviderSpec] = {
         tips=(
             "Sign in with your Nintendo Account and let the eShop transactions page finish loading.",
             "Purchase history is read from your saved browser profile (not cookie text alone).",
-            "Library sync merges Virtual Game Cards (full digital entitlements) with eShop receipts for purchase dates.",
-            "Nintendo only exposes about two years of eShop history - BAKLOG keeps older digital purchases in your library.",
+            "Library sync merges Virtual Game Cards (full digital entitlements) "
+            "with eShop receipts for purchase dates.",
+            "Nintendo only exposes about two years of eShop history - "
+            "BAKLOG keeps older digital purchases in your library.",
             "Use bulk Remove on a library row if you want a title dropped for good on the next sync.",
-            "Physical cartridges are not included. Sessions last about two weeks; reconnect when new buys do not appear.",
+            "Physical cartridges are not included. Sessions last about two weeks; "
+            "reconnect when new buys do not appear.",
         ),
     ),
     "nintendo_wishlist": ProviderSpec(

--- a/fetchers/build_free_claims.py
+++ b/fetchers/build_free_claims.py
@@ -23,8 +23,8 @@ from shared.free_claims_sources import (
     has_valid_claim_links,
     is_epic_mobile_store,
     merge_manual_and_auto,
-    normalize_claim_urls,
     norm_title,
+    normalize_claim_urls,
 )
 from shared.profile_paths import free_claims_path
 from shared.safe_write import safe_write_text

--- a/fetchers/fetch_nintendo.py
+++ b/fetchers/fetch_nintendo.py
@@ -220,7 +220,7 @@ def _nintendo_drift_baseline(output_path: Path) -> int | None:
     return len(games) or None
 
 
-def refuse_nintendo_drift_result(
+def refuse_nintendo_source_drift(
     items: list[dict],
     *,
     label: str,
@@ -729,7 +729,7 @@ def main() -> int:
             )
         )
 
-    drift_exit = refuse_nintendo_drift_result(
+    drift_exit = refuse_nintendo_source_drift(
         games_out,
         label="Nintendo library rows",
         allow_drift=args.allow_drift,

--- a/js/bind-events.js
+++ b/js/bind-events.js
@@ -18,6 +18,7 @@ import {
   savePrefs,
   persistCurrentSort,
   setCoopFilterMode,
+  setPicksLimitForView,
 } from './prefs.js';
 import {
   renderTable,
@@ -52,6 +53,7 @@ import {
   normalizePicksLimit,
   renderPicksLimitButtons,
   applyPicksCollapsedState,
+  picksViewKey,
 } from './picks-ui.js';
 import { stopSpotlightRotation } from './dashboard-spotlight.js';
 import { recordSponsoredClick } from './anon-metrics.js';
@@ -431,8 +433,7 @@ export function bindEvents() {
   document.getElementById("picksLimitGroup").addEventListener("click", e => {
     const btn = e.target.closest(".picks-limit-btn");
     if (!btn) return;
-    state.prefs.picksLimit = +btn.dataset.limit || 16;
-    savePrefs();
+    setPicksLimitForView(picksViewKey(), +btn.dataset.limit || 16);
     renderPicksLimitButtons();
     renderPicks();
   });

--- a/js/picks-ui.js
+++ b/js/picks-ui.js
@@ -21,7 +21,7 @@ import {
   isOwnedByTitle,
 } from './deals.js';
 import { getPersonal, filterOutHidden } from './personal-storage.js';
-import { savePrefs } from './prefs.js';
+import { getPicksLimitForView, setPicksLimitForView } from './prefs.js';
 import { syncCoverFits } from './covers.js';
 import { sponsoredPickSlotHtml, sponsoredDealPickSlotHtml, pickLocationForView, houseLocationForView, renderHouseLocationSlot } from './sponsored-deals.js';
 
@@ -88,14 +88,17 @@ export function dealCardHtml(g) {
     </div>`;
 }
 
+export function picksViewKey() {
+  const v = state.activeView;
+  return v === "wishlist" ? "wishlist" : v === "itch" ? "itch" : "library";
+}
+
 export function normalizePicksLimit() {
-  const validLimits = [16, 24, 48, 96];
-  const n = Number(state.prefs.picksLimit);
-  if (!validLimits.includes(n)) {
-    state.prefs.picksLimit = 16;
-    savePrefs();
-  }
-  return state.prefs.picksLimit;
+  const view = picksViewKey();
+  const limit = getPicksLimitForView(view);
+  const stored = Number(state.prefs.viewPicksLimits?.[view]);
+  if (stored !== limit) setPicksLimitForView(view, limit);
+  return limit;
 }
 
 export function renderPicksLimitButtons() {
@@ -186,7 +189,7 @@ export function renderPicks() {
     default: data = pickView === "wishlist" ? wishlistDeals : backlogRated;
   }
   if (pickView === "itch" && tab !== "topRated") data = backlogRated;
-  const limit = state.prefs.picksLimit || 16;
+  const limit = getPicksLimitForView(pickView);
   const pickLoc = tab === 'wishlistDeals'
     ? pickLocationForView(pickView === 'wishlist' ? 'wishlist' : 'deals', 'pick')
     : pickLocationForView(pickView, 'pick');

--- a/js/prefs.js
+++ b/js/prefs.js
@@ -4,6 +4,43 @@ import { personalStore } from './personal-store.js';
 import { resolveCoopFilterMode } from './table-query.js';
 import { migrateColumnPrefs } from './table-columns.js';
 
+export const PICKS_LIMIT_VIEWS = ["library", "wishlist", "itch"];
+const VALID_PICKS_LIMITS = [16, 24, 48, 96];
+const DEFAULT_PICKS_LIMIT = 16;
+
+function coercePicksLimit(n) {
+  const v = Number(n);
+  return VALID_PICKS_LIMITS.includes(v) ? v : DEFAULT_PICKS_LIMIT;
+}
+
+function normalizeViewPicksLimits(raw) {
+  const src = raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {};
+  const out = {};
+  for (const view of PICKS_LIMIT_VIEWS) {
+    out[view] = coercePicksLimit(src[view]);
+  }
+  return out;
+}
+
+/** Persisted picks row cap for the given tab (library / wishlist / itch). */
+export function getPicksLimitForView(view) {
+  if (!PICKS_LIMIT_VIEWS.includes(view)) return DEFAULT_PICKS_LIMIT;
+  if (!state.prefs.viewPicksLimits || typeof state.prefs.viewPicksLimits !== "object") {
+    state.prefs.viewPicksLimits = normalizeViewPicksLimits({});
+  }
+  return coercePicksLimit(state.prefs.viewPicksLimits[view]);
+}
+
+export function setPicksLimitForView(view, limit) {
+  if (!PICKS_LIMIT_VIEWS.includes(view)) return;
+  if (!state.prefs.viewPicksLimits || typeof state.prefs.viewPicksLimits !== "object") {
+    state.prefs.viewPicksLimits = normalizeViewPicksLimits({});
+  }
+  state.prefs.viewPicksLimits[view] = coercePicksLimit(limit);
+  delete state.prefs.picksLimit;
+  savePrefs();
+}
+
 export const COOP_FILTER_LABELS = {
   any: "Any co-op",
   online: "Online co-op",
@@ -37,7 +74,8 @@ export function loadPrefs() {
     picksTab: "topRated", libraryPicksTab: "topRated", itchPicksTab: "topRated", picksCollapsed: false,
     columns: {}, rowHeroBackdrop: true, genreFilters: [], genreFilterMode: "OR", quickWinMaxHours: 15,
     metricsDisabled: [],
-    storeFilter: "", wishlistStoreFilter: "", releaseYearFilter: "", picksLimit: 16,
+    storeFilter: "", wishlistStoreFilter: "", releaseYearFilter: "",
+    viewPicksLimits: normalizeViewPicksLimits({}),
     dealOnSaleOnly: false, dealHistoricalLowOnly: false, dealHideOwned: false,
     dealMinDiscount: 0, dealMaxPrice: 100, viewSorts: {},
     shareAnonStats: false,
@@ -51,8 +89,9 @@ export function loadPrefs() {
     autoFetchStale24h: true,
     connectionNotes: {},
   };
-  let merged;
-  try { merged = { ...fallback, ...(JSON.parse(localStorage.getItem(prefsStorageKey()) || "{}")) }; } catch { return fallback; }
+  let stored = {};
+  try { stored = JSON.parse(localStorage.getItem(prefsStorageKey()) || "{}"); } catch { return fallback; }
+  const merged = { ...fallback, ...stored };
   if (!["off", "any", "online", "local", "both"].includes(merged.coopFilterMode)) {
     merged.coopFilterMode = merged.coopAny ? "any" : "off";
   }
@@ -102,6 +141,18 @@ export function loadPrefs() {
   }
   migrateColumnPrefs(merged);
   merged.picksCollapsed = merged.picksCollapsed === true;
+  if (!merged.viewPicksLimits || typeof merged.viewPicksLimits !== "object") {
+    merged.viewPicksLimits = {};
+  }
+  if (Object.prototype.hasOwnProperty.call(stored, "picksLimit")) {
+    const coerced = coercePicksLimit(stored.picksLimit);
+    merged.viewPicksLimits = Object.fromEntries(
+      PICKS_LIMIT_VIEWS.map((view) => [view, coerced]),
+    );
+  } else {
+    merged.viewPicksLimits = normalizeViewPicksLimits(merged.viewPicksLimits);
+  }
+  delete merged.picksLimit;
   return merged;
 }
 

--- a/scripts/audit_free_surface_data.py
+++ b/scripts/audit_free_surface_data.py
@@ -31,7 +31,6 @@ from shared.free_claims_sources import (
     is_epic_mobile_store,
     item_missing_link_fields,
     norm_title,
-    normalize_claim_urls,
 )
 from shared.profile_paths import (
     free_claims_path,

--- a/scripts/probe_nintendo_vgc.py
+++ b/scripts/probe_nintendo_vgc.py
@@ -20,10 +20,10 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from auth.secrets import profile_dir
-from clients.nintendo_vgc import NintendoVgcAuthError, NintendoVgcCaptureError, NintendoVgcClient
-from fetchers._base import catalog_file
-from shared.profile_paths import profile_cache_dir
+from auth.secrets import profile_dir  # noqa: E402
+from clients.nintendo_vgc import NintendoVgcAuthError, NintendoVgcCaptureError, NintendoVgcClient  # noqa: E402
+from fetchers._base import catalog_file  # noqa: E402
+from shared.profile_paths import profile_cache_dir  # noqa: E402
 
 GAMES_NINTENDO_JSON = Path("games_nintendo.json")
 RAW_DUMP = profile_cache_dir() / "nintendo" / "vgc_probe.json"

--- a/tests/library-count-animation.test.js
+++ b/tests/library-count-animation.test.js
@@ -57,6 +57,13 @@ function rafSync() {
 
 describe('flashCountUp', () => {
   let flushRaf;
+  const POPUP_REAP_MS = 900; // POPUP_LIFETIME_MS + 200 in library-count-animation.js
+
+  function finishStrictSyncAnimation(dur) {
+    flushRaf(dur + 50);
+    // Tick-synced popups schedule reap at +900ms; advancing past that clears them before we assert.
+    if (dur < POPUP_REAP_MS) vi.advanceTimersByTime(Math.ceil(dur));
+  }
 
   beforeEach(() => {
     document.body.innerHTML = '';
@@ -128,8 +135,7 @@ describe('flashCountUp', () => {
     const node = mountCountSurface();
     flashCountUp(node, 10, 13, n => String(Math.round(n)), { popups: true });
     const dur = strictSyncRollMs(3, 3);
-    flushRaf(dur + 50);
-    vi.advanceTimersByTime(Math.ceil(dur));
+    finishStrictSyncAnimation(dur);
     const popups = [...document.querySelectorAll('.library-count-popup')];
     expect(popups.length).toBe(3);
     const tops = popups.map(el => parseFloat(el.style.top));
@@ -180,8 +186,7 @@ describe('flashCountUp', () => {
     const firstBurstCount = document.querySelectorAll('.library-count-popup').length;
     expect(firstBurstCount).toBeGreaterThan(0);
     flashCountUp(node, 3, 6, n => String(Math.round(n)), { popups: true });
-    flushRaf(roll3);
-    vi.advanceTimersByTime(roll3);
+    finishStrictSyncAnimation(roll3);
     const second = document.querySelectorAll('.library-count-popup').length;
     // Popups from the first episode + new ones — second total should be >= first.
     expect(second).toBeGreaterThanOrEqual(firstBurstCount);
@@ -214,8 +219,7 @@ describe('flashCountUp', () => {
     armLibraryCountAnimations();
     fireLibraryCountFlash('library', 1946, 1949);
     const dur3 = strictSyncRollMs(3, 3);
-    flushRaf(dur3 + 50);
-    vi.advanceTimersByTime(Math.ceil(dur3));
+    finishStrictSyncAnimation(dur3);
     expect(document.querySelectorAll('.library-count-popup').length).toBe(3);
   });
 
@@ -233,8 +237,7 @@ describe('flashCountUp', () => {
     state.activeView = 'library';
     fireLibraryCountFlash('library', 10, 13, { rowPrev: 8, rowNext: 11 });
     const dur3 = strictSyncRollMs(3, 3);
-    flushRaf(dur3 + 50);
-    vi.advanceTimersByTime(Math.ceil(dur3));
+    finishStrictSyncAnimation(dur3);
     expect(document.querySelectorAll('.library-count-popup').length).toBe(3);
   });
 
@@ -246,8 +249,7 @@ describe('flashCountUp', () => {
     state.activeView = 'library';
     fireLibraryCountFlash('library', 10, 13);
     const dur3 = strictSyncRollMs(3, 3);
-    flushRaf(dur3 + 50);
-    vi.advanceTimersByTime(Math.ceil(dur3));
+    finishStrictSyncAnimation(dur3);
     expect(document.querySelectorAll('.library-count-popup').length).toBe(3);
   });
 

--- a/tests/test_nintendo_legacy_carry.py
+++ b/tests/test_nintendo_legacy_carry.py
@@ -12,7 +12,7 @@ from fetchers.fetch_nintendo import (
     carry_forward_nintendo_legacy,
     load_nintendo_dropped_ids,
     maybe_repair_nintendo_catalog_on_disk,
-    refuse_nintendo_drift_result,
+    refuse_nintendo_source_drift,
     repair_nintendo_stale_catalog,
 )
 
@@ -127,7 +127,7 @@ def test_refuse_nintendo_drift_uses_fresh_baseline_not_total(
     monkeypatch.setattr("fetchers.fetch_nintendo.catalog_file", lambda _p: catalog)
     rows = [{"id": str(i)} for i in range(40)]
     assert (
-        refuse_nintendo_drift_result(
+        refuse_nintendo_source_drift(
             rows,
             label="Nintendo library rows",
             allow_drift=False,
@@ -137,7 +137,7 @@ def test_refuse_nintendo_drift_uses_fresh_baseline_not_total(
     )
     small = [{"id": str(i)} for i in range(20)]
     assert (
-        refuse_nintendo_drift_result(
+        refuse_nintendo_source_drift(
             small,
             label="Nintendo library rows",
             allow_drift=False,


### PR DESCRIPTION
## Summary
- Implement per-view `viewPicksLimits` in prefs (tests added in 1df6ad6 but API was missing).
- Fix library-count-animation strict-sync tests that advanced fake timers past the 900ms popup reap timeout.
- Clear ruff failures: Nintendo registry line length, free-claims import sort, unused audit import, probe E402.

## Test plan
- [x] `ruff check .`
- [x] `npm test -- tests/prefs.test.js tests/library-count-animation.test.js`
- [ ] CI green on merge

Made with [Cursor](https://cursor.com)