### PR TITLE
feat: pre-ship v0.8.27 — macOS CI, trust, sign_in_active

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,3 +160,53 @@ jobs:
           } else {
             gh release create $tag @assets --title "BAKLOG $tag" --generate-notes
           }
+
+  build-macos:
+    name: Build and attach macOS release
+    runs-on: macos-latest
+    needs: build
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Verify release auth secrets (fail fast)
+        env:
+          BAKLOG_SUPABASE_URL: ${{ secrets.BAKLOG_SUPABASE_URL }}
+          BAKLOG_SUPABASE_ANON_KEY: ${{ secrets.BAKLOG_SUPABASE_ANON_KEY }}
+        run: |
+          if [ -z "$BAKLOG_SUPABASE_URL" ] || [ -z "$BAKLOG_SUPABASE_ANON_KEY" ]; then
+            echo "::error::GitHub repo secrets BAKLOG_SUPABASE_URL and BAKLOG_SUPABASE_ANON_KEY must be set before tagging."
+            exit 1
+          fi
+          echo "Release auth secrets present (values not printed)."
+
+      - name: Build macOS bundle
+        env:
+          BAKLOG_SUPABASE_URL: ${{ secrets.BAKLOG_SUPABASE_URL }}
+          BAKLOG_SUPABASE_ANON_KEY: ${{ secrets.BAKLOG_SUPABASE_ANON_KEY }}
+        run: bash packaging/build_macos.sh
+
+      - name: Verify macOS artifacts exist
+        run: |
+          test -f release/BAKLOG-macos.zip
+          test -f release/BAKLOG-macos.sha256
+          shasum -a 256 release/BAKLOG-macos.zip
+
+      - name: Upload macOS assets to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${{ github.ref_name }}"
+          gh release upload "$tag" release/BAKLOG-macos.zip release/BAKLOG-macos.sha256 --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,20 +24,26 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [0.8.27] - 2026-06-27
 
-### Changed
-
-- Public copy aligned to canonical **no telemetry by default** wording (README, SECURITY, Pro promo trust points, guide FAQ, landing trust section).
-- **Run** / **RunManager** extracted from `server.py` into `shared/run_manager.py`; server line budget ratcheted to 3000.
-- Connections left-rail grouping and status pills moved to `js/connections-rail.js`.
-- Dev vs frozen footgun mitigated: document `PORT=8766` with separate `BAKLOG_DATA_DIR`; dev banner warns about shared localhost storage.
-
 ### Added
 
+- macOS release pipeline: `packaging/build_macos.sh`, CI `build-macos` job uploads `BAKLOG-macos.zip` + `.sha256` on tag.
+- Unsigned-beta trust notes in diagnostics/update-check (`unsigned_beta`, `trust_note`) and guide docs (SmartScreen, Gatekeeper, ARP drift).
+- `sign_in_active` on `/api/update-check` so the update banner hides **Update now** while a store sign-in window is open.
 - In-app update recovery: apply scripts write `apply-result.json`, restore from backup on copy failure, and retain the newest `BAKLOG-backup-*` only.
 - Ready-state persistence (`ready.json`) survives server/tray restart; **Discard download** clears verified packages from disk.
 - `GET /api/update/apply-result`, `POST /api/update/discard-ready`; post-apply UI polling with tray restart recovery copy.
 - Zip bundle ships **Uninstall BAKLOG.bat** for portable cleanup; Inno uninstall/finish copy is portable-aware when `portable.txt` exists.
 - Apply blocked while a store sign-in window is open; update-check exposes `fetchers_in_flight` for proactive UI hints.
+
+### Changed
+
+- Personal doc load/save extracted to `shared/server_personal.py`; `server.py` line budget headroom restored.
+- `apply_update.sh` no longer depends on system `python3` for path resolution.
+- `js/fetcher/runner/index.js` added to module-size CI budget (2200 lines, ratchet down after splits).
+- Public copy aligned to canonical **no telemetry by default** wording (README, SECURITY, Pro promo trust points, guide FAQ, landing trust section).
+- **Run** / **RunManager** extracted from `server.py` into `shared/run_manager.py`; server line budget ratcheted to 3000.
+- Connections left-rail grouping and status pills moved to `js/connections-rail.js`.
+- Dev vs frozen footgun mitigated: document `PORT=8766` with separate `BAKLOG_DATA_DIR`; dev banner warns about shared localhost storage.
 - Streaming download progress in `fetch_url_to_file`; tray notifies when a verified update is ready to install.
 - Diagnostics and update-check expose `install_source`, `arp_version`, and `arp_version_mismatch` (Windows Setup vs zip apply visibility).
 - Update install confirm footnote when Add/Remove Programs may lag behind in-app zip updates.
@@ -47,7 +53,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 - `/api/config` `runtime_label` (`dev` / `installed` / `portable`) for UI runtime detection; `frozen` kept for compatibility.
 - Tray menu **Open data folder** opens the active profile data directory in Explorer.
 - Installer finish page shows library vs app paths; full uninstall nudges Connections **Export bundle** before wipe.
-- `packaging/build_macos.sh` maintainer checklist; ARCHITECTURE rough-edges table refreshed.
+- `packaging/build_macos.sh` full PyInstaller build + CI attach on tag.
 
 ### Fixed
 

