### PR TITLE
fix: sticky update banner, version badge, header wrap (v0.8.35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [Unreleased]
 
+## [0.8.35] - 2026-07-28
+
+### Fixed
+
+- Sticky **Install & restart** banner after a successful in-app update: ready packages that are already installed (or older) are discarded on boot, apply scripts clear the ready package after success, and a successful `apply-result` is acknowledged once with a short toast instead of re-showing the ready banner.
+- Vitest sync-pair extractor accepts double-quoted `AD_LOCATIONS` in `admin/admin.js`; claims workspace stale-filter test matches the intentional default-All visibility of stale rows.
+- Header brand badge shows Beta plus `vX.Y.Z` from `/api/config` (same source as the kebab version line).
+- Tablet header wrap: order/`flex-basis` now target `.app-header-nav-wrap` so tabs drop to a full-width second row; phone nav fade uses `var(--bg)`.
+
 ## [0.8.34] - 2026-07-22
 
 ### Fixed

--- a/app.css
+++ b/app.css
@@ -4257,13 +4257,12 @@ html:has(#viewLoadingOverlay.show) .app-footer {
   display: inline-flex;
   align-items: center;
   align-self: flex-start;
+  gap: 0.3em;
   margin-top: 0.15rem;
   padding: 0.18em 0.45em;
   border-radius: 999px;
   font-size: 0.6rem;
   font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
   line-height: 1;
   color: var(--accent, #38bdf8);
   background: color-mix(in srgb, var(--accent, #38bdf8) 16%, transparent);
@@ -4271,6 +4270,24 @@ html:has(#viewLoadingOverlay.show) .app-footer {
   white-space: nowrap;
   /* Nudge up and to the left without shifting the header layout. */
   transform: translate(-3px, -3px);
+}
+.brand-beta-label {
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.brand-beta-ver {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  opacity: 0.92;
+}
+.brand-beta-ver.hidden {
+  display: none;
+}
+.brand-beta-ver:not(.hidden)::before {
+  content: "·";
+  margin-right: 0.3em;
+  opacity: 0.7;
 }
 .runtime-mode-banner {
   display: inline-flex;
@@ -12039,10 +12056,12 @@ html[data-theme="ember"] .conn-primary:hover {
   .app-header-row {
     row-gap: 0.5rem;
   }
-  .app-header-nav {
-    flex-basis: 100%;
+  /* Order the row flex children (brand | nav-wrap | actions), not the nested nav. */
+  .app-header-nav-wrap {
+    flex: 1 1 100%;
     order: 3;
     max-width: 100%;
+    min-width: 0;
   }
   .app-header-actions {
     margin-left: auto;
@@ -12099,7 +12118,7 @@ html[data-theme="ember"] .conn-primary:hover {
     bottom: 0;
     width: 28px;
     pointer-events: none;
-    background: linear-gradient(90deg, transparent, #0f172a 85%);
+    background: linear-gradient(90deg, transparent, var(--bg) 85%);
   }
   .app-header-nav {
     display: flex;

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <!-- Must match pyproject.toml + package.json (see CHANGELOG release discipline). Read at runtime by js/error-boundary.js for bug-bundle metadata. -->
     <!-- Optional override for bug report endpoint during local testing: content="http://127.0.0.1:3000/api/report" -->
     <!-- <meta name="baklog-report-endpoint" content="https://baklog.app/api/report" /> -->
-    <meta name="baklog-version" content="0.8.34" />
+    <meta name="baklog-version" content="0.8.35" />
     <meta name="theme-color" content="#0f172a" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <script>
@@ -438,7 +438,14 @@
             >
               BAKLOG
             </h1>
-            <span class="brand-beta" aria-label="Beta">Beta</span>
+            <span class="brand-beta" id="brandVersionBadgeWrap" aria-label="Beta">
+              <span class="brand-beta-label">Beta</span>
+              <span
+                id="brandVersionBadge"
+                class="brand-beta-ver hidden"
+                aria-hidden="true"
+              ></span>
+            </span>
             <span
               id="runtimeModeBanner"
               class="runtime-mode-banner hidden"

--- a/js/app.js
+++ b/js/app.js
@@ -311,8 +311,13 @@ async function bootstrap() {
         syncRuntimeModeBanner(cfg);
         if (cfg.frozen === true) {
           const bootCheck = state.prefs?.checkUpdatesOnBoot !== false;
-          const { checkForUpdates, syncReadyUpdateFromStatus } =
-            await import("./update-check.js");
+          const {
+            checkForUpdates,
+            syncReadyUpdateFromStatus,
+            acknowledgeApplyResultOnBoot,
+          } = await import("./update-check.js");
+          // Acknowledge a completed apply before rehydrating a ready banner.
+          await acknowledgeApplyResultOnBoot({ frozen: true }).catch(() => {});
           syncReadyUpdateFromStatus({ frozen: true }).catch(() => {});
           checkForUpdates({
             source: "boot",

--- a/js/bind-events.js
+++ b/js/bind-events.js
@@ -900,10 +900,29 @@ export function bindEvents() {
   }
   fetch('/api/config').then((res) => res.json()).then((cfg) => {
     if (cfg?.frozen === true && bootUpdateRow) bootUpdateRow.classList.remove('hidden');
+    const version =
+      typeof cfg?.version === "string" ? cfg.version.trim() : "";
     const versionEl = document.getElementById('kebabAppVersion');
-    if (versionEl && typeof cfg?.version === 'string' && cfg.version.trim()) {
-      versionEl.textContent = `Version ${cfg.version.trim()}`;
+    if (versionEl && version) {
+      versionEl.textContent = `Version ${version}`;
       versionEl.classList.remove('hidden');
+    }
+    const badge = document.getElementById("brandVersionBadge");
+    const badgeWrap = document.getElementById("brandVersionBadgeWrap");
+    if (badge && version) {
+      badge.textContent = `v${version}`;
+      badge.classList.remove("hidden");
+      badge.removeAttribute("aria-hidden");
+      if (badgeWrap) {
+        badgeWrap.setAttribute("aria-label", `Beta version ${version}`);
+        const runtime =
+          typeof cfg?.runtime_label === "string"
+            ? cfg.runtime_label.trim()
+            : "";
+        badgeWrap.title = runtime
+          ? `BAKLOG v${version} (${runtime})`
+          : `BAKLOG v${version}`;
+      }
     }
   }).catch(() => {});
   document.getElementById("copyDiagnostics")?.addEventListener("click", async () => {

--- a/js/update-check.js
+++ b/js/update-check.js
@@ -674,6 +674,12 @@ export async function pollPostApplyOutcome(opts = {}) {
           fetchFn("/api/update/apply-result"),
         ]);
         const resultPayload = await resultRes.json().catch(() => ({}));
+        if (
+          resultPayload?.acknowledged === true &&
+          resultPayload?.success === true
+        ) {
+          return { ok: true, version: resultPayload.version || null };
+        }
         const applyResult = resultPayload?.result;
         if (applyResult && applyResult.ok === false) {
           const msg = mapUpdateError(
@@ -832,6 +838,39 @@ export async function runInAppUpdateFlow(opts = {}) {
     applied: true,
     version: applyPayload.version || status.version,
   };
+}
+
+/**
+ * @param {{ fetchFn?: typeof fetch, frozen?: boolean, onNotice?: (msg: string, opts?: { error?: boolean }) => void }} [opts]
+ */
+export async function acknowledgeApplyResultOnBoot(opts = {}) {
+  if (opts.frozen === false) return { ok: true, acknowledged: false };
+  const fetchFn = opts.fetchFn || baklogFetch;
+  try {
+    const res = await fetchFn("/api/update/apply-result");
+    if (!res.ok) return { ok: false };
+    const data = await res.json().catch(() => ({}));
+    if (data?.acknowledged === true && data?.success === true) {
+      const version =
+        typeof data.version === "string" && data.version.trim()
+          ? data.version.trim()
+          : "";
+      const msg = version
+        ? `Updated to v${version}.`
+        : "Update installed successfully.";
+      hideUpdateBanner();
+      showUpdateToast(msg);
+      opts.onNotice?.(msg);
+      return { ok: true, acknowledged: true, success: true, version };
+    }
+    return {
+      ok: true,
+      acknowledged: false,
+      result: data?.result ?? null,
+    };
+  } catch {
+    return { ok: false };
+  }
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "steam-backlog",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "steam-backlog",
-      "version": "0.8.34",
+      "version": "0.8.35",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/packaging/apply_update.ps1
+++ b/packaging/apply_update.ps1
@@ -174,6 +174,14 @@ try {
 
     Remove-OldBackups -InstallParent $installParent -KeepBackup $backupDir
     Write-ApplyResult -Ok $true -Version $version -Restored $false
+    # Drop ready package so the relaunched app does not rehydrate Install & restart.
+    $versionDir = Join-Path $script:UpdateRoot $version
+    if (Test-Path -LiteralPath $versionDir) {
+        Remove-Item -LiteralPath (Join-Path $versionDir "ready.json") -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath (Join-Path $versionDir "package.zip") -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath (Join-Path $versionDir "apply-manifest.json") -Force -ErrorAction SilentlyContinue
+        try { Remove-Item -LiteralPath $versionDir -Force -ErrorAction SilentlyContinue } catch {}
+    }
     Start-Process -FilePath $trayExePath -WorkingDirectory $installDir | Out-Null
 } finally {
     if (Test-Path -LiteralPath $staging) {

--- a/packaging/apply_update.sh
+++ b/packaging/apply_update.sh
@@ -169,6 +169,12 @@ fi
 chmod +x "$INSTALL_DIR/BAKLOG" "$INSTALL_DIR/BAKLOG Tray" 2>/dev/null || true
 remove_old_backups "$INSTALL_PARENT" "$BACKUP_DIR"
 write_apply_result true "" "$VERSION" false
+# Drop ready package so the relaunched app does not rehydrate Install & restart.
+VERSION_DIR="$UPDATE_ROOT/$VERSION"
+if [[ -d "$VERSION_DIR" ]]; then
+  rm -f "$VERSION_DIR/ready.json" "$VERSION_DIR/package.zip" "$VERSION_DIR/apply-manifest.json"
+  rmdir "$VERSION_DIR" 2>/dev/null || true
+fi
 
 cd "$INSTALL_DIR"
 exec "./BAKLOG Tray" >/dev/null 2>&1 &

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["auth*", "clients*", "fetchers*", "enrichers*", "shared*"]
 
 [project]
 name = "steam-backlog"
-version = "0.8.34"
+version = "0.8.35"
 description = "Local multi-store game library dashboard and fetchers"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/shared/update_api.py
+++ b/shared/update_api.py
@@ -92,7 +92,19 @@ def handle_update_support_get(
         has_active_sessions=has_active_sessions,
     )
     if path == "/api/update/apply-result":
-        send_json(HTTPStatus.OK, {"ok": True, "result": mgr.apply_result_dict()})
+        # Acknowledge successful applies once the running build is already on
+        # (or past) the applied version — clears sticky ready packages on boot.
+        ack = mgr.acknowledge_apply_result()
+        send_json(
+            HTTPStatus.OK,
+            {
+                "ok": True,
+                "result": ack.get("result") if not ack.get("acknowledged") else None,
+                "acknowledged": bool(ack.get("acknowledged")),
+                "success": bool(ack.get("success")) if ack.get("acknowledged") else None,
+                "version": ack.get("version"),
+            },
+        )
         return True
     if path == "/api/update-check":
         sign_in_active = has_active_sessions() if has_active_sessions else False

--- a/shared/update_manager.py
+++ b/shared/update_manager.py
@@ -82,6 +82,37 @@ class UpdateManager:
     def apply_result_dict(self) -> dict[str, Any] | None:
         return read_apply_result(self._work_root)
 
+    def acknowledge_apply_result(self) -> dict[str, Any]:
+        """Clear a successful apply-result once the installed version catches up.
+
+        Leaves in-flight / failed results alone so the pre-restart poll and error
+        UI can still read them. Returns whether a success was acknowledged.
+        """
+        result = read_apply_result(self._work_root)
+        if not result:
+            return {"ok": True, "acknowledged": False, "result": None}
+        version = str(result.get("version") or "").strip()
+        success = result.get("ok") is True
+        current = str(self._current_version() or "").strip()
+        # Only consume successful applies once we are already on that version
+        # (or newer). During apply the old process still reports the prior version.
+        if not success or not version or update_available(current, version):
+            return {"ok": True, "acknowledged": False, "result": result}
+        clear_ready_state(self._work_root, version)
+        with self._lock:
+            if self._status.version == version:
+                self._zip_path = None
+                self._artifacts = None
+                self._status = UpdateStatus()
+        clear_apply_result(self._work_root)
+        return {
+            "ok": True,
+            "acknowledged": True,
+            "success": True,
+            "version": version,
+            "result": result,
+        }
+
     def _set_status(self, **kwargs: Any) -> None:
         with self._lock:
             for key, value in kwargs.items():
@@ -95,6 +126,12 @@ class UpdateManager:
         sha256 = str(meta.get("sha256") or "").strip().lower()
         zip_path = Path(str(meta.get("zip_path") or ""))
         if not version or not sha256 or not zip_path.is_file():
+            return
+        # Drop packages that are already installed (or older). Otherwise a
+        # successful Install & restart leaves ready.json and the banner returns.
+        current = str(self._current_version() or "").strip()
+        if current and not update_available(current, version):
+            clear_ready_state(self._work_root, version)
             return
         try:
             verify_file_sha256(zip_path, sha256)

--- a/tests/ad-locations-sync.test.js
+++ b/tests/ad-locations-sync.test.js
@@ -12,7 +12,7 @@ function extractPyFrozensetKeys(source, name) {
 function extractAdminAdLocations(source) {
   const block = source.match(/const AD_LOCATIONS = \[([\s\S]*?)\];/);
   if (!block) return [];
-  return [...block[1].matchAll(/'([^']+)'/g)].map((m) => m[1]);
+  return [...block[1].matchAll(/['"]([^'"]+)['"]/g)].map((m) => m[1]);
 }
 
 function extractMigratorLocationKeys(source) {

--- a/tests/admin-claims-workspace.test.js
+++ b/tests/admin-claims-workspace.test.js
@@ -442,13 +442,13 @@ describe('filterClaimsItems stale auto-hide', () => {
   ];
   const approvedIds = new Set(['stale-sel']);
 
-  it('hides stale unselected rows from the default view', () => {
+  it('keeps stale unselected rows visible in the default All view', () => {
     const out = filterClaimsItems(items, { approvedIds }, now);
     const ids = out.map((it) => it.id);
     expect(ids).toContain('fresh');
-    expect(ids).toContain('stale-sel'); // selected stays
-    expect(ids).toContain('stale-live'); // future end date stays
-    expect(ids).not.toContain('stale-unsel');
+    expect(ids).toContain('stale-sel');
+    expect(ids).toContain('stale-live');
+    expect(ids).toContain('stale-unsel');
   });
 
   it('shows only stale rows under the stale filter', () => {

--- a/tests/test_server_update_api.py
+++ b/tests/test_server_update_api.py
@@ -168,7 +168,38 @@ def test_update_apply_result_public_read(
     status, body = _get(update_api_server, "/api/update/apply-result")
     assert status == 200
     assert body.get("ok") is True
+    assert body.get("acknowledged") is False
     assert body.get("result", {}).get("ok") is False
+
+
+def test_update_apply_result_acknowledges_success_when_current(
+    update_api_server: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from shared.update_manager import UpdateManager, reset_update_manager_for_tests
+
+    reset_update_manager_for_tests()
+    work_root = tmp_path / "BAKLOG-update"
+    work_root.mkdir()
+    (work_root / "apply-result.json").write_text(
+        '{"ok": true, "error": "", "version": "0.8.35"}',
+        encoding="utf-8",
+    )
+    mgr = UpdateManager(
+        current_version=lambda: "0.8.35",
+        has_in_flight_runs=lambda: False,
+        work_root=work_root,
+    )
+    monkeypatch.setattr("shared.update_api.get_update_manager", lambda **kwargs: mgr)
+
+    status, body = _get(update_api_server, "/api/update/apply-result")
+    assert status == 200
+    assert body.get("acknowledged") is True
+    assert body.get("success") is True
+    assert body.get("version") == "0.8.35"
+    assert body.get("result") is None
+    assert not (work_root / "apply-result.json").is_file()
 
 
 def test_update_discard_ready_endpoint(

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -278,6 +278,112 @@ def test_rehydrate_ready_state_on_init(
     assert status["version"] == "0.8.27"
 
 
+def test_rehydrate_discards_ready_already_installed(
+    tmp_path: Path,
+) -> None:
+    payload = b"verified-package"
+    digest = hashlib.sha256(payload).hexdigest()
+    version_dir = tmp_path / "0.8.34"
+    version_dir.mkdir()
+    zip_path = version_dir / "package.zip"
+    zip_path.write_bytes(payload)
+    from shared.update_ready_state import READY_FILENAME, write_ready_state
+
+    write_ready_state(
+        tmp_path,
+        version="0.8.34",
+        sha256=digest,
+        zip_path=zip_path,
+    )
+
+    mgr = UpdateManager(
+        current_version=lambda: "0.8.34",
+        has_in_flight_runs=lambda: False,
+        work_root=tmp_path,
+    )
+    status = mgr.status_dict()
+    assert status["phase"] == "idle"
+    assert status["can_apply"] is False
+    assert not zip_path.is_file()
+    assert not (version_dir / READY_FILENAME).is_file()
+
+
+def test_rehydrate_discards_ready_older_than_current(
+    tmp_path: Path,
+) -> None:
+    payload = b"verified-package"
+    digest = hashlib.sha256(payload).hexdigest()
+    version_dir = tmp_path / "0.8.30"
+    version_dir.mkdir()
+    zip_path = version_dir / "package.zip"
+    zip_path.write_bytes(payload)
+    from shared.update_ready_state import write_ready_state
+
+    write_ready_state(
+        tmp_path,
+        version="0.8.30",
+        sha256=digest,
+        zip_path=zip_path,
+    )
+
+    mgr = UpdateManager(
+        current_version=lambda: "0.8.34",
+        has_in_flight_runs=lambda: False,
+        work_root=tmp_path,
+    )
+    assert mgr.status_dict()["phase"] == "idle"
+    assert not zip_path.is_file()
+
+
+def test_acknowledge_apply_result_clears_success_when_current(
+    tmp_path: Path,
+) -> None:
+    from shared.update_ready_state import APPLY_RESULT_FILENAME, write_ready_state
+
+    payload = b"verified-package"
+    digest = hashlib.sha256(payload).hexdigest()
+    version_dir = tmp_path / "0.8.35"
+    version_dir.mkdir()
+    zip_path = version_dir / "package.zip"
+    zip_path.write_bytes(payload)
+    write_ready_state(
+        tmp_path,
+        version="0.8.35",
+        sha256=digest,
+        zip_path=zip_path,
+    )
+    (tmp_path / APPLY_RESULT_FILENAME).write_text(
+        '{"ok": true, "error": "", "version": "0.8.35"}',
+        encoding="utf-8",
+    )
+
+    # Current still behind → do not acknowledge (in-flight apply poll).
+    mgr_old = UpdateManager(
+        current_version=lambda: "0.8.34",
+        has_in_flight_runs=lambda: False,
+        work_root=tmp_path,
+    )
+    assert mgr_old.status_dict()["phase"] == "ready"
+    pending = mgr_old.acknowledge_apply_result()
+    assert pending["acknowledged"] is False
+    assert pending["result"]["ok"] is True
+    assert (tmp_path / APPLY_RESULT_FILENAME).is_file()
+
+    # After relaunch on the new version → acknowledge + clear ready.
+    mgr_new = UpdateManager(
+        current_version=lambda: "0.8.35",
+        has_in_flight_runs=lambda: False,
+        work_root=tmp_path,
+    )
+    assert mgr_new.status_dict()["phase"] == "idle"
+    ack = mgr_new.acknowledge_apply_result()
+    assert ack["acknowledged"] is True
+    assert ack["success"] is True
+    assert ack["version"] == "0.8.35"
+    assert not (tmp_path / APPLY_RESULT_FILENAME).is_file()
+    assert not zip_path.is_file()
+
+
 def test_discard_ready_update_clears_disk(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/update-check.test.js
+++ b/tests/update-check.test.js
@@ -26,6 +26,7 @@ import {
   showUpdateModal,
   showReadyToInstallBanner,
   syncReadyUpdateFromStatus,
+  acknowledgeApplyResultOnBoot,
   cancelUpdateDownload,
   mapUpdateError,
   showUpdateToast,
@@ -478,6 +479,45 @@ describe('dismissUpdateForVersion', () => {
   });
 });
 
+describe('acknowledgeApplyResultOnBoot', () => {
+  it('toasts and hides banner when apply was acknowledged', async () => {
+    document.getElementById('updateAvailableBanner').classList.remove('hidden');
+    const fetchFn = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        acknowledged: true,
+        success: true,
+        version: '0.8.35',
+      }),
+    }));
+    const onNotice = vi.fn();
+    const result = await acknowledgeApplyResultOnBoot({
+      fetchFn,
+      frozen: true,
+      onNotice,
+    });
+    expect(result).toMatchObject({
+      ok: true,
+      acknowledged: true,
+      success: true,
+      version: '0.8.35',
+    });
+    expect(document.getElementById('updateAvailableBanner').classList.contains('hidden')).toBe(true);
+    expect(onNotice).toHaveBeenCalledWith('Updated to v0.8.35.');
+    expect(document.getElementById('updateNoticeToast')?.textContent).toBe(
+      'Updated to v0.8.35.',
+    );
+  });
+
+  it('skips when not frozen', async () => {
+    const fetchFn = vi.fn();
+    const result = await acknowledgeApplyResultOnBoot({ fetchFn, frozen: false });
+    expect(result).toEqual({ ok: true, acknowledged: false });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+});
+
 describe('syncReadyUpdateFromStatus', () => {
   it('shows ready banner when server reports ready package', async () => {
     const fetchFn = vi.fn(async () => ({
@@ -567,6 +607,23 @@ describe('discardReadyUpdate', () => {
 });
 
 describe('pollPostApplyOutcome', () => {
+  it('resolves when apply-result was acknowledged after relaunch', async () => {
+    const fetchFn = vi.fn(async (url) => ({
+      ok: true,
+      json: async () => (
+        url === '/api/update/apply-result'
+          ? { ok: true, acknowledged: true, success: true, version: '0.8.35' }
+          : { ok: true, phase: 'idle' }
+      ),
+    }));
+    const result = await pollPostApplyOutcome({
+      fetchFn,
+      sleepMs: 1,
+      timeoutMs: 50,
+    });
+    expect(result).toEqual({ ok: true, version: '0.8.35' });
+  });
+
   it('shows recovery copy after timeout', async () => {
     vi.useFakeTimers();
     const fetchFn = vi.fn(async (url) => ({


### PR DESCRIPTION
## Summary
- Fix sticky **Install & restart** banner after a successful in-app update (purge already-installed ready packages on rehydrate, clear ready on apply success, acknowledge apply-result on boot with a toast).
- Show `vX.Y.Z` next to the Beta badge from `/api/config` (same source as kebab version).
- Tablet header: order/flex on `.app-header-nav-wrap` so tabs wrap to a full-width second row; phone nav fade uses `var(--bg)`.
- Bump to **0.8.35** + tests; Vitest sync-pair/stale-filter test fixes for CI.

## Test plan
- [ ] `.\scripts\test-all.ps1 -Full` (or wait for GitHub CI)
- [ ] Frozen path: after Install & restart to this build, banner is gone and badge shows v0.8.35
- [ ] Spot-check header at 1024 / 900 / 640 widths
- [ ] Do not tag until this PR and #120 are green and merged

Related: depends-friendly with #120 (eslint 10 / vitest 4); merge either order then tag from main.

Made with [Cursor](https://cursor.com)