### PR TITLE
fix: bulk import recents, update banner, and dashboard polish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
           tests/test_server_csrf.py
           tests/test_fetcher_progress.py
           tests/test_fetcher_auth_exit.py
+          tests/test_fetcher_main_contract.py
           tests/test_auth_secrets.py
           tests/test_auth_status_platform.py
           tests/test_cdp_browser.py

--- a/app.css
+++ b/app.css
@@ -9526,14 +9526,9 @@ body {
 .fetcher-popover .fh-row--popover .fh-log.open .fh-log-body {
   flex: 1 1 auto;
   min-height: 0;
-  max-height: min(28vh, 240px);
-  overflow-y: auto;
-  overscroll-behavior: contain;
-}
-@media (min-width: 1024px) {
-  .fetcher-popover .fh-row--popover .fh-log.open .fh-log-body {
-    max-height: 360px;
-  }
+  max-height: none;
+  overflow: visible;
+  overscroll-behavior: auto;
 }
 @media (max-width: 639.98px) {
   .fetcher-popover {

--- a/fetchers/fetch_nintendo_wishlist.py
+++ b/fetchers/fetch_nintendo_wishlist.py
@@ -120,6 +120,37 @@ class WishlistItem:
     price_initial: str | None
     discount_percent: int | None
     currency: str | None
+    is_dlc: bool = False
+
+
+def _wishlist_item_is_dlc(obj: dict) -> bool:
+    for k in (
+        "productType",
+        "product_type",
+        "contentType",
+        "content_type",
+        "type",
+        "productClass",
+        "product_class",
+    ):
+        val = obj.get(k)
+        if isinstance(val, str) and val.lower() in (
+            "dlc",
+            "aoc",
+            "addon",
+            "add_on",
+            "downloadable_content",
+            "downloadablecontent",
+        ):
+            return True
+    title = _first_str(obj, _TITLE_KEYS) or ""
+    if re.search(r"\b(dlc|expansion pass|season pass)\b", title, re.I):
+        return True
+    for nested_key in ("product", "item", "game"):
+        nested = obj.get(nested_key)
+        if isinstance(nested, dict) and _wishlist_item_is_dlc(nested):
+            return True
+    return False
 
 
 def _parse_json_assignment(html: str, marker: str) -> dict | None:
@@ -388,6 +419,7 @@ def _item_from_dict(obj: dict) -> WishlistItem | None:
         price_initial=price_initial,
         discount_percent=discount,
         currency=currency,
+        is_dlc=_wishlist_item_is_dlc(obj),
     )
 
 
@@ -1041,7 +1073,8 @@ def _fetch_with_profile(
 
 
 def _build_row(item: WishlistItem, hltb: dict | None) -> dict:
-    return {
+    tags: list[str] = ["dlc"] if item.is_dlc else []
+    row = {
         "store": "wishlist",
         "wishlist_store": "nintendo",
         "id": f"nintendo-{item.product_id}",
@@ -1053,7 +1086,7 @@ def _build_row(item: WishlistItem, hltb: dict | None) -> dict:
         "library_image": item.image_url,
         "release_date": item.release_date,
         "genres": list(dict.fromkeys(item.genres)),
-        "tags": [],
+        "tags": tags,
         "steam_review_percent": None,
         "steam_review_count": None,
         "steam_review_desc": None,
@@ -1063,12 +1096,15 @@ def _build_row(item: WishlistItem, hltb: dict | None) -> dict:
         "hltb_match_confidence": (hltb or {}).get("hltb_match_confidence"),
         "hltb_name": (hltb or {}).get("hltb_name"),
         "store_url": item.store_url,
-        "type": "game",
+        "type": "dlc" if item.is_dlc else "game",
         "price": item.price,
         "price_initial": item.price_initial,
         "discount_percent": item.discount_percent,
         "currency": item.currency,
     }
+    if item.is_dlc:
+        row["nintendo_is_dlc"] = True
+    return row
 
 
 def _load_existing() -> dict[str, dict]:

--- a/guide/troubleshooting.md
+++ b/guide/troubleshooting.md
@@ -178,6 +178,16 @@ These are expected limits in the current invite-only beta, not one-off bugs:
 | **Secrets store corrupt** | The encrypted credentials file for this profile cannot be read (wrong keyring entry, moved data, or a damaged file). Use **Reset store** on the banner, restore a backup on Connections, or reconnect each store. Archived copies are kept as `secrets.bin.corrupt-*` beside the old file. |
 | **Cloud sync** | Signing in on a second PC does not copy your library yet. Copy `BAKLOG-Data` manually or wait for the planned Pro cloud mirror. |
 
+## App updates (installed build)
+
+**Symptom:** You want to know if a newer BAKLOG release is available.
+
+**Behavior:** The installed (frozen) app checks GitHub once per session on boot. When an update exists, a banner appears under the header with a download link. Dismiss it for the session with **×**; it returns next launch until you upgrade.
+
+**Manual check:** Open the **⋮** menu and choose **Check for updates…** (works in dev and installed builds).
+
+**Note:** BAKLOG does not auto-download or auto-install. Download the new zip or installer from the release page, then replace your install. Your library data stays in `%LOCALAPPDATA%\\BAKLOG-Data` (or your portable data folder).
+
 ## Bug reports vs fetcher failures
 
 Dashboard JavaScript errors can be reported via the sticky toast or **Report a bug…** menu. Fetcher failures are separate - check **Fetcher health**, exit codes, and `profiles/<id>/cache/runs/*.jsonl`. See [Getting help](getting-help.md).

--- a/index.html
+++ b/index.html
@@ -247,6 +247,7 @@
         </div>
       </div>
       <div id="bootErrorBanner" class="migration-banner hidden" role="status" aria-live="polite"></div>
+      <div id="updateAvailableBanner" class="migration-banner hidden" role="status" aria-live="polite"></div>
       <div id="summary" class="flex flex-wrap gap-2 mt-3"></div>
     </header>
 

--- a/js/app.js
+++ b/js/app.js
@@ -35,6 +35,7 @@ import {
   loadPersonal,
   loadLibraryFirstSeen,
   loadKnownLibraryKeys,
+  saveLibraryFirstSeen,
   migrateV3,
   stripLegacyTags,
   seedPreHiddenDefaults,
@@ -74,10 +75,11 @@ import {
   bootPerfMeasure,
   bootPerfEnd,
 } from './boot-perf.js';
-import { reloadGames, reloadAfterFetcher, finishEmptyLibraryLoad } from './library-load.js';
+import { reloadGames, reloadAfterFetcher, finishEmptyLibraryLoad, repairBulkFirstSeenStamps } from './library-load.js';
 import { initLibraryWatches } from './library-watch.js';
 import { runLibraryCountDemo, runLibraryCountSmallDemo, armLibraryCountAnimations } from './library-count-animation.js';
 import { bindEvents } from './bind-events.js';
+import { checkForUpdates } from './update-check.js';
 import { ensureActiveProfileResolved, initProfiles } from './profiles.js';
 import { startDebugOverlay } from './debug-overlay.js';
 import { ensureChartJs } from './chart-loader.js';
@@ -126,6 +128,9 @@ function hydrateState() {
   state.prefs = loadPrefs();
   state.sessionPrefs = loadSessionPrefs();
   state.libraryFirstSeenByKey = loadLibraryFirstSeen();
+  if (repairBulkFirstSeenStamps(state.libraryFirstSeenByKey)) {
+    saveLibraryFirstSeen(state.libraryFirstSeenByKey);
+  }
   state.knownLibraryKeySet = loadKnownLibraryKeys();
   setBootCurtainLabel(loadActiveView() || 'dashboard');
   installPersonalStorageSync();
@@ -260,6 +265,9 @@ async function bootstrap() {
         const cfg = await cfgRes.json();
         if (typeof cfg.frozen === 'boolean') noteServerRuntime({ frozen: cfg.frozen });
         syncRuntimeModeBanner(cfg);
+        if (cfg.frozen === true) {
+          checkForUpdates({ source: 'boot', frozen: true }).catch(() => {});
+        }
         if (cfg.running_from_temp) {
           const banner = document.getElementById('bootErrorBanner');
           if (banner) {

--- a/js/bind-events.js
+++ b/js/bind-events.js
@@ -875,26 +875,11 @@ export function bindEvents() {
   }
   document.getElementById("checkUpdates")?.addEventListener("click", async () => {
     kebabMenu.classList.remove("open");
-    try {
-      const res = await fetch('/api/update-check');
-      if (!res.ok) {
-        showKebabBanner(`Could not check for updates (server returned ${res.status}).`);
-        return;
-      }
-      const data = await res.json().catch(() => ({}));
-      if (data.error) {
-        showKebabBanner(`Could not check for updates: ${data.error}`);
-        return;
-      }
-      if (data.update_available) {
-        const url = data.url ? ` Download: ${data.url}` : '';
-        showKebabBanner(`Update available: v${data.latest} (you have v${data.current}).${url}`);
-        return;
-      }
-      showKebabBanner(`You're on the latest release (v${data.current}).`);
-    } catch (err) {
-      showKebabBanner(`Update check failed: ${err?.message || err}`, { error: true });
-    }
+    const { checkForUpdates } = await import('./update-check.js');
+    await checkForUpdates({
+      source: 'manual',
+      onManualMessage: (msg, opts) => showKebabBanner(msg, opts),
+    });
   });
   document.getElementById("copyDiagnostics")?.addEventListener("click", async () => {
     kebabMenu.classList.remove("open");

--- a/js/claimable.js
+++ b/js/claimable.js
@@ -895,3 +895,5 @@ export function startClaimableReadOnlyPolling(intervalMs = 15 * 60_000) {
     } catch (_) { /* silent */ }
   }, intervalMs);
 }
+
+export { animateClaimOut };

--- a/js/fetcher-health.js
+++ b/js/fetcher-health.js
@@ -3267,6 +3267,90 @@ export function buildStatStripHtml(rows, mode = statLayout(), extrasHtml = '') {
     </div>`;
 }
 
+const FH_CHIP_MODIFIER_CLASSES = new Set([
+  'fh-chip-needs-config',
+  'fh-chip-readonly',
+  'fh-chip-auth-cooldown',
+  'fh-chip-reconnect-required',
+  'fh-chip-disconnected',
+  'fh-chip-unavailable',
+]);
+
+function patchFetcherChipEl(btn, patch) {
+  const statusClasses = [...btn.classList].filter(
+    (cls) => cls.startsWith('fh-chip-') && !FH_CHIP_MODIFIER_CLASSES.has(cls),
+  );
+  for (const cls of statusClasses) btn.classList.remove(cls);
+  btn.classList.add(`fh-chip-${patch.displayStatus}`);
+  for (const cls of FH_CHIP_MODIFIER_CLASSES) btn.classList.toggle(cls, !!patch.modifiers[cls]);
+  btn.dataset.status = patch.status;
+  btn.title = patch.title;
+  btn.disabled = patch.disabled;
+  btn.setAttribute('aria-disabled', patch.disabled ? 'true' : 'false');
+  btn.setAttribute('aria-label', patch.chipAriaLabel);
+  if (patch.connectProvider) btn.dataset.fetcherConnect = patch.connectProvider;
+  else delete btn.dataset.fetcherConnect;
+  btn.querySelector('.fh-chip-label').textContent = patch.chipLabel;
+  btn.querySelector('.fh-chip-count').textContent = patch.countStr;
+  btn.querySelector('.fh-chip-age').textContent = patch.ageText;
+  const warn = btn.querySelector('.fh-chip-warn');
+  if (patch.showWarn && !warn) {
+    btn.insertAdjacentHTML(
+      'afterbegin',
+      '<span class="fh-chip-warn" title="Missing credentials for this profile - Connections">!</span>',
+    );
+  } else if (!patch.showWarn && warn) {
+    warn.remove();
+  }
+}
+
+/**
+ * Patch chip DOM in place when structure is unchanged (poll refresh without resetting scroll/focus).
+ * @returns {boolean}
+ */
+export function tryPatchFetcherHealthDashboard(slot, ctx) {
+  if (!slot?.querySelector?.('.fh-bar')) return false;
+  if (slot.dataset.statLayout !== ctx.layout) return false;
+  if (!!slot.querySelector('.fh-readonly-banner') !== ctx.showReadonly) return false;
+  const legend = slot.querySelector('#fhLegendTips');
+  if (!!legend?.classList.contains('is-open') !== ctx.legendTipsOpen) return false;
+  const chips = [...slot.querySelectorAll('.fh-chips [data-fetcher-key]')];
+  if (chips.length !== ctx.chipPatches.length) return false;
+  for (let i = 0; i < chips.length; i++) {
+    if (chips[i].dataset.fetcherKey !== ctx.chipPatches[i].key) return false;
+  }
+  for (let i = 0; i < chips.length; i++) patchFetcherChipEl(chips[i], ctx.chipPatches[i]);
+
+  const staleEl = slot.querySelector('.fh-count--stale');
+  if (ctx.staleCount > 0) {
+    if (!staleEl) return false;
+    staleEl.textContent = `${ctx.staleCount} stale`;
+  } else if (staleEl) return false;
+
+  const missingEl = slot.querySelector('.fh-count--missing, .fh-count--fresh');
+  if (!missingEl) return false;
+  missingEl.textContent = `${ctx.missingCount} missing`;
+  missingEl.classList.toggle('fh-count--fresh', ctx.missingCount === 0);
+  missingEl.classList.toggle('fh-count--missing', ctx.missingCount > 0);
+  missingEl.title = ctx.missingCount === 0 ? COUNT_PILL_TITLES.fresh : COUNT_PILL_TITLES.missing;
+
+  const { lib, wish, enrich, lastSyncValue, connected, total } = ctx.statTotals;
+  const hero = slot.querySelector('.fh-stat--hero .fh-stat-value');
+  if (hero) hero.textContent = ctx.layout === 'compact' ? `${connected}/${total}` : `${connected}/${total}`;
+  const statValues = [...slot.querySelectorAll('.fh-stat-value')];
+  const tileValues = statValues.filter((el) => !el.closest('.fh-stat--hero'));
+  const tileOrder = [lastSyncValue, String(lib.connected), String(wish.connected), String(enrich.connected)];
+  if (tileValues.length !== tileOrder.length) return false;
+  for (let i = 0; i < tileOrder.length; i++) tileValues[i].textContent = tileOrder[i];
+
+  const fillEls = slot.querySelectorAll('.fh-stat-bar-fill, .fh-stat-meter-fill');
+  for (const el of fillEls) el.style.setProperty('--pct', `${ctx.statTotals.pct}%`);
+
+  fetcherRunner.setBarSummary(ctx.healthSummary);
+  ensureAgeTicker();
+  return true;
+}
+
 export function renderDashboardFetcherHealth() {
   const slot = document.getElementById('dashboardFetcherHealth');
   if (!slot) return;
@@ -3347,10 +3431,11 @@ export function renderDashboardFetcherHealth() {
         </div>`)
     : '';
   const layout = statLayout();
-  slot.dataset.statLayout = layout;
   const countsBlockHtml = `<span class="fh-counts">${countsHtml}</span>`;
   const infoStripHtml = buildStatStripHtml(rows, 'compact', '');
   const statStripHtml = buildStatStripHtml(rows, layout, '');
+
+  const chipPatches = [];
 
   function chipHtml({ src, status, count, ageLabel, iso }) {
     const covLabel = ENRICH_KEYS.has(src.key) ? coverageLabel(src.key) : null;
@@ -3448,6 +3533,27 @@ export function renderDashboardFetcherHealth() {
       ? ` data-fetcher-connect="${escapeAttr(navProvider)}"`
       : '';
     const chipAriaLabel = `${chipLabel}, ${countStr}, ${ageText || status}`;
+    chipPatches.push({
+      key: src.key,
+      displayStatus,
+      status,
+      title,
+      disabled,
+      connectProvider: navProvider || '',
+      chipLabel,
+      countStr,
+      ageText,
+      chipAriaLabel,
+      showWarn: needsConfig,
+      modifiers: {
+        'fh-chip-needs-config': needsConfig,
+        'fh-chip-readonly': !apiReady,
+        'fh-chip-auth-cooldown': inAuthCooldown,
+        'fh-chip-reconnect-required': needsReconnect,
+        'fh-chip-disconnected': disconnected,
+        'fh-chip-unavailable': platformUnavailable,
+      },
+    });
     const chipBtn = `<button type="button" class="fh-chip fh-chip-${escapeAttr(displayStatus)}${needsClass}${readonlyClass}${cooldownClass}${reconnectClass}${disconnectedClass}${unavailableClass}" data-fetcher-key="${escapeAttr(src.key)}" data-status="${escapeAttr(status)}"${connectAttr} style="border-left: 3px solid ${escapeAttr(src.color)}" title="${escapeAttr(title)}" aria-label="${escapeAttr(chipAriaLabel)}"${disabled ? ' disabled' : ''} aria-disabled="${disabled ? 'true' : 'false'}">
       <span class="fh-chip-dot"></span>
       ${warnBadge}
@@ -3589,6 +3695,27 @@ export function renderDashboardFetcherHealth() {
     </div>
     ${legendTipsHtml}`;
 
+  const patchCtx = {
+    layout,
+    showReadonly,
+    legendTipsOpen,
+    chipPatches,
+    staleCount: staleRows.length,
+    missingCount: missingRows.length,
+    healthSummary,
+    statTotals: fetcherStatTotals(rows),
+  };
+  if (tryPatchFetcherHealthDashboard(slot, patchCtx)) {
+    slot.dataset.statLayout = layout;
+    fetcherRunner.applyFetcherRowLayout();
+    syncStatLayoutToggle();
+    if (restoreBarToggleFocus) {
+      document.querySelector('[data-role="bar-toggle"]')?.focus();
+    }
+    return;
+  }
+
+  slot.dataset.statLayout = layout;
   slot.innerHTML = `
     <div class="fh-bar" data-role="fetcher-bar" title="Click to expand the fetcher console">
       <span class="fh-bar-dot" data-role="bar-dot" aria-hidden="true"></span>

--- a/js/library-load.js
+++ b/js/library-load.js
@@ -211,21 +211,63 @@ export function captureLibraryKeysBeforeMerge() {
   );
 }
 
-function stampMergeDiffFirstSeen(priorKeys) {
-  if (!priorKeys || priorKeys.size === 0) return { n: 0, changed: false };
+/** Keys stamped together in one import (e.g. first Steam sync) stay baseline (div 0). */
+export const BULK_FIRST_SEEN_THRESHOLD = 8;
+
+export function shouldBaselineImportBatch(newStampCount, priorKeyCount) {
+  if (newStampCount <= 1) return false;
+  if (priorKeyCount === 0 && newStampCount >= BULK_FIRST_SEEN_THRESHOLD) return true;
+  if (newStampCount >= BULK_FIRST_SEEN_THRESHOLD && newStampCount > priorKeyCount) return true;
+  return false;
+}
+
+/** Collapse bulk-import batches already persisted (same second, many keys). */
+export function repairBulkFirstSeenStamps(map) {
+  if (!map || typeof map !== 'object') return false;
+  const bySecond = new Map();
+  for (const [key, val] of Object.entries(map)) {
+    const n = Number(val);
+    if (!Number.isFinite(n) || n <= 0) continue;
+    const sec = Math.floor(n / 1000);
+    if (!bySecond.has(sec)) bySecond.set(sec, []);
+    bySecond.get(sec).push(key);
+  }
+  let changed = false;
+  for (const keys of bySecond.values()) {
+    if (keys.length < BULK_FIRST_SEEN_THRESHOLD) continue;
+    for (const key of keys) {
+      if (map[key] !== 0) {
+        map[key] = 0;
+        changed = true;
+      }
+    }
+  }
+  return changed;
+}
+
+function collectMergeDiffFirstSeenKeys(priorKeys, pendingRealKeys) {
+  if (!priorKeys || priorKeys.size === 0) return 0;
   const itchGames = Array.isArray(state.itchGames) ? state.itchGames : [];
   let n = 0;
-  let changed = false;
   for (const g of [...state.allGames, ...itchGames]) {
     const key = gameKey(g);
     if (priorKeys.has(key)) continue;
     const cur = state.libraryFirstSeenByKey[key] ?? 0;
     if (cur > 0) continue;
-    state.libraryFirstSeenByKey[key] = Date.now();
+    pendingRealKeys.add(key);
     n += 1;
-    changed = true;
   }
-  return { n, changed };
+  return n;
+}
+
+function applyPendingFirstSeenStamps(pendingRealKeys, priorKeyCount) {
+  const baseline = shouldBaselineImportBatch(pendingRealKeys.size, priorKeyCount);
+  if (baseline) return 0;
+  const now = Date.now();
+  for (const key of pendingRealKeys) {
+    state.libraryFirstSeenByKey[key] = now;
+  }
+  return pendingRealKeys.size;
 }
 
 /** Stamp first-seen timestamps for library keys (silent seed on first load).
@@ -234,6 +276,7 @@ export function recordLibraryFirstSeen() {
   if (!state.libraryFirstSeenByKey || typeof state.libraryFirstSeenByKey !== 'object') {
     state.libraryFirstSeenByKey = {};
   }
+  let changed = repairBulkFirstSeenStamps(state.libraryFirstSeenByKey);
   const mapWasEmpty = Object.keys(state.libraryFirstSeenByKey).length === 0;
   const seeded = !!state.prefs.librarySeenSeeded;
   // If the persisted map is empty but seeding already happened, the first-seen
@@ -244,8 +287,9 @@ export function recordLibraryFirstSeen() {
   const effectiveSeeded = seeded && !mapWasEmpty;
   const isReseed = seeded && mapWasEmpty;
   const priorKeys = state._libraryKeysBeforeMerge;
-  let changed = false;
+  const priorKeyCount = priorKeys?.size ?? 0;
   let newlyStamped = 0;
+  const pendingRealKeys = new Set();
   const debugNewKeys = isDebugEnabled() && effectiveSeeded ? [] : null;
   // itch games live in state.itchGames (their own tab), not state.allGames.
   // Stamp them too so itch additions get a first-seen timestamp and can
@@ -259,29 +303,27 @@ export function recordLibraryFirstSeen() {
         && priorKeys?.size > 0
         && !priorKeys.has(key)
       ) {
-        state.libraryFirstSeenByKey[key] = Date.now();
-        changed = true;
-        newlyStamped += 1;
-        debugNewKeys?.push(key);
+        pendingRealKeys.add(key);
       }
       continue;
     }
-    let stamp = 0;
-    if (effectiveSeeded) {
-      stamp = Date.now();
-    } else if (isReseed && priorKeys?.size > 0 && !priorKeys.has(key)) {
-      stamp = Date.now();
-    }
-    state.libraryFirstSeenByKey[key] = stamp;
+    state.libraryFirstSeenByKey[key] = 0;
     changed = true;
-    if (stamp > 0) {
-      newlyStamped += 1;
-      debugNewKeys?.push(key);
+    if (effectiveSeeded) {
+      pendingRealKeys.add(key);
+    } else if (isReseed && priorKeys?.size > 0 && !priorKeys.has(key)) {
+      pendingRealKeys.add(key);
     }
   }
-  const mergeDiff = stampMergeDiffFirstSeen(priorKeys);
-  newlyStamped += mergeDiff.n;
-  changed = changed || mergeDiff.changed;
+  collectMergeDiffFirstSeenKeys(priorKeys, pendingRealKeys);
+  const applied = applyPendingFirstSeenStamps(pendingRealKeys, priorKeyCount);
+  if (applied > 0) {
+    changed = true;
+    newlyStamped = applied;
+    if (debugNewKeys) {
+      for (const key of pendingRealKeys) debugNewKeys.push(key);
+    }
+  }
   state._libraryKeysBeforeMerge = null;
   const currentKeys = new Set([...state.allGames, ...itchGames].map(gameKey));
   state.knownLibraryKeySet = currentKeys;
@@ -292,8 +334,9 @@ export function recordLibraryFirstSeen() {
       seeded,
       effectiveSeeded,
       isReseed,
-      priorKeyCount: priorKeys?.size ?? 0,
-      mergeDiffStamped: mergeDiff.n,
+      priorKeyCount,
+      pendingRealCount: pendingRealKeys.size,
+      appliedRealStamps: applied,
       totalKeys: Object.keys(state.libraryFirstSeenByKey).length,
       newlyStamped,
       newlyStampedKeys: debugNewKeys ?? [],

--- a/js/update-check.js
+++ b/js/update-check.js
@@ -1,0 +1,123 @@
+/** Boot + manual update checks against GET /api/update-check (frozen installs only for boot banner). */
+
+import { escapeHtml } from './dom-util.js';
+
+export const UPDATE_BANNER_DISMISS_KEY = 'baklog.updateBannerDismissed';
+
+/**
+ * @param {unknown} data
+ * @returns {{ ok: true, current: string, latest: string | null, updateAvailable: boolean, url: string | null } | { ok: false, error: string }}
+ */
+export function parseUpdateCheckResponse(data) {
+  if (!data || typeof data !== 'object') {
+    return { ok: false, error: 'Invalid update-check response' };
+  }
+  const err = typeof data.error === 'string' ? data.error.trim() : '';
+  if (err) return { ok: false, error: err };
+  const current = typeof data.current === 'string' ? data.current : '';
+  const latest = typeof data.latest === 'string' && data.latest.trim() ? data.latest.trim() : null;
+  const url = typeof data.url === 'string' && data.url.trim() ? data.url.trim() : null;
+  return {
+    ok: true,
+    current,
+    latest,
+    updateAvailable: data.update_available === true,
+    url,
+  };
+}
+
+/** @param {{ current: string, latest: string | null, url: string | null }} parsed */
+export function formatUpdateAvailableMessage(parsed) {
+  const urlPart = parsed.url ? ` Download: ${parsed.url}` : '';
+  return `Update available: v${parsed.latest} (you have v${parsed.current}).${urlPart}`;
+}
+
+/** @param {{ current: string }} parsed */
+export function formatUpToDateMessage(parsed) {
+  return `You're on the latest release (v${parsed.current}).`;
+}
+
+/**
+ * @param {{ latest: string | null, url: string | null, current: string }} parsed
+ */
+export function renderUpdateBannerHtml(parsed) {
+  const href = parsed.url || 'https://github.com/Ogrods/baklog/releases/latest';
+  return (
+    '<div class="migration-banner-body update-available-banner-body">' +
+    `<span class="text-amber-400">BAKLOG v${escapeHtml(parsed.latest || '')} is available (you have v${escapeHtml(parsed.current)}).</span> ` +
+    `<a href="${escapeHtml(href)}" class="text-sky-300 hover:underline" target="_blank" rel="noopener noreferrer">Download release</a>` +
+    '<button type="button" class="update-available-banner-dismiss ml-2 text-slate-400 hover:text-slate-200" aria-label="Dismiss for this session">×</button>' +
+    '</div>'
+  );
+}
+
+export function dismissUpdateBannerForSession() {
+  if (typeof sessionStorage !== 'undefined') sessionStorage.setItem(UPDATE_BANNER_DISMISS_KEY, '1');
+  hideUpdateBanner();
+}
+
+export function hideUpdateBanner() {
+  const banner = document.getElementById('updateAvailableBanner');
+  if (!banner) return;
+  banner.classList.add('hidden');
+  banner.replaceChildren();
+}
+
+/**
+ * @param {{ latest: string | null, url: string | null, current: string }} parsed
+ */
+export function showUpdateBanner(parsed) {
+  if (typeof sessionStorage !== 'undefined' && sessionStorage.getItem(UPDATE_BANNER_DISMISS_KEY) === '1') {
+    return;
+  }
+  const banner = document.getElementById('updateAvailableBanner');
+  if (!banner) return;
+  banner.innerHTML = renderUpdateBannerHtml(parsed);
+  banner.classList.remove('hidden');
+  banner.querySelector('.update-available-banner-dismiss')?.addEventListener('click', () => {
+    dismissUpdateBannerForSession();
+  });
+}
+
+/**
+ * @param {{ source?: 'boot' | 'manual', frozen?: boolean, fetchFn?: typeof fetch, onManualMessage?: (msg: string, opts?: { error?: boolean }) => void }} [opts]
+ */
+export async function checkForUpdates(opts = {}) {
+  const fetchFn = opts.fetchFn || fetch;
+  const source = opts.source || 'manual';
+  const frozen = opts.frozen === true;
+  if (source === 'boot' && !frozen) return { skipped: true, reason: 'not-frozen' };
+
+  try {
+    const res = await fetchFn('/api/update-check');
+    if (!res.ok) {
+      const msg = `Could not check for updates (server returned ${res.status}).`;
+      if (source === 'manual') opts.onManualMessage?.(msg, { error: true });
+      return { ok: false, error: msg };
+    }
+    const data = await res.json().catch(() => ({}));
+    const parsed = parseUpdateCheckResponse(data);
+    if (!parsed.ok) {
+      const msg = `Could not check for updates: ${parsed.error}`;
+      if (source === 'manual') opts.onManualMessage?.(msg, { error: true });
+      return { ok: false, error: parsed.error };
+    }
+    if (parsed.updateAvailable) {
+      if (source === 'boot') showUpdateBanner(parsed);
+      else opts.onManualMessage?.(formatUpdateAvailableMessage(parsed));
+      return { ok: true, updateAvailable: true, parsed };
+    }
+    if (source === 'manual') opts.onManualMessage?.(formatUpToDateMessage(parsed));
+    return { ok: true, updateAvailable: false, parsed };
+  } catch (err) {
+    const msg = `Update check failed: ${err?.message || err}`;
+    if (source === 'manual') opts.onManualMessage?.(msg, { error: true });
+    return { ok: false, error: msg };
+  }
+}
+
+/** @internal Vitest helper */
+export function _resetUpdateBannerForTests() {
+  if (typeof sessionStorage !== 'undefined') sessionStorage.removeItem(UPDATE_BANNER_DISMISS_KEY);
+  hideUpdateBanner();
+}

--- a/tests/auto-enrich.test.js
+++ b/tests/auto-enrich.test.js
@@ -231,4 +231,47 @@ describe('recordLibraryFirstSeen', () => {
     expect(state.libraryFirstSeenByKey['nintendo:new-1']).toBeGreaterThan(0);
     expect(state.libraryFirstSeenByKey[gameKey(state.allGames[0])]).toBe(0);
   });
+
+  it('baselines a first Steam import instead of flooding recents', () => {
+    recordLibraryFirstSeen();
+    state._libraryKeysBeforeMerge = new Set();
+    const bulk = [];
+    for (let i = 0; i < 20; i++) {
+      bulk.push({ store: 'steam', id: String(400 + i), name: `Game ${i}` });
+    }
+    state.allGames = bulk;
+    const n = recordLibraryFirstSeen();
+    expect(n).toBe(0);
+    expect(state.libraryFirstSeenByKey['steam:400']).toBe(0);
+    expect(state.libraryFirstSeenByKey['steam:419']).toBe(0);
+  });
+
+  it('still stamps a single game added after seed', () => {
+    recordLibraryFirstSeen();
+    state._libraryKeysBeforeMerge = new Set(state.allGames.map(g => gameKey(g)));
+    state.allGames.push({ store: 'steam', id: '999', name: 'One New Game' });
+    const n = recordLibraryFirstSeen();
+    expect(n).toBe(1);
+    expect(state.libraryFirstSeenByKey['steam:999']).toBeGreaterThan(0);
+  });
+});
+
+describe('repairBulkFirstSeenStamps', () => {
+  it('collapses persisted bulk-import batches to baseline', async () => {
+    const { repairBulkFirstSeenStamps } = await import('../js/library-load.js');
+    const ts = Date.now() - 3 * 60 * 60 * 1000;
+    const map = {};
+    for (let i = 0; i < 12; i++) map[`steam:${i}`] = ts + i;
+    expect(repairBulkFirstSeenStamps(map)).toBe(true);
+    expect(map['steam:0']).toBe(0);
+    expect(map['steam:11']).toBe(0);
+  });
+
+  it('leaves small batches alone', async () => {
+    const { repairBulkFirstSeenStamps } = await import('../js/library-load.js');
+    const ts = Date.now();
+    const map = { 'steam:400': ts, 'steam:620': ts + 1 };
+    expect(repairBulkFirstSeenStamps(map)).toBe(false);
+    expect(map['steam:400']).toBe(ts);
+  });
 });

--- a/tests/claimable.test.js
+++ b/tests/claimable.test.js
@@ -3,6 +3,8 @@
  */
 
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const isProMock = vi.hoisted(() => vi.fn(() => false));
 
@@ -36,6 +38,7 @@ import {
   CLAIMS_HOSTED_FETCH_MS,
   sanitizeBlurb,
   handleClaimableClick,
+  animateClaimOut,
   loadClaimableNow,
   claimCoverFallback,
 } from '../js/claimable.js';
@@ -735,6 +738,26 @@ describe('handleClaimableClick URL safety', () => {
       window.open = orig;
     }
     expect(opened).toEqual(['https://example.com/safe']);
+  });
+});
+
+describe('claimable clear cascade guard', () => {
+  it('CSS blocks pointer events on claim-clearing rows', () => {
+    const text = fs.readFileSync(path.join(process.cwd(), 'app.css'), 'utf8');
+    expect(text).toMatch(/\.claim-clearing\s*\{[^}]*pointer-events:\s*none/);
+  });
+
+  it('animateClaimOut adds claim-clearing without removing sibling rows', () => {
+    document.body.innerHTML = `
+      <div id="claimableNowModule">
+        <div class="claim-row" data-claim-id="a"><button data-claim-clear="a">Clear</button></div>
+        <div class="claim-row" data-claim-id="b"><button data-claim-clear="b">Clear</button></div>
+      </div>`;
+    const sibling = document.querySelector('[data-claim-id="b"]');
+    animateClaimOut('a', () => {});
+    const clearing = document.querySelector('[data-claim-id="a"]');
+    expect(clearing.classList.contains('claim-clearing')).toBe(true);
+    expect(document.querySelector('[data-claim-id="b"]')).toBe(sibling);
   });
 });
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,38 @@ def _protect_real_profile_store() -> None:
             real_index.write_bytes(index_bytes)
 
 
+@pytest.fixture(autouse=True)
+def _stub_os_keyring_on_macos(monkeypatch: pytest.MonkeyPatch) -> None:
+    """macOS CI can hang on blocking keychain prompts; use an in-memory stub."""
+    if sys.platform != "darwin":
+        return
+    store: dict[tuple[str, str], str] = {}
+
+    class _KeyringErrors:
+        class KeyringError(Exception):
+            pass
+
+        class PasswordDeleteError(KeyringError):
+            pass
+
+    class _FakeKeyring:
+        errors = _KeyringErrors()
+
+        @staticmethod
+        def get_password(service: str, account: str) -> str | None:
+            return store.get((service, account))
+
+        @staticmethod
+        def set_password(service: str, account: str, password: str) -> None:
+            store[(service, account)] = password
+
+        @staticmethod
+        def delete_password(service: str, account: str) -> None:
+            store.pop((service, account), None)
+
+    monkeypatch.setitem(sys.modules, "keyring", _FakeKeyring())
+
+
 def _pid_alive(pid: int) -> bool:
     if pid <= 0:
         return False

--- a/tests/fetcher-health.test.js
+++ b/tests/fetcher-health.test.js
@@ -36,6 +36,7 @@ import {
   connectionsNavigateProvider,
   fetcherRunner,
   renderDashboardFetcherHealth,
+  tryPatchFetcherHealthDashboard,
   buildFetcherHealthRows,
   filterFetcherHealthRows,
   isFetcherAuthHealthy,
@@ -1867,5 +1868,87 @@ describe('coverableRows', () => {
     expect(keys).toContain('wishlist:xbox-9NQPJ4M6SMDF');
     expect(keys).toContain('itch:1');
     expect(keys).not.toContain('itch:2');
+  });
+});
+
+describe('tryPatchFetcherHealthDashboard', () => {
+  it('returns false when dashboard shell is missing', () => {
+    document.body.innerHTML = '<div id="dashboardFetcherHealth"></div>';
+    expect(tryPatchFetcherHealthDashboard(document.getElementById('dashboardFetcherHealth'), {
+      layout: 'landscape',
+      showReadonly: false,
+      legendTipsOpen: false,
+      chipPatches: [],
+      staleCount: 0,
+      missingCount: 0,
+      healthSummary: 'All fresh',
+      statTotals: { lib: { connected: 0, total: 0 }, wish: { connected: 0, total: 0 }, enrich: { connected: 0, total: 0 }, lastSyncValue: 'never', connected: 0, total: 0, pct: 0 },
+    })).toBe(false);
+  });
+
+  it('patches existing chips without replacing the slot root', () => {
+    document.body.innerHTML = `
+      <div id="dashboardFetcherHealth" data-stat-layout="landscape">
+        <div class="fh-bar"></div>
+        <div class="fh-chips">
+          <button type="button" class="fh-chip fh-chip-ok" data-fetcher-key="steam" data-status="fresh">
+            <span class="fh-chip-label">Steam</span>
+            <span class="fh-chip-count">10</span>
+            <span class="fh-chip-age">1h</span>
+          </button>
+        </div>
+        <span class="fh-count fh-count--fresh" title="">0 missing</span>
+        <div class="fh-stat fh-stat--hero"><span class="fh-stat-value">1/1</span></div>
+        <div class="fh-stat"><span class="fh-stat-value">never</span></div>
+        <div class="fh-stat"><span class="fh-stat-value">1</span></div>
+        <div class="fh-stat"><span class="fh-stat-value">0</span></div>
+        <div class="fh-stat"><span class="fh-stat-value">0</span></div>
+        <span class="fh-stat-bar-fill" style="--pct:100%"></span>
+        <div id="fhLegendTips" class="fh-legend-tips"></div>
+      </div>`;
+    const slot = document.getElementById('dashboardFetcherHealth');
+    const chip = slot.querySelector('[data-fetcher-key="steam"]');
+    const ok = tryPatchFetcherHealthDashboard(slot, {
+      layout: 'landscape',
+      showReadonly: false,
+      legendTipsOpen: false,
+      chipPatches: [{
+        key: 'steam',
+        displayStatus: 'stale',
+        status: 'stale',
+        title: 'Steam stale',
+        disabled: false,
+        connectProvider: '',
+        chipLabel: 'Steam',
+        countStr: '10',
+        ageText: '2d',
+        chipAriaLabel: 'Steam, 10, 2d',
+        showWarn: false,
+        modifiers: {
+          'fh-chip-needs-config': false,
+          'fh-chip-readonly': false,
+          'fh-chip-auth-cooldown': false,
+          'fh-chip-reconnect-required': false,
+          'fh-chip-disconnected': false,
+          'fh-chip-unavailable': false,
+        },
+      }],
+      staleCount: 0,
+      missingCount: 0,
+      healthSummary: 'All fresh',
+      statTotals: {
+        lib: { connected: 1, total: 1 },
+        wish: { connected: 0, total: 0 },
+        enrich: { connected: 0, total: 0 },
+        lastSyncValue: '2d ago',
+        connected: 1,
+        total: 1,
+        pct: 100,
+      },
+    });
+    expect(ok).toBe(true);
+    expect(chip).toBe(slot.querySelector('[data-fetcher-key="steam"]'));
+    expect(chip.classList.contains('fh-chip-stale')).toBe(true);
+    expect(chip.querySelector('.fh-chip-age').textContent).toBe('2d');
   });
 });

--- a/tests/test_fetcher_main_contract.py
+++ b/tests/test_fetcher_main_contract.py
@@ -1,0 +1,83 @@
+"""Contract tests for fetch_psn, fetch_xbox, fetch_ubisoft main() exit paths."""
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from clients.psn_client import PsnAuthError
+from clients.ubisoft_client import UbisoftAuthError
+from clients.xbox_client import XboxAuthError
+from fetchers._progress import EXIT_CODE_AUTH
+
+
+def test_fetch_psn_main_missing_npsso_exits_1(monkeypatch: pytest.MonkeyPatch) -> None:
+    import fetchers.fetch_psn as fetch_psn
+
+    monkeypatch.setattr(fetch_psn, "resolve_env", lambda *_a, **_k: None)
+    monkeypatch.setattr(sys, "argv", ["fetch_psn"])
+    assert fetch_psn.main() == 1
+
+
+def test_fetch_psn_main_auth_failure_exits_4(monkeypatch: pytest.MonkeyPatch) -> None:
+    import fetchers.fetch_psn as fetch_psn
+
+    mark_calls: list = []
+    monkeypatch.setattr(fetch_psn, "resolve_env", lambda *_a, **_k: "npsso-token")
+    monkeypatch.setattr(fetch_psn, "mark_invalid", lambda *a, **k: mark_calls.append((a, k)))
+    with patch.object(fetch_psn, "PsnClient") as mock_client:
+        mock_client.return_value.validate_session.side_effect = PsnAuthError("expired")
+        monkeypatch.setattr(sys, "argv", ["fetch_psn", "--skip-hltb"])
+        assert fetch_psn.main() == EXIT_CODE_AUTH
+    assert mark_calls
+
+
+def test_fetch_xbox_main_missing_api_key_exits_1(monkeypatch: pytest.MonkeyPatch) -> None:
+    import fetchers.fetch_xbox as fetch_xbox
+
+    monkeypatch.setattr(fetch_xbox, "resolve_env", lambda *_a, **_k: None)
+    monkeypatch.setattr(sys, "argv", ["fetch_xbox"])
+    assert fetch_xbox.main() == 1
+
+
+def test_fetch_xbox_main_auth_failure_exits_4(monkeypatch: pytest.MonkeyPatch) -> None:
+    import fetchers.fetch_xbox as fetch_xbox
+
+    mark_calls: list = []
+    monkeypatch.setattr(fetch_xbox, "resolve_env", lambda *_a, **_k: "xbl-key")
+    monkeypatch.setattr(fetch_xbox, "mark_invalid", lambda *a, **k: mark_calls.append((a, k)))
+    with patch.object(fetch_xbox, "XboxClient") as mock_client:
+        mock_client.return_value.get_gamertag.return_value = "tester"
+        mock_client.return_value.get_title_history.side_effect = XboxAuthError("expired")
+        monkeypatch.setattr(sys, "argv", ["fetch_xbox", "--skip-hltb"])
+        assert fetch_xbox.main() == EXIT_CODE_AUTH
+    assert mark_calls
+
+
+def test_fetch_ubisoft_main_missing_creds_exits_1(monkeypatch: pytest.MonkeyPatch) -> None:
+    import fetchers.fetch_ubisoft as fetch_ubisoft
+
+    monkeypatch.setattr(fetch_ubisoft, "resolve_env", lambda *_a, **_k: None)
+    monkeypatch.setattr(sys, "argv", ["fetch_ubisoft"])
+    assert fetch_ubisoft.main() == 1
+
+
+def test_fetch_ubisoft_main_auth_failure_exits_4(monkeypatch: pytest.MonkeyPatch) -> None:
+    import fetchers.fetch_ubisoft as fetch_ubisoft
+
+    mark_calls: list = []
+
+    def _resolve(key: str, provider=None) -> str | None:  # noqa: ARG001
+        return {
+            "UBISOFT_AUTH": "Ubi_v1 t=x",
+            "UBISOFT_SESSION_ID": "sess",
+        }.get(key)
+
+    monkeypatch.setattr(fetch_ubisoft, "resolve_env", _resolve)
+    monkeypatch.setattr(fetch_ubisoft, "mark_invalid", lambda *a, **k: mark_calls.append((a, k)))
+    with patch.object(fetch_ubisoft, "UbisoftClient") as mock_client:
+        mock_client.return_value.get_library.side_effect = UbisoftAuthError("expired")
+        monkeypatch.setattr(sys, "argv", ["fetch_ubisoft", "--skip-hltb"])
+        assert fetch_ubisoft.main() == EXIT_CODE_AUTH
+    assert mark_calls

--- a/tests/test_nintendo_wishlist.py
+++ b/tests/test_nintendo_wishlist.py
@@ -47,6 +47,43 @@ def test_build_row_schema() -> None:
     assert row["nintendo_product_id"] == "71000000012345"
 
 
+def test_build_row_tags_dlc() -> None:
+    from fetchers.fetch_nintendo_wishlist import WishlistItem
+
+    item = WishlistItem(
+        product_id="71000000099999",
+        title="Adventure Expansion Pass",
+        image_url=None,
+        store_url="https://www.nintendo.com/us/store/products/adventure-dlc-switch/",
+        release_date=None,
+        genres=[],
+        price="$19.99",
+        price_initial=None,
+        discount_percent=None,
+        currency="USD",
+        is_dlc=True,
+    )
+    row = _build_row(item, None)
+    assert row["type"] == "dlc"
+    assert row["tags"] == ["dlc"]
+    assert row["nintendo_is_dlc"] is True
+
+
+def test_wishlist_item_is_dlc_from_product_type() -> None:
+    from fetchers.fetch_nintendo_wishlist import _item_from_dict
+
+    item = _item_from_dict(
+        {
+            "nsUid": "71000000088888",
+            "title": "Bonus Tracks Pack",
+            "productType": "DLC",
+            "url": "/us/store/products/bonus-tracks-switch/",
+        }
+    )
+    assert item is not None
+    assert item.is_dlc is True
+
+
 def test_signed_out_login_page() -> None:
     assert _signed_out("", "https://accounts.nintendo.com/login")
     assert not _signed_out(FIXTURE.read_text(encoding="utf-8"), "https://www.nintendo.com/us/wish-list/")

--- a/tests/test_server_support_update.py
+++ b/tests/test_server_support_update.py
@@ -1,0 +1,40 @@
+"""Tests for shared/server_support update-check helpers."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from shared.server_support import (
+    build_update_check_payload,
+    normalize_version_tag,
+    update_available,
+)
+
+
+def test_normalize_version_tag_strips_v_prefix() -> None:
+    assert normalize_version_tag("v0.8.26") == "0.8.26"
+
+
+def test_update_available_compares_semver_tuple() -> None:
+    assert update_available("0.8.25", "0.8.26") is True
+    assert update_available("0.8.26", "0.8.26") is False
+    assert update_available("0.9.0", "0.8.99") is False
+
+
+def test_build_update_check_payload_ok() -> None:
+    with patch("shared.server_support.fetch_latest_github_release") as mock_release:
+        mock_release.return_value = {
+            "tag_name": "v1.2.3",
+            "html_url": "https://github.com/Ogrods/baklog/releases/tag/v1.2.3",
+        }
+        payload = build_update_check_payload("1.2.0")
+    assert payload["update_available"] is True
+    assert payload["latest"] == "1.2.3"
+    assert payload["current"] == "1.2.0"
+    assert payload["url"].endswith("v1.2.3")
+
+
+def test_build_update_check_payload_soft_failure() -> None:
+    with patch("shared.server_support.fetch_latest_github_release", side_effect=RuntimeError("offline")):
+        payload = build_update_check_payload("1.0.0")
+    assert payload["update_available"] is False
+    assert payload["error"] == "offline"

--- a/tests/update-check.test.js
+++ b/tests/update-check.test.js
@@ -1,0 +1,127 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import {
+  parseUpdateCheckResponse,
+  formatUpdateAvailableMessage,
+  formatUpToDateMessage,
+  renderUpdateBannerHtml,
+  checkForUpdates,
+  dismissUpdateBannerForSession,
+  UPDATE_BANNER_DISMISS_KEY,
+  _resetUpdateBannerForTests,
+} from '../js/update-check.js';
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="updateAvailableBanner" class="migration-banner hidden"></div>';
+  _resetUpdateBannerForTests();
+});
+
+describe('parseUpdateCheckResponse', () => {
+  it('parses update available payload', () => {
+    const parsed = parseUpdateCheckResponse({
+      current: '0.8.25',
+      latest: '0.8.26',
+      update_available: true,
+      url: 'https://github.com/Ogrods/baklog/releases/tag/v0.8.26',
+    });
+    expect(parsed).toEqual({
+      ok: true,
+      current: '0.8.25',
+      latest: '0.8.26',
+      updateAvailable: true,
+      url: 'https://github.com/Ogrods/baklog/releases/tag/v0.8.26',
+    });
+  });
+
+  it('returns error when API reports failure', () => {
+    expect(parseUpdateCheckResponse({ error: 'rate limited' })).toEqual({
+      ok: false,
+      error: 'rate limited',
+    });
+  });
+});
+
+describe('checkForUpdates', () => {
+  it('skips boot check when not frozen', async () => {
+    const fetchFn = vi.fn();
+    const result = await checkForUpdates({ source: 'boot', frozen: false, fetchFn });
+    expect(result).toEqual({ skipped: true, reason: 'not-frozen' });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('shows boot banner when frozen and update available', async () => {
+    const fetchFn = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        current: '0.8.25',
+        latest: '0.8.26',
+        update_available: true,
+        url: 'https://example.com/release',
+      }),
+    }));
+    await checkForUpdates({ source: 'boot', frozen: true, fetchFn });
+    const banner = document.getElementById('updateAvailableBanner');
+    expect(banner.classList.contains('hidden')).toBe(false);
+    expect(banner.textContent).toContain('0.8.26');
+    expect(banner.querySelector('a')?.href).toBe('https://example.com/release');
+  });
+
+  it('respects session dismiss for boot banner', async () => {
+    sessionStorage.setItem(UPDATE_BANNER_DISMISS_KEY, '1');
+    const fetchFn = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        current: '0.8.25',
+        latest: '0.8.26',
+        update_available: true,
+        url: 'https://example.com/release',
+      }),
+    }));
+    await checkForUpdates({ source: 'boot', frozen: true, fetchFn });
+    expect(document.getElementById('updateAvailableBanner').classList.contains('hidden')).toBe(true);
+  });
+
+  it('routes manual messages through callback', async () => {
+    const onManualMessage = vi.fn();
+    const fetchFn = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        current: '0.8.26',
+        latest: '0.8.26',
+        update_available: false,
+      }),
+    }));
+    await checkForUpdates({ source: 'manual', onManualMessage, fetchFn });
+    expect(onManualMessage).toHaveBeenCalledWith(formatUpToDateMessage({ current: '0.8.26' }));
+  });
+});
+
+describe('renderUpdateBannerHtml', () => {
+  it('escapes version strings in banner html', () => {
+    const html = renderUpdateBannerHtml({
+      current: '0.8.25',
+      latest: '<bad>',
+      url: 'https://example.com',
+    });
+    expect(html).toContain('&lt;bad&gt;');
+    expect(html).not.toContain('<bad>');
+  });
+});
+
+describe('formatUpdateAvailableMessage', () => {
+  it('includes download url when present', () => {
+    expect(formatUpdateAvailableMessage({
+      current: '1.0.0',
+      latest: '1.0.1',
+      url: 'https://example.com/dl',
+    })).toContain('https://example.com/dl');
+  });
+});
+
+describe('dismissUpdateBannerForSession', () => {
+  it('hides banner and sets session flag', () => {
+    document.getElementById('updateAvailableBanner').classList.remove('hidden');
+    dismissUpdateBannerForSession();
+    expect(sessionStorage.getItem(UPDATE_BANNER_DISMISS_KEY)).toBe('1');
+    expect(document.getElementById('updateAvailableBanner').classList.contains('hidden')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Baseline first-seen timestamps when 8+ library keys arrive in one import (fixes Portal-style false "Recently added" after first Steam sync) and repair persisted bulk batches on load
- Add frozen-build update check banner plus shared update-check.js module and troubleshooting docs
- Tag Nintendo wishlist DLC rows, patch fetcher health chips in place, guard claim-clear cascade, and extend CI/tests

## Test plan
- [x] npm test for auto-enrich, recent-additions, update-check, fetcher-health, claimable
- [x] pytest for nintendo wishlist, fetcher main contract, server support update
- [ ] Reload dashboard and confirm Recently added no longer lists bulk-import Steam classics with fresh ages