--- a/guide/getting-started.md
+++ b/guide/getting-started.md
@@ -17,7 +17,7 @@ On Windows, use the project `.venv` Python - not the Microsoft Store `python.exe
 If you received a beta invite:
 
 1. Download and run **BAKLOG-Setup.exe** from your invite link.
-2. If SmartScreen warns about an unknown publisher, click **More info**, then **Run anyway**.
+2. If SmartScreen warns about an unknown publisher, click **More info**, then **Run anyway**. BAKLOG is an unsigned beta — see [Unsigned beta builds](troubleshooting.md#unsigned-beta-builds-no-code-signing).
 3. Launch **BAKLOG** from the Start Menu. A tray icon appears and your browser opens.
 4. Open the **Connections** tab and connect each store you use (Chrome or Edge required).
 
@@ -33,6 +33,13 @@ PORT=8766
 That keeps library files out of `BAKLOG-Data` and gives dev its own browser origin so localStorage is not shared with the installed app on port 8765. The dashboard header shows a **Dev server** chip when the dev server is active. See [troubleshooting](troubleshooting.md#dev-server-vs-frozen-exe-same-browser-origin).
 
 Portable zip builds work too: unzip to a normal folder, then run `Start BAKLOG.bat` or `BAKLOG Tray.exe`. Add an empty `portable.txt` beside `BAKLOG.exe` only if you want all data in the unzip folder (thumb drives). See `BETA-README.txt` in the bundle.
+
+## Beta (macOS)
+
+1. Download **BAKLOG-macos.zip** from [GitHub Releases](https://github.com/Ogrods/BAKLOG/releases/latest) (or your invite link once tagged).
+2. Unzip to a normal folder (not Downloads directly — Gatekeeper is stricter there). Double-click **Start BAKLOG.command** or run **BAKLOG Tray** from the `BAKLOG` folder.
+3. If macOS blocks the app ("cannot be opened"), right-click **BAKLOG Tray** → **Open** once, or run `xattr -cr /path/to/BAKLOG` in Terminal. See [Unsigned beta builds](troubleshooting.md#unsigned-beta-builds-no-code-signing).
+4. Library data lives in `~/Library/Application Support/BAKLOG-Data` (or beside the app when `portable.txt` is present). In-app updates use `apply_update.sh` once a mac zip is on the release.
 
 ## Install (from source)
 

--- a/guide/troubleshooting.md
+++ b/guide/troubleshooting.md
@@ -178,6 +178,18 @@ These are expected limits in the current invite-only beta, not one-off bugs:
 | **Secrets store corrupt** | The encrypted credentials file for this profile cannot be read (wrong keyring entry, moved data, or a damaged file). Use **Reset store** on the banner, restore a backup on Connections, or reconnect each store. Archived copies are kept as `secrets.bin.corrupt-*` beside the old file. |
 | **Cloud sync** | Signing in on a second PC does not copy your library yet. Copy `BAKLOG-Data` manually or wait for the planned Pro cloud mirror. |
 
+## Unsigned beta builds (no code signing)
+
+BAKLOG beta builds are **not code-signed** yet. That is normal for invite-only testing — you are not doing anything wrong.
+
+| Platform | What you may see | What to do |
+|----------|------------------|------------|
+| **Windows** | SmartScreen "Unknown publisher" on first launch or after manual download | **More info** → **Run anyway**. Only download from [GitHub Releases](https://github.com/Ogrods/BAKLOG/releases) or your official invite link. |
+| **Windows Setup + in-app updates** | Add/Remove Programs shows an older version than the app header | Expected: zip-based in-app updates replace files but do not refresh Inno's registry entry. Re-run **BAKLOG-Setup.exe** when you want Settings → Apps to match, or ignore if the in-app version is correct. **Copy diagnostics** shows `install_source`, `arp_version`, and `arp_version_mismatch`. |
+| **macOS** | "App can't be opened" or quarantine after download/update | Right-click the app → **Open** once, or `xattr -cr /path/to/BAKLOG` in Terminal. Unzip to Applications or another stable folder, not directly from Downloads. |
+
+We skip paid signing for now; future releases may add certificates. Verify SHA-256 sidecars on release assets when you want extra assurance.
+
 ## App updates (installed build)
 
 **Symptom:** You want to know if a newer BAKLOG release is available.
@@ -198,11 +210,9 @@ These are expected limits in the current invite-only beta, not one-off bugs:
 
 **Version:** Your current build version appears at the bottom of the **⋮** menu on installed builds.
 
-**Platforms:** Windows uses `BAKLOG-win64.zip` + `apply_update.ps1`. macOS uses the same pipeline with `BAKLOG-macos.zip` + `apply_update.sh` once a mac frozen build is published on GitHub; until then mac installs still get notify + release-page link only.
+**Platforms:** Windows uses `BAKLOG-win64.zip` + `apply_update.ps1`. macOS uses `BAKLOG-macos.zip` + `apply_update.sh` on tagged releases (built in CI alongside Windows).
 
-**macOS zip deferred:** There is no official `BAKLOG-macos.zip` on GitHub Releases yet. macOS users should run from source or wait for release notifications; in-app apply stays blocked with `platform_zip_missing` until the artifact ships. Maintainers: see `packaging/build_macos.sh` for the manual build checklist.
-
-**Add/Remove Programs vs in-app version:** On Windows Setup installs, zip-based in-app updates replace app files but do not refresh the Inno uninstall registry version. Use **Copy diagnostics** or `GET /api/diagnostics` (`install_source`, `arp_version`, `arp_version_mismatch`) to compare; re-run **BAKLOG-Setup.exe** when Settings → Apps should match the running build.
+**Add/Remove Programs vs in-app version:** On Windows Setup installs, zip-based in-app updates replace app files but do not refresh the Inno uninstall registry version. Use **Copy diagnostics** or `GET /api/diagnostics` (`install_source`, `arp_version`, `arp_version_mismatch`, `trust_note`) to compare; re-run **BAKLOG-Setup.exe** when Settings → Apps should match the running build.
 
 **Security:** Updates download only from the official `Ogrods/BAKLOG` GitHub release assets. The server verifies the published `.sha256` sidecar before apply is allowed. Apply is blocked while fetchers are running, a store sign-in window is open, or when BAKLOG is running from a temporary zip-extract folder.
 

--- a/js/update-check.js
+++ b/js/update-check.js
@@ -81,6 +81,7 @@ export function renderSetupArpFootnote(hints = _installHints) {
  *   publishedAt: string | null,
  *   dismissed: boolean,
  *   fetchersInFlight: boolean,
+ *   signInActive: boolean,
  * } | { ok: false, error: string }}
  */
 export function parseUpdateCheckResponse(data) {
@@ -124,8 +125,14 @@ export function parseUpdateCheckResponse(data) {
     publishedAt,
     dismissed: data.dismissed === true,
     fetchersInFlight: data.fetchers_in_flight === true,
+    signInActive: data.sign_in_active === true,
     ...installHintsFromPayload(data),
   };
+}
+
+/** @param {{ fetchersInFlight?: boolean, signInActive?: boolean }} parsed */
+function updateMutationsBlocked(parsed) {
+  return parsed.fetchersInFlight === true || parsed.signInActive === true;
 }
 
 /** @param {{ latest: string | null, dismissed?: boolean }} parsed */
@@ -185,13 +192,16 @@ export function mapUpdateError(message, code = null) {
  *   applyBlockedMessage?: string | null,
  *   applySupported?: boolean,
  *   fetchersInFlight?: boolean,
+ *   signInActive?: boolean,
  * }} parsed
  */
 export function renderApplyBlockedHint(parsed) {
-  if (parsed.applySupported && !parsed.fetchersInFlight) return '';
-  const msg = parsed.fetchersInFlight
-    ? mapUpdateError('', 'fetchers_running')
-    : parsed.applyBlockedMessage?.trim();
+  if (parsed.applySupported && !updateMutationsBlocked(parsed)) return '';
+  const msg = parsed.signInActive
+    ? mapUpdateError('', 'sign_in_active')
+    : parsed.fetchersInFlight
+      ? mapUpdateError('', 'fetchers_running')
+      : parsed.applyBlockedMessage?.trim();
   if (!msg) return '';
   return `<p class="update-blocked-hint text-sm text-slate-400 mt-1">${escapeHtml(msg)}</p>`;
 }
@@ -204,12 +214,13 @@ export function renderApplyBlockedHint(parsed) {
  *   applySupported?: boolean,
  *   applyBlockedMessage?: string | null,
  *   fetchersInFlight?: boolean,
+ *   signInActive?: boolean,
  *   releaseNotes?: string | null,
  * }} parsed
  */
 export function renderUpdateBannerHtml(parsed) {
   const href = parsed.url || 'https://github.com/Ogrods/BAKLOG/releases/latest';
-  const canUpdateNow = parsed.applySupported && !parsed.fetchersInFlight;
+  const canUpdateNow = parsed.applySupported && !updateMutationsBlocked(parsed);
   const updateBtn = canUpdateNow
     ? '<button type="button" class="update-available-banner-apply ml-2 text-sky-300 hover:underline">Update now</button>'
     : '';
@@ -265,6 +276,7 @@ export function renderUpdateProgressHtml(status, { cancellable = false } = {}) {
  *   applySupported?: boolean,
  *   applyBlockedMessage?: string | null,
  *   fetchersInFlight?: boolean,
+ *   signInActive?: boolean,
  * }} parsed
  */
 export function renderUpdateModalHtml(parsed) {
@@ -272,7 +284,7 @@ export function renderUpdateModalHtml(parsed) {
   const notes = parsed.releaseNotes
     ? `<pre class="update-modal-notes whitespace-pre-wrap text-sm text-slate-300 max-h-64 overflow-y-auto mt-3 p-3 rounded bg-slate-900/80 border border-slate-700">${escapeHtml(parsed.releaseNotes)}</pre>`
     : '<p class="text-sm text-slate-400 mt-3">See the release page for details.</p>';
-  const canUpdateNow = parsed.applySupported && !parsed.fetchersInFlight;
+  const canUpdateNow = parsed.applySupported && !updateMutationsBlocked(parsed);
   const updateBtn = canUpdateNow
     ? '<button type="button" class="update-modal-apply bg-sky-700 hover:bg-sky-600 px-3 py-2 rounded text-sm">Update now</button>'
     : '';

--- a/packaging/apply_update.sh
+++ b/packaging/apply_update.sh
@@ -44,11 +44,7 @@ json_field_int() {
 
 realpath_safe() {
   local target="$1"
-  if command -v python3 >/dev/null 2>&1; then
-    python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$target"
-  else
-    (cd "$(dirname "$target")" && pwd -P)/$(basename "$target")
-  fi
+  (cd "$(dirname "$target")" && pwd -P)/$(basename "$target")
 }
 
 restore_install_from_backup() {

--- a/packaging/baklog.spec
+++ b/packaging/baklog.spec
@@ -8,6 +8,12 @@ from pathlib import Path
 root = Path(SPEC).resolve().parent.parent
 app_icon = str(root / "packaging" / "BAKLOG.ico")
 
+_keyring_backends = (
+    ["keyring.backends.Windows"]
+    if sys.platform == "win32"
+    else ["keyring.backends.macOS"]
+)
+
 block_cipher = None
 
 datas = [
@@ -63,7 +69,7 @@ hiddenimports = [
     "shared.update_messages",
     "shared.update_api",
     "shared.update_ready_state",
-    "keyring.backends.Windows",
+    *_keyring_backends,
     "cryptography.hazmat.primitives.ciphers.aead",
     "certifi",
     "jwt",

--- a/packaging/build_macos.sh
+++ b/packaging/build_macos.sh
@@ -1,49 +1,104 @@
 #!/usr/bin/env bash
-# macOS frozen build checklist (manual — not run in CI yet).
-# Mirrors packaging/build_windows.ps1: frontend build → PyInstaller onedir → zip + sha256.
+# Build BAKLOG macOS onedir bundle with PyInstaller + zip + sha256 sidecar.
+# Run from repo root. Requires: Python 3.11+, Node 22+, pip install pyinstaller.
+#
+# Release artifacts use STABLE filenames (same pattern as build_windows.ps1):
+#   BAKLOG-macos.zip
+#   BAKLOG-macos.sha256
+#
+# Usage:
+#   ./packaging/build_macos.sh
+
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-OUT_DIR="${1:-$ROOT/release/BAKLOG}"
+cd "$ROOT"
 
-cat <<'EOF'
-BAKLOG macOS frozen build — maintainer checklist
-==============================================
+RELEASE_DIR="${ROOT}/release"
+OUT_DIR="${RELEASE_DIR}/BAKLOG"
 
-Status: DEFERRED — GitHub Releases ship BAKLOG-win64.zip + Setup.exe only.
-macOS installs use update-check notify + release-page link until BAKLOG-macos.zip exists.
+if [[ -x "${ROOT}/.venv/bin/python" ]]; then
+  PYTHON="${ROOT}/.venv/bin/python"
+else
+  PYTHON="python3"
+fi
 
-Prerequisites
-  - macOS 13+ on Apple Silicon or Intel (match CI smoke target)
-  - Python 3.11+ venv with pip install -r requirements.txt
-  - pip install pyinstaller
-  - Node.js 22+ (npm run build for dist/index.html parity)
+echo "Installing Python dependencies..."
+"${PYTHON}" -m pip install -r requirements.txt
+"${PYTHON}" -m pip install pyinstaller
 
-Build steps
-  1. cd "$ROOT" && npm ci && npm run build
-  2. pyinstaller packaging/baklog.spec --distpath release --workpath build/pyinstaller
-  3. cp packaging/apply_update.sh "$OUT_DIR/apply_update.sh"
-  4. chmod +x "$OUT_DIR/apply_update.sh"
-  5. (Optional) codesign ad-hoc or Developer ID — unsigned builds match current Windows beta policy
-  6. cd release && zip -r BAKLOG-macos.zip BAKLOG
-  7. shasum -a 256 BAKLOG-macos.zip | tee BAKLOG-macos.sha256
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm not found — install Node.js 22+ before building the frozen bundle" >&2
+  exit 1
+fi
 
-Release wiring (after first successful artifact)
-  - Upload BAKLOG-macos.zip + .sha256 to GitHub Release (same tag as Windows)
-  - Confirm shared/update_release.py picks mac asset on darwin
-  - Run scripts/frozen_bundle_smoke.py against the onedir bundle
-  - Add release.yml macOS job or manual upload step (see ARCHITECTURE.md rough edges)
+echo "Building production frontend (esbuild dist/)..."
+npm ci
+npm run vendor:supabase
+npm run build
+npm run check:dist-integrity
 
-Verify locally
-  - open release/BAKLOG/BAKLOG (or BAKLOG.app if spec bundles one)
-  - GET http://127.0.0.1:8765/api/config → frozen: true, runtime_label: installed
-  - apply_update.sh present beside server binary
+mkdir -p "${RELEASE_DIR}"
 
+echo "Building BAKLOG + BAKLOG Tray (onedir)..."
+"${PYTHON}" -m PyInstaller packaging/baklog.spec --noconfirm --distpath "${RELEASE_DIR}" --workpath "${ROOT}/build/pyinstaller"
+
+SERVER_BIN="${OUT_DIR}/BAKLOG"
+TRAY_BIN="${OUT_DIR}/BAKLOG Tray"
+if [[ ! -x "${SERVER_BIN}" ]]; then
+  echo "Build failed: ${SERVER_BIN} not found" >&2
+  exit 1
+fi
+if [[ ! -x "${TRAY_BIN}" ]]; then
+  echo "Build failed: ${TRAY_BIN} not found" >&2
+  exit 1
+fi
+
+FALLBACK_JSON="${OUT_DIR}/_internal/curated/free_claims.fallback.json"
+if [[ ! -f "${FALLBACK_JSON}" ]]; then
+  echo "Build failed: bundled curated feed missing at ${FALLBACK_JSON}" >&2
+  exit 1
+fi
+
+cp -f "${ROOT}/packaging/BETA-README.txt" "${OUT_DIR}/BETA-README.txt"
+cp -f "${ROOT}/packaging/apply_update.sh" "${OUT_DIR}/apply_update.sh"
+chmod +x "${OUT_DIR}/apply_update.sh" "${SERVER_BIN}" "${TRAY_BIN}"
+
+echo "Writing bundled account-auth .env..."
+if [[ -z "${BAKLOG_SUPABASE_URL:-}" || -z "${BAKLOG_SUPABASE_ANON_KEY:-}" ]]; then
+  echo "  Auth env: BAKLOG_SUPABASE_URL=${BAKLOG_SUPABASE_URL:+set}${BAKLOG_SUPABASE_URL:-MISSING}, BAKLOG_SUPABASE_ANON_KEY=${BAKLOG_SUPABASE_ANON_KEY:+set}${BAKLOG_SUPABASE_ANON_KEY:-MISSING}" >&2
+fi
+"${PYTHON}" "${ROOT}/scripts/write_bundle_auth_env.py" "${OUT_DIR}"
+
+cat > "${OUT_DIR}/Start BAKLOG.command" <<'EOF'
+#!/bin/bash
+cd "$(dirname "$0")"
+open -a "Google Chrome" "http://127.0.0.1:8765" 2>/dev/null || true
+exec "./BAKLOG Tray"
 EOF
+chmod +x "${OUT_DIR}/Start BAKLOG.command"
 
-echo "Target output dir: $OUT_DIR"
-echo "(Build commands are commented out until CI/mac maintainer capacity exists.)"
+VERSION="0.0.0"
+if [[ -f "${ROOT}/pyproject.toml" ]]; then
+  VERSION="$(grep -E '^version\s*=' "${ROOT}/pyproject.toml" | head -1 | sed -E 's/.*"([^"]+)".*/\1/')"
+fi
 
-# Uncomment when running manually:
-# cp "$ROOT/packaging/apply_update.sh" "$OUT_DIR/apply_update.sh"
-# chmod +x "$OUT_DIR/apply_update.sh"
+ZIP_NAME="BAKLOG-macos.zip"
+ZIP_PATH="${RELEASE_DIR}/${ZIP_NAME}"
+rm -f "${ZIP_PATH}"
+(
+  cd "${RELEASE_DIR}"
+  zip -r -q "${ZIP_NAME}" BAKLOG
+)
+
+HASH="$(shasum -a 256 "${ZIP_PATH}" | awk '{print $1}')"
+HASH_FILE="${RELEASE_DIR}/BAKLOG-macos.sha256"
+printf '%s  %s' "${HASH}" "${ZIP_NAME}" > "${HASH_FILE}"
+
+echo ""
+echo "Done (macOS unsigned beta — Gatekeeper may prompt on first launch or after in-app update)."
+echo "  Folder:  ${OUT_DIR}"
+echo "  Zip:     ${ZIP_PATH}"
+echo "  SHA256:  ${HASH_FILE}"
+echo "  Version: ${VERSION} (embedded in bundle; zip filename is stable)"
+echo "Upload both zip + .sha256 to the GitHub Release tag alongside Windows assets."

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -11,6 +11,10 @@ const jsDir = path.join(root, 'js');
 const MAX_LINES = 3800;
 const EXEMPT = new Set(['table-query.worker.js']);
 
+/** Monolith runner — split incrementally; budget ratchets down after extractions. */
+const RUNNER_MAX_LINES = 2200;
+const RUNNER_FILES = ['js/fetcher/runner/index.js'];
+
 function lineCount(filePath) {
   return fs.readFileSync(filePath, 'utf8').split(/\r?\n/).length;
 }
@@ -21,15 +25,24 @@ for (const ent of fs.readdirSync(jsDir, { withFileTypes: true })) {
   if (EXEMPT.has(ent.name)) continue;
   const p = path.join(jsDir, ent.name);
   const lines = lineCount(p);
-  if (lines > MAX_LINES) offenders.push({ file: `js/${ent.name}`, lines });
+  if (lines > MAX_LINES) offenders.push({ file: `js/${ent.name}`, lines, max: MAX_LINES });
+}
+
+for (const rel of RUNNER_FILES) {
+  const p = path.join(root, rel);
+  if (!fs.existsSync(p)) continue;
+  const lines = lineCount(p);
+  if (lines > RUNNER_MAX_LINES) {
+    offenders.push({ file: rel, lines, max: RUNNER_MAX_LINES });
+  }
 }
 
 if (offenders.length) {
-  console.error(`Module size budget exceeded (max ${MAX_LINES} lines):`);
+  console.error('Module size budget exceeded:');
   for (const o of offenders.sort((a, b) => b.lines - a.lines)) {
-    console.error(`  ${o.file}: ${o.lines} lines`);
+    console.error(`  ${o.file}: ${o.lines} lines (max ${o.max})`);
   }
   process.exit(1);
 }
 
-console.log(`OK — all js/*.js modules are within ${MAX_LINES} lines.`);
+console.log(`OK — js/*.js ≤ ${MAX_LINES} lines; runner ≤ ${RUNNER_MAX_LINES}.`);

--- a/server.py
+++ b/server.py
@@ -235,6 +235,14 @@ from shared.server_static import (  # noqa: E402
 from shared.server_static import (  # noqa: E402
     static_class as _static_class_impl,
 )
+from shared.server_personal import (  # noqa: E402
+    BAKLOG_ALLOW_EMPTY_HEADER as _BAKLOG_ALLOW_EMPTY_HEADER,
+    PERSONAL_MAX_BYTES,
+    PersonalCorruptError,
+    PersonalEmptyOverwriteError,
+    load_personal_doc as _load_personal_doc,
+    save_personal_doc as _save_personal_doc,
+)
 from shared.subprocess_guard import _max_run_seconds_from_env, popen_fetcher  # noqa: E402, F401 — re-exported for tests
 
 MAX_RUN_SECONDS = _max_run_seconds_from_env()
@@ -293,196 +301,6 @@ def _refresh_personal_paths() -> None:
         _secrets.reset_cache()
     except Exception:  # noqa: BLE001 - cache reset is best-effort
         pass
-PERSONAL_BACKUP_KEEP = 10
-PERSONAL_MAX_BYTES = 32 * 1024 * 1024  # 32 MB hard cap on the PUT body
-_personal_lock = threading.RLock()
-_personal_last_backup_at = 0.0
-
-
-def _empty_personal_doc() -> dict[str, Any]:
-    return {
-        "personal": {},
-        "prefs": {},
-        "manual": [],
-        "libraryFirstSeen": {},
-        "updated_at": None,
-        "schema_version": 1,
-    }
-
-
-class PersonalCorruptError(RuntimeError):
-    """personal.json is unreadable and no backup could be restored."""
-
-
-class PersonalEmptyOverwriteError(RuntimeError):
-    """Refusing to replace a populated personal doc with a fully empty payload."""
-
-
-_BAKLOG_ALLOW_EMPTY_HEADER = "X-BAKLOG-Allow-Empty"
-
-
-def _personal_doc_is_meaningful(doc: dict[str, Any]) -> bool:
-    """True when the stored doc carries personal edits, manual games, or first-seen stamps."""
-    personal = doc.get("personal")
-    if isinstance(personal, dict):
-        if any(k != "__migrated_v3" for k in personal):
-            return True
-    manual = doc.get("manual")
-    if isinstance(manual, list) and manual:
-        return True
-    library_first_seen = doc.get("libraryFirstSeen")
-    if isinstance(library_first_seen, dict) and library_first_seen:
-        return True
-    return False
-
-
-def _personal_payload_is_empty(validated: dict[str, Any]) -> bool:
-    """True when the incoming payload has no personal/manual/first-seen data."""
-    personal = validated.get("personal") or {}
-    if not isinstance(personal, dict):
-        return True
-    if any(k != "__migrated_v3" for k in personal):
-        return False
-    manual = validated.get("manual") or []
-    if isinstance(manual, list) and manual:
-        return False
-    library_first_seen = validated.get("libraryFirstSeen") or {}
-    if isinstance(library_first_seen, dict) and library_first_seen:
-        return False
-    return True
-
-
-def _normalize_personal_doc(doc: dict[str, Any]) -> dict[str, Any]:
-    doc.setdefault("personal", {})
-    doc.setdefault("prefs", {})
-    doc.setdefault("manual", [])
-    doc.setdefault("libraryFirstSeen", {})
-    doc.setdefault("updated_at", None)
-    doc.setdefault("schema_version", 1)
-    return doc
-
-
-def _restore_personal_from_backup() -> dict[str, Any] | None:
-    backup_dir = personal_backup_dir()
-    if not backup_dir.is_dir():
-        return None
-    backups = sorted(backup_dir.glob("personal-*.json"), reverse=True)
-    for backup in backups:
-        try:
-            with backup.open("r", encoding="utf-8") as f:
-                doc = json.load(f)
-        except (OSError, json.JSONDecodeError):
-            continue
-        if isinstance(doc, dict):
-            return _normalize_personal_doc(doc)
-    return None
-
-
-def _load_personal_doc() -> dict[str, Any]:
-    with _personal_lock:
-        path = personal_path()
-        if not path.exists():
-            return _empty_personal_doc()
-        try:
-            with path.open("r", encoding="utf-8") as f:
-                doc = json.load(f)
-        except (OSError, json.JSONDecodeError) as exc:
-            restored = _restore_personal_from_backup()
-            if restored is not None:
-                print(
-                    f"[personal] primary file corrupt ({exc!r}); serving newest backup",
-                    file=sys.stderr,
-                    flush=True,
-                )
-                return restored
-            raise PersonalCorruptError(
-                f"personal data at {path} is corrupt and no backup could be read"
-            ) from exc
-        if not isinstance(doc, dict):
-            raise PersonalCorruptError(f"personal data at {path} is not a JSON object")
-        return _normalize_personal_doc(doc)
-
-
-def _validate_personal_payload(payload: Any) -> dict[str, Any]:
-    if not isinstance(payload, dict):
-        raise ValueError("payload must be a JSON object")
-    personal = payload.get("personal", {})
-    prefs = payload.get("prefs", {})
-    manual = payload.get("manual", [])
-    library_first_seen = payload.get("libraryFirstSeen", {})
-    if not isinstance(personal, dict):
-        raise ValueError("personal must be an object")
-    if not isinstance(prefs, dict):
-        raise ValueError("prefs must be an object")
-    if not isinstance(manual, list):
-        raise ValueError("manual must be an array")
-    if not isinstance(library_first_seen, dict):
-        raise ValueError("libraryFirstSeen must be an object")
-    return {
-        "personal": personal,
-        "prefs": prefs,
-        "manual": manual,
-        "libraryFirstSeen": library_first_seen,
-    }
-
-
-def _rotate_personal_backup() -> None:
-    """Keep a rolling set of timestamped backups so a bad save can't wipe
-    out months of edits. Runs at most once every 5 minutes; the previous
-    on-disk file becomes the backup before being overwritten."""
-    global _personal_last_backup_at
-    now = time.time()
-    if now - _personal_last_backup_at < 300:
-        return
-    path = personal_path()
-    if not path.exists():
-        return
-    backup_dir = personal_backup_dir()
-    backup_dir.mkdir(parents=True, exist_ok=True)
-    stamp = time.strftime("%Y%m%d-%H%M%S", time.localtime(now))
-    backup = backup_dir / f"personal-{stamp}.json"
-    try:
-        backup.write_bytes(path.read_bytes())
-    except OSError as exc:
-        print(f"[personal] backup failed: {exc!r}", file=sys.stderr)
-        return
-    _personal_last_backup_at = now
-    # Prune oldest backups beyond the keep-count.
-    backups = sorted(backup_dir.glob("personal-*.json"))
-    for old in backups[:-PERSONAL_BACKUP_KEEP]:
-        try:
-            old.unlink()
-        except OSError:
-            pass
-
-
-def _save_personal_doc(payload: dict[str, Any], *, allow_empty: bool = False) -> dict[str, Any]:
-    """Atomic write: temp file + os.replace(). Never partial; never corrupted."""
-    with _personal_lock:
-        validated = _validate_personal_payload(payload)
-        if not allow_empty and _personal_payload_is_empty(validated):
-            existing = _load_personal_doc()
-            if _personal_doc_is_meaningful(existing):
-                path = personal_path()
-                print(
-                    f"[personal] refusing empty overwrite of populated doc at {path}",
-                    file=sys.stderr,
-                    flush=True,
-                )
-                raise PersonalEmptyOverwriteError("refusing empty overwrite")
-        doc = _empty_personal_doc()
-        doc.update(validated)
-        doc["updated_at"] = time.time()
-        pdir = personal_dir()
-        pdir.mkdir(parents=True, exist_ok=True)
-        path = personal_path()
-        _rotate_personal_backup()
-        tmp = path.with_suffix(".json.tmp")
-        with tmp.open("w", encoding="utf-8") as f:
-            json.dump(doc, f, ensure_ascii=False, indent=2)
-        os.replace(tmp, path)
-        _refresh_personal_paths()
-        return doc
 
 
 # A fetcher is just a label plus an argv. argv is fixed at definition time;

--- a/server.py
+++ b/server.py
@@ -216,6 +216,7 @@ from shared.profile_paths import (  # noqa: E402
     free_claims_path,
     get_active_profile_id,
     personal_backup_dir,
+    personal_path,  # noqa: F401 — re-exported for tests
     profile_root,
     runs_dir,
     set_request_profile_id,

--- a/server.py
+++ b/server.py
@@ -216,12 +216,24 @@ from shared.profile_paths import (  # noqa: E402
     free_claims_path,
     get_active_profile_id,
     personal_backup_dir,
-    personal_dir,
-    personal_path,
     profile_root,
     runs_dir,
     set_request_profile_id,
     sponsors_path,
+)
+from shared.server_personal import (  # noqa: E402
+    BAKLOG_ALLOW_EMPTY_HEADER as _BAKLOG_ALLOW_EMPTY_HEADER,
+)
+from shared.server_personal import (  # noqa: E402
+    PERSONAL_MAX_BYTES,
+    PersonalCorruptError,
+    PersonalEmptyOverwriteError,
+)
+from shared.server_personal import (  # noqa: E402
+    load_personal_doc as _load_personal_doc,
+)
+from shared.server_personal import (  # noqa: E402
+    save_personal_doc as _save_personal_doc,
 )
 from shared.server_static import (  # noqa: E402
     LIBRARY_JSON_RE as _LIBRARY_JSON_RE,
@@ -234,14 +246,6 @@ from shared.server_static import (  # noqa: E402
 )
 from shared.server_static import (  # noqa: E402
     static_class as _static_class_impl,
-)
-from shared.server_personal import (  # noqa: E402
-    BAKLOG_ALLOW_EMPTY_HEADER as _BAKLOG_ALLOW_EMPTY_HEADER,
-    PERSONAL_MAX_BYTES,
-    PersonalCorruptError,
-    PersonalEmptyOverwriteError,
-    load_personal_doc as _load_personal_doc,
-    save_personal_doc as _save_personal_doc,
 )
 from shared.subprocess_guard import _max_run_seconds_from_env, popen_fetcher  # noqa: E402, F401 — re-exported for tests
 

--- a/shared/install_visibility.py
+++ b/shared/install_visibility.py
@@ -63,10 +63,31 @@ def arp_version_mismatch(current_version: str, arp_version: str | None) -> bool:
     return normalize_version_tag(arp_version) != normalize_version_tag(current_version)
 
 
+def install_trust_fields() -> dict[str, Any]:
+    """Unsigned-beta trust notes for frozen builds (no code signing yet)."""
+    if not is_frozen():
+        return {}
+    fields: dict[str, Any] = {"unsigned_beta": True}
+    if sys.platform == "win32":
+        fields["trust_note"] = (
+            "Unsigned beta: SmartScreen may warn on first launch — More info, then Run anyway. "
+            "In-app zip updates do not refresh Add/Remove Programs; re-run Setup when you want ARP to match."
+        )
+    elif sys.platform == "darwin":
+        fields["trust_note"] = (
+            "Unsigned beta: Gatekeeper may block after in-app update — right-click Open once, "
+            "or run: xattr -cr /path/to/BAKLOG.app (or the BAKLOG folder) in Terminal."
+        )
+    else:
+        fields["trust_note"] = "Unsigned beta build — verify downloads from GitHub Releases only."
+    return fields
+
+
 def install_visibility_fields(current_version: str) -> dict[str, Any]:
     arp = read_arp_display_version()
     return {
         "install_source": detect_install_source(),
         "arp_version": arp,
         "arp_version_mismatch": arp_version_mismatch(current_version, arp),
+        **install_trust_fields(),
     }

--- a/shared/server_personal.py
+++ b/shared/server_personal.py
@@ -1,0 +1,207 @@
+"""Personal doc load/save (personal.json) — extracted from server.py."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+import time
+from typing import Any
+
+from shared.profile_paths import personal_backup_dir, personal_dir, personal_path
+
+PERSONAL_BACKUP_KEEP = 10
+PERSONAL_MAX_BYTES = 32 * 1024 * 1024  # 32 MB hard cap on the PUT body
+
+_personal_lock = threading.RLock()
+_personal_last_backup_at = 0.0
+
+BAKLOG_ALLOW_EMPTY_HEADER = "X-BAKLOG-Allow-Empty"
+
+
+class PersonalCorruptError(RuntimeError):
+    """personal.json is unreadable and no backup could be restored."""
+
+
+class PersonalEmptyOverwriteError(RuntimeError):
+    """Refusing to replace a populated personal doc with a fully empty payload."""
+
+
+def _empty_personal_doc() -> dict[str, Any]:
+    return {
+        "personal": {},
+        "prefs": {},
+        "manual": [],
+        "libraryFirstSeen": {},
+        "updated_at": None,
+        "schema_version": 1,
+    }
+
+
+def _personal_doc_is_meaningful(doc: dict[str, Any]) -> bool:
+    """True when the stored doc carries personal edits, manual games, or first-seen stamps."""
+    personal = doc.get("personal")
+    if isinstance(personal, dict):
+        if any(k != "__migrated_v3" for k in personal):
+            return True
+    manual = doc.get("manual")
+    if isinstance(manual, list) and manual:
+        return True
+    library_first_seen = doc.get("libraryFirstSeen")
+    if isinstance(library_first_seen, dict) and library_first_seen:
+        return True
+    return False
+
+
+def _personal_payload_is_empty(validated: dict[str, Any]) -> bool:
+    """True when the incoming payload has no personal/manual/first-seen data."""
+    personal = validated.get("personal") or {}
+    if not isinstance(personal, dict):
+        return True
+    if any(k != "__migrated_v3" for k in personal):
+        return False
+    manual = validated.get("manual") or []
+    if isinstance(manual, list) and manual:
+        return False
+    library_first_seen = validated.get("libraryFirstSeen") or {}
+    if isinstance(library_first_seen, dict) and library_first_seen:
+        return False
+    return True
+
+
+def _normalize_personal_doc(doc: dict[str, Any]) -> dict[str, Any]:
+    doc.setdefault("personal", {})
+    doc.setdefault("prefs", {})
+    doc.setdefault("manual", [])
+    doc.setdefault("libraryFirstSeen", {})
+    doc.setdefault("updated_at", None)
+    doc.setdefault("schema_version", 1)
+    return doc
+
+
+def _restore_personal_from_backup() -> dict[str, Any] | None:
+    backup_dir = personal_backup_dir()
+    if not backup_dir.is_dir():
+        return None
+    backups = sorted(backup_dir.glob("personal-*.json"), reverse=True)
+    for backup in backups:
+        try:
+            with backup.open("r", encoding="utf-8") as f:
+                doc = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(doc, dict):
+            return _normalize_personal_doc(doc)
+    return None
+
+
+def load_personal_doc() -> dict[str, Any]:
+    with _personal_lock:
+        path = personal_path()
+        if not path.exists():
+            return _empty_personal_doc()
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                doc = json.load(f)
+        except (OSError, json.JSONDecodeError) as exc:
+            restored = _restore_personal_from_backup()
+            if restored is not None:
+                print(
+                    f"[personal] primary file corrupt ({exc!r}); serving newest backup",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                return restored
+            raise PersonalCorruptError(
+                f"personal data at {path} is corrupt and no backup could be read"
+            ) from exc
+        if not isinstance(doc, dict):
+            raise PersonalCorruptError(f"personal data at {path} is not a JSON object")
+        return _normalize_personal_doc(doc)
+
+
+def _validate_personal_payload(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ValueError("payload must be a JSON object")
+    personal = payload.get("personal", {})
+    prefs = payload.get("prefs", {})
+    manual = payload.get("manual", [])
+    library_first_seen = payload.get("libraryFirstSeen", {})
+    if not isinstance(personal, dict):
+        raise ValueError("personal must be an object")
+    if not isinstance(prefs, dict):
+        raise ValueError("prefs must be an object")
+    if not isinstance(manual, list):
+        raise ValueError("manual must be an array")
+    if not isinstance(library_first_seen, dict):
+        raise ValueError("libraryFirstSeen must be an object")
+    return {
+        "personal": personal,
+        "prefs": prefs,
+        "manual": manual,
+        "libraryFirstSeen": library_first_seen,
+    }
+
+
+def _rotate_personal_backup() -> None:
+    """Keep a rolling set of timestamped backups so a bad save can't wipe edits."""
+    global _personal_last_backup_at
+    now = time.time()
+    if now - _personal_last_backup_at < 300:
+        return
+    path = personal_path()
+    if not path.exists():
+        return
+    backup_dir = personal_backup_dir()
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    stamp = time.strftime("%Y%m%d-%H%M%S", time.localtime(now))
+    backup = backup_dir / f"personal-{stamp}.json"
+    try:
+        backup.write_bytes(path.read_bytes())
+    except OSError as exc:
+        print(f"[personal] backup failed: {exc!r}", file=sys.stderr)
+        return
+    _personal_last_backup_at = now
+    backups = sorted(backup_dir.glob("personal-*.json"))
+    for old in backups[:-PERSONAL_BACKUP_KEEP]:
+        try:
+            old.unlink()
+        except OSError:
+            pass
+
+
+def _rebind_after_save() -> None:
+    """Refresh server module paths after personal.json write (profile switch tests)."""
+    import server as mod
+
+    mod._refresh_personal_paths()
+
+
+def save_personal_doc(payload: dict[str, Any], *, allow_empty: bool = False) -> dict[str, Any]:
+    """Atomic write: temp file + os.replace(). Never partial; never corrupted."""
+    with _personal_lock:
+        validated = _validate_personal_payload(payload)
+        if not allow_empty and _personal_payload_is_empty(validated):
+            existing = load_personal_doc()
+            if _personal_doc_is_meaningful(existing):
+                path = personal_path()
+                print(
+                    f"[personal] refusing empty overwrite of populated doc at {path}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                raise PersonalEmptyOverwriteError("refusing empty overwrite")
+        doc = _empty_personal_doc()
+        doc.update(validated)
+        doc["updated_at"] = time.time()
+        pdir = personal_dir()
+        pdir.mkdir(parents=True, exist_ok=True)
+        path = personal_path()
+        _rotate_personal_backup()
+        tmp = path.with_suffix(".json.tmp")
+        with tmp.open("w", encoding="utf-8") as f:
+            json.dump(doc, f, ensure_ascii=False, indent=2)
+        os.replace(tmp, path)
+        _rebind_after_save()
+        return doc

--- a/shared/server_support.py
+++ b/shared/server_support.py
@@ -187,6 +187,7 @@ def build_update_check_payload(
     current_version: str,
     *,
     fetchers_in_flight: bool = False,
+    sign_in_active: bool = False,
 ) -> dict[str, Any]:
     from shared.install_paths import runtime_label
     from shared.install_visibility import install_visibility_fields
@@ -218,6 +219,7 @@ def build_update_check_payload(
         "release_notes": None,
         "published_at": None,
         "fetchers_in_flight": fetchers_in_flight,
+        "sign_in_active": sign_in_active,
         **install_visibility_fields(current_version),
     }
     try:

--- a/shared/update_api.py
+++ b/shared/update_api.py
@@ -95,11 +95,13 @@ def handle_update_support_get(
         send_json(HTTPStatus.OK, {"ok": True, "result": mgr.apply_result_dict()})
         return True
     if path == "/api/update-check":
+        sign_in_active = has_active_sessions() if has_active_sessions else False
         send_json(
             HTTPStatus.OK,
             build_update_check_payload(
                 current_version(),
                 fetchers_in_flight=has_in_flight_runs(),
+                sign_in_active=sign_in_active,
             ),
         )
         return True

--- a/tests/test_install_visibility.py
+++ b/tests/test_install_visibility.py
@@ -55,14 +55,25 @@ def test_read_arp_display_version_non_windows() -> None:
 
 
 def test_install_visibility_fields_includes_keys() -> None:
-    with patch("shared.install_visibility.detect_install_source", return_value="zip"):
-        with patch("shared.install_visibility.read_arp_display_version", return_value=None):
-            fields = install_visibility_fields("1.0.0")
+    with patch("shared.install_visibility.is_frozen", return_value=False):
+        with patch("shared.install_visibility.detect_install_source", return_value="zip"):
+            with patch("shared.install_visibility.read_arp_display_version", return_value=None):
+                fields = install_visibility_fields("1.0.0")
     assert fields == {
         "install_source": "zip",
         "arp_version": None,
         "arp_version_mismatch": False,
     }
+
+
+def test_install_trust_fields_when_frozen() -> None:
+    with patch("shared.install_visibility.is_frozen", return_value=True):
+        with patch("shared.install_visibility.sys.platform", "win32"):
+            with patch("shared.install_visibility.detect_install_source", return_value="zip"):
+                with patch("shared.install_visibility.read_arp_display_version", return_value=None):
+                    fields = install_visibility_fields("0.8.27")
+    assert fields["unsigned_beta"] is True
+    assert "SmartScreen" in fields["trust_note"]
 
 
 def test_build_diagnostics_payload_includes_install_visibility() -> None:

--- a/tests/test_packaging_manifest.py
+++ b/tests/test_packaging_manifest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -62,7 +63,11 @@ def _spec_resolved_hiddenimports() -> set[str]:
         "shared.built_frontend",
         "shared.legacy_env",
         "shared.uninstall_cleanup",
-        "keyring.backends.Windows",
+        (
+            "keyring.backends.macOS"
+            if sys.platform == "darwin"
+            else "keyring.backends.Windows"
+        ),
         "cryptography.hazmat.primitives.ciphers.aead",
     }
     return out
@@ -153,6 +158,20 @@ def test_build_script_ships_uninstall_bat() -> None:
     text = (ROOT / "packaging" / "build_windows.ps1").read_text(encoding="utf-8")
     assert "Uninstall BAKLOG.bat" in text
     assert (ROOT / "packaging" / "Uninstall BAKLOG.bat").is_file()
+
+
+def test_build_macos_script_exists() -> None:
+    script = ROOT / "packaging" / "build_macos.sh"
+    assert script.is_file()
+    text = script.read_text(encoding="utf-8")
+    assert "BAKLOG-macos.zip" in text
+    assert "apply_update.sh" in text
+
+
+def test_release_workflow_includes_macos_job() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    assert "build-macos:" in workflow
+    assert "BAKLOG-macos.zip" in workflow
 
 
 def test_build_script_generates_assets_before_pyinstaller() -> None:

--- a/tests/test_server_support_update.py
+++ b/tests/test_server_support_update.py
@@ -90,3 +90,10 @@ def test_build_update_check_payload_soft_failure() -> None:
         payload = build_update_check_payload("1.0.0")
     assert payload["update_available"] is False
     assert payload["error"] == "offline"
+
+
+def test_build_update_check_payload_sign_in_active() -> None:
+    with patch("shared.server_support.fetch_latest_github_release", side_effect=RuntimeError("offline")):
+        payload = build_update_check_payload("1.0.0", sign_in_active=True)
+    assert payload["sign_in_active"] is True
+    assert payload["fetchers_in_flight"] is False

--- a/tests/update-check.test.js
+++ b/tests/update-check.test.js
@@ -115,6 +115,14 @@ describe('renderApplyBlockedHint', () => {
   it('returns empty string when apply is supported', () => {
     expect(renderApplyBlockedHint({ applySupported: true })).toBe('');
   });
+
+  it('shows sign-in hint when sign-in window is active', () => {
+    const html = renderApplyBlockedHint({
+      applySupported: true,
+      signInActive: true,
+    });
+    expect(html).toContain('sign-in window');
+  });
 });
 
 describe('isUpdateBannerDismissed', () => {


### PR DESCRIPTION
## Summary
- macOS release pipeline: build_macos.sh + release.yml build-macos job
- Unsigned-beta trust notes in diagnostics and guides (no code signing)
- sign_in_active on /api/update-check + update banner UI gate
- shared/server_personal.py extract; apply_update.sh without python3
- Runner module-size CI budget (2200 lines)

## Test plan
- [x] pytest 1561 passed locally
- [x] vitest 1591 passed locally
- [x] check-module-size.mjs OK
- [ ] CI green on PR
- [ ] Tag v0.8.27 after merge

Made with [Cursor](https://cursor.com)