### PR TITLE
test: audit plan sync-pairs, tier guards, lighthouse runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "perf:profile": "node scripts/generate-perf-profile.mjs",
     "audit:header": "node scripts/audit-header-rule.mjs",
     "audit:tab-curtain": "node scripts/audit-tab-curtain.mjs",
-    "audit:ui": "node scripts/audit-header-rule.mjs && node scripts/audit-tab-curtain.mjs"
+    "audit:ui": "node scripts/audit-header-rule.mjs && node scripts/audit-tab-curtain.mjs",
+    "audit:lighthouse": "powershell -ExecutionPolicy Bypass -File scripts/run-lighthouse-audits.ps1 -SkipBuild"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",

--- a/scripts/run-lighthouse-audits.ps1
+++ b/scripts/run-lighthouse-audits.ps1
@@ -1,0 +1,91 @@
+# Run Lighthouse on app (built + perf profile) and landing static page.
+# Reports land in lighthouse/ (gitignored). Requires: npm i -g lighthouse OR npx lighthouse.
+param(
+    [switch]$SkipBuild,
+    [string]$AppUrl = 'http://127.0.0.1:8765',
+    [string]$LandingUrl = 'http://127.0.0.1:4000/landing/index.html'
+)
+
+$ErrorActionPreference = 'Stop'
+$root = Split-Path -Parent $PSScriptRoot
+Set-Location $root
+
+$py = Join-Path $root '.venv\Scripts\python.exe'
+$lighthouseDir = Join-Path $root 'lighthouse'
+New-Item -ItemType Directory -Force -Path $lighthouseDir | Out-Null
+
+$stamp = Get-Date -Format 'yyyy-MM-dd'
+$appReport = Join-Path $lighthouseDir "app-$stamp.report.html"
+$landingReport = Join-Path $lighthouseDir "landing-$stamp.report.html"
+
+function Invoke-Lighthouse {
+    param([string]$Url, [string]$Out)
+    Write-Host "==> lighthouse $Url"
+    npx --yes lighthouse $Url `
+        --only-categories=performance,accessibility,best-practices `
+        --output=html `
+        --output-path=$Out `
+        --quiet `
+        --chrome-flags="--headless --no-sandbox"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "lighthouse failed for $Url (exit $LASTEXITCODE)"
+    }
+    if (-not (Test-Path $Out)) {
+        Write-Error "lighthouse report missing: $Out"
+    }
+}
+
+# --- Landing (static) ---
+$landingProc = Start-Process -FilePath $py -ArgumentList @('-m', 'http.server', '4000', '--directory', '.') -WorkingDirectory $root -PassThru -WindowStyle Hidden
+Start-Sleep -Seconds 2
+try {
+    Invoke-Lighthouse -Url $LandingUrl -Out $landingReport
+} finally {
+    if ($landingProc -and -not $landingProc.HasExited) {
+        Stop-Process -Id $landingProc.Id -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# --- App (built + perf profile) ---
+$fixturePerf = Join-Path $root 'tests\fixtures\perf-profile\perf'
+$destPerf = Join-Path $root 'profiles\perf'
+if (-not (Test-Path $fixturePerf)) {
+    node scripts/generate-perf-profile.mjs
+}
+New-Item -ItemType Directory -Force -Path $destPerf | Out-Null
+Copy-Item -Recurse -Force (Join-Path $fixturePerf '*') $destPerf
+
+if (-not $SkipBuild) {
+    Write-Host '==> npm run build'
+    npm run build
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}
+
+$env:BAKLOG_PROFILE = 'perf'
+$env:BAKLOG_SERVE_BUILT = '1'
+$env:BAKLOG_ADMIN = '0'
+$env:BAKLOG_AUTH_DISABLED = '1'
+
+$server = Start-Process -FilePath $py -ArgumentList 'server.py' -WorkingDirectory $root -PassThru -WindowStyle Hidden
+try {
+    $deadline = (Get-Date).AddSeconds(45)
+    $ready = $false
+    while ((Get-Date) -lt $deadline) {
+        try {
+            $r = Invoke-WebRequest -Uri "$AppUrl/api/config" -UseBasicParsing -TimeoutSec 2
+            if ($r.StatusCode -eq 200) { $ready = $true; break }
+        } catch {}
+        Start-Sleep -Milliseconds 500
+    }
+    if (-not $ready) { Write-Error "App server not ready at $AppUrl" }
+    Invoke-Lighthouse -Url $AppUrl -Out $appReport
+} finally {
+    if ($server -and -not $server.HasExited) {
+        & $py scripts/stop_baklog.py 2>$null | Out-Null
+        if (-not $server.HasExited) { Stop-Process -Id $server.Id -Force -ErrorAction SilentlyContinue }
+    }
+}
+
+Write-Host "Lighthouse reports:"
+Write-Host "  $appReport"
+Write-Host "  $landingReport"

--- a/tests/marketing-claims.test.js
+++ b/tests/marketing-claims.test.js
@@ -78,4 +78,21 @@ describe('marketing copy guardrails', () => {
     expect(text).not.toMatch(/\$2\.99|\$4\.99/);
     expect(text).toMatch(/Support BAKLOG/);
   });
+
+  it('landing tier table marks cloud sync and deal alerts as Coming on paid', () => {
+    const text = readFileSync('landing/index.html', 'utf8');
+    const start = text.indexOf('class="tier-compare"');
+    expect(start).toBeGreaterThan(-1);
+    const end = text.indexOf('</table>', start);
+    const table = text.slice(start, end);
+    expect(table).toMatch(/Cloud sync[\s\S]*?<td>✕<\/td>[\s\S]*?<td>Coming<\/td>/i);
+    expect(table).toMatch(/Deal\/watchlist alerts[\s\S]*?<td>✕<\/td>[\s\S]*?<td>Coming<\/td>/i);
+  });
+
+  it('landing tier table keeps queue-all refresh as coming on paid', () => {
+    const text = readFileSync('landing/index.html', 'utf8');
+    const start = text.indexOf('class="tier-compare"');
+    const table = text.slice(start, text.indexOf('</table>', start));
+    expect(table).toMatch(/Manual store refresh[\s\S]*coming/i);
+  });
 });

--- a/tests/sync-pairs.test.js
+++ b/tests/sync-pairs.test.js
@@ -1,25 +1,37 @@
-/** AGENTS.md rule 6 sync-pair guards (subset with machine-checkable parity). */
+/** AGENTS.md rule 6 sync-pair guards (consolidated entry + machine-checkable parity). */
 import fs from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { CLAIM_SOURCE_RANK } from '../js/claim-card.js';
 import { AD_LOCATIONS } from '../js/sponsored-deals.js';
 import { stripClaimTitleDecorations } from '../js/claim-card.js';
+import { STORE_BRAND_COLORS } from '../js/store-brand-colors.js';
 
 const ROOT = path.resolve(import.meta.dirname, '..');
+
+/** Dedicated parity modules (also rule 6): library-noise-parity.test.js, blurb-sanitize-parity.test.js, ad-locations-sync.test.js, pro-promo-sync.test.js */
 
 function read(rel) {
   return fs.readFileSync(path.join(ROOT, rel), 'utf8');
 }
 
+function parsePythonDictLiteral(text) {
+  return JSON.parse(text.replace(/'/g, '"'));
+}
+
 describe('sync pairs (AGENTS.md rule 6)', () => {
-  it('CLAIM_SOURCE_RANK matches Python SOURCE_PRECEDENCE order', () => {
+  it('CLAIM_SOURCE_RANK matches Python SOURCE_PRECEDENCE exactly', () => {
     const py = read('shared/free_claims_sources.py');
-    const epic = py.match(/SOURCE_PRECEDENCE\s*=\s*\{([^}]+)\}/);
-    expect(epic).toBeTruthy();
-    expect(CLAIM_SOURCE_RANK.epic).toBe(0);
-    expect(CLAIM_SOURCE_RANK.gamerpower).toBe(1);
-    expect(CLAIM_SOURCE_RANK.itad).toBe(2);
+    const m = py.match(/SOURCE_PRECEDENCE\s*=\s*(\{[^}]+\})/);
+    expect(m).toBeTruthy();
+    const precedence = parsePythonDictLiteral(m[1]);
+    for (const [source, rank] of Object.entries(precedence)) {
+      expect(CLAIM_SOURCE_RANK[source], source).toBe(rank);
+    }
+    for (const source of Object.keys(CLAIM_SOURCE_RANK)) {
+      if (source === 'manual' || source === 'other') continue;
+      expect(precedence, `missing ${source} in SOURCE_PRECEDENCE`).toHaveProperty(source);
+    }
   });
 
   it('stripClaimTitleDecorations matches Python strip_giveaway_decorations fixture', () => {
@@ -31,13 +43,34 @@ describe('sync pairs (AGENTS.md rule 6)', () => {
     }
   });
 
+  it('STORE_BRAND_COLORS matches app.css --brand-* tokens', () => {
+    const css = read('app.css');
+    for (const [store, hex] of Object.entries(STORE_BRAND_COLORS)) {
+      if (store === 'other' || store === 'manual') continue;
+      const varName = `--brand-${store.replace(/_/g, '-')}`;
+      const re = new RegExp(`${varName.replace(/-/g, '\\-')}:\\s*(#[0-9a-fA-F]{3,8})`);
+      const match = css.match(re);
+      expect(match, varName).toBeTruthy();
+      expect(match[1].toLowerCase()).toBe(hex.toLowerCase());
+    }
+  });
+
+  it('landing/marquee-speed.js MARQUEE_PX_PER_SEC matches js/marquee-speed.js', () => {
+    const landing = read('landing/marquee-speed.js');
+    const app = read('js/marquee-speed.js');
+    const landingVal = landing.match(/MARQUEE_PX_PER_SEC\s*=\s*(\d+)/)?.[1];
+    const appVal = app.match(/MARQUEE_PX_PER_SEC\s*=\s*(\d+)/)?.[1];
+    expect(landingVal).toBeTruthy();
+    expect(appVal).toBe(landingVal);
+  });
+
   it('AD_LOCATIONS keys are unique and non-empty', () => {
     const keys = Object.keys(AD_LOCATIONS);
     expect(keys.length).toBeGreaterThan(0);
     expect(new Set(keys).size).toBe(keys.length);
   });
 
-  it('committed fetcher-registry.js matches Python export header', () => {
+  it('committed fetcher-registry.js matches Python export (see test_fetcher_registry_drift.py)', () => {
     const js = read('js/fetcher-registry.js');
     expect(js).toContain('Regenerate: python -c "from fetchers.registry import export_js_registry');
     const py = read('fetchers/registry.py');

--- a/tests/test_fetcher_registry_drift.py
+++ b/tests/test_fetcher_registry_drift.py
@@ -1,0 +1,16 @@
+"""Regenerated js/fetcher-registry.js must match the committed file (no drift)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fetchers.registry import export_js_registry
+
+ROOT = Path(__file__).resolve().parents[1]
+COMMITTED = ROOT / "js" / "fetcher-registry.js"
+
+
+def test_export_js_registry_matches_committed_file(tmp_path: Path) -> None:
+    out = tmp_path / "fetcher-registry.js"
+    export_js_registry(out)
+    assert out.read_text(encoding="utf-8") == COMMITTED.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Expand `tests/sync-pairs.test.js` for AGENTS rule 6 parity (SOURCE_PRECEDENCE, store brands, marquee speed)
- Add `tests/test_fetcher_registry_drift.py` to catch fetcher-registry export drift
- Extend landing tier marketing-claims guards (cloud sync / deal alerts = Coming)
- Add opt-in `scripts/run-lighthouse-audits.ps1` + `npm run audit:lighthouse`

## Test plan
- [x] pytest: test_fetcher_registry_drift, test_profile_cache_sync
- [x] vitest: sync-pairs, marketing-claims, landing-axe
- [ ] CI green