### PR TITLE
fix: keep Connect open when Chrome launcher exits 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Fixed
 
+- Headed Connect on Windows: Chrome/Edge launcher exit code 0 no longer aborts before CDP attaches (Battle.net and other browser sign-ins were closing immediately with "Browser exited immediately (code 0)"). Wait for `/json/version`, and on exit 0 with no CDP release the profile lock and retry once.
 - Sticky **Install & restart** banner after a successful in-app update: ready packages that are already installed (or older) are discarded on boot, apply scripts clear the ready package after success, and a successful `apply-result` is acknowledged once with a short toast instead of re-showing the ready banner.
 - Vitest sync-pair extractor accepts double-quoted `AD_LOCATIONS` in `admin/admin.js`; claims workspace stale-filter test matches the intentional default-All visibility of stale rows.
 - Header brand badge shows Beta plus `vX.Y.Z` from `/api/config` (same source as the kebab version line).

--- a/auth/cdp_browser.py
+++ b/auth/cdp_browser.py
@@ -1628,17 +1628,24 @@ def launch_persistent_profile(
         )
 
         deadline = time.time() + 30
+        # On Windows the Popen handle is often a short-lived launcher that exits 0
+        # while the real Chrome/Edge child keeps CDP alive on ``port``. Do not
+        # treat exit 0 as fatal — keep polling /json/version (same rule as
+        # browser_session_gone / CdpContext.close).
+        launcher_exited_zero = False
         while time.time() < deadline:
-            if proc.poll() is not None:
-                exit_code = proc.returncode
-                # Capture any early output before the process died.
+            exit_code = proc.poll()
+            if exit_code is not None and exit_code != 0:
                 early_output = ""
                 try:
                     raw = proc.stdout.read(8192) if proc.stdout else b""
                     early_output = raw.decode("utf-8", errors="replace").strip()[:500]
                 except Exception:
                     pass
-                proc.kill()
+                try:
+                    proc.kill()
+                except Exception:
+                    pass
                 if attempt == 0 and exit_code == 21:
                     released_pids = release_chromium_profile_lock(profile)
                     break
@@ -1653,6 +1660,8 @@ def launch_persistent_profile(
                     "Install Google Chrome or Microsoft Edge, set BAKLOG_CHROME_PATH "
                     "to the browser executable, or try the other installed browser."
                 )
+            if exit_code == 0:
+                launcher_exited_zero = True
             try:
                 version = _fetch_json(f"http://127.0.0.1:{port}/json/version", timeout=2)
                 ws_url = version.get("webSocketDebuggerUrl")
@@ -1663,6 +1672,11 @@ def launch_persistent_profile(
             time.sleep(0.2)
         if ws_url:
             break
+        # Exit 0 with no CDP yet often means SingletonLock handoff (Chrome exits
+        # the second instance cleanly). Release the profile lock and relaunch once.
+        if attempt == 0 and launcher_exited_zero:
+            released_pids = release_chromium_profile_lock(profile)
+            continue
 
     if not ws_url:
         if proc is not None:
@@ -1673,7 +1687,10 @@ def launch_persistent_profile(
                 late_output = raw.decode("utf-8", errors="replace").strip()[:500]
             except Exception:
                 pass
-            proc.kill()
+            try:
+                proc.kill()
+            except Exception:
+                pass
         detail = f" (output: {late_output})" if late_output else ""
         raise _browser_launch_error(
             f"Browser did not start CDP debugging endpoint in time.{detail}"

--- a/tests/test_cdp_browser.py
+++ b/tests/test_cdp_browser.py
@@ -589,6 +589,23 @@ def test_launch_goto_title() -> None:
 class TestLaunchWaitExitZero:
     """Windows Chrome launcher often exits 0 before CDP attaches."""
 
+    @staticmethod
+    def _popen_only_fake(fake_proc_cls, real_popen):
+        """Return Popen stand-in that fakes Chrome launches only.
+
+        Patching ``subprocess.Popen`` globally breaks conftest leak detection
+        (tasklist/ps), so non-Chrome calls must use the real Popen.
+        """
+
+        def _popen(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args")
+            first = str(cmd[0]) if cmd else ""
+            if first.endswith("chrome.exe") or first.endswith("chrome"):
+                return fake_proc_cls()
+            return real_popen(*args, **kwargs)
+
+        return _popen
+
     def test_exit_zero_waits_for_cdp_then_attaches(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
@@ -598,6 +615,7 @@ class TestLaunchWaitExitZero:
         exe.write_bytes(b"")
         profile = tmp_path / "profile"
         version_hits = {"n": 0}
+        real_popen = cdp.subprocess.Popen
 
         class FakeProc:
             stdout = io.BytesIO(b"")
@@ -613,6 +631,9 @@ class TestLaunchWaitExitZero:
 
             def terminate(self) -> None:
                 return None
+
+            def communicate(self, input=None, timeout=None):  # noqa: A002
+                return (b"", b"")
 
             def __enter__(self) -> FakeProc:
                 return self
@@ -644,7 +665,11 @@ class TestLaunchWaitExitZero:
 
         monkeypatch.setattr(cdp, "find_chromium_executable", lambda: exe)
         monkeypatch.setattr(cdp, "_free_port", lambda: 9222)
-        monkeypatch.setattr(cdp.subprocess, "Popen", lambda *a, **k: FakeProc())
+        monkeypatch.setattr(
+            cdp.subprocess,
+            "Popen",
+            self._popen_only_fake(FakeProc, real_popen),
+        )
         monkeypatch.setattr(cdp, "_fetch_json", fake_fetch)
         monkeypatch.setattr(cdp.time, "sleep", lambda _s: None)
         monkeypatch.setattr(
@@ -677,6 +702,7 @@ class TestLaunchWaitExitZero:
         profile = tmp_path / "profile"
         lock_calls: list[Path] = []
         clock = {"t": 0.0}
+        real_popen = cdp.subprocess.Popen
 
         class FakeProc:
             stdout = io.BytesIO(b"")
@@ -686,6 +712,9 @@ class TestLaunchWaitExitZero:
 
             def kill(self) -> None:
                 return None
+
+            def communicate(self, input=None, timeout=None):  # noqa: A002
+                return (b"", b"")
 
             def __enter__(self) -> FakeProc:
                 return self
@@ -702,7 +731,11 @@ class TestLaunchWaitExitZero:
 
         monkeypatch.setattr(cdp, "find_chromium_executable", lambda: exe)
         monkeypatch.setattr(cdp, "_free_port", lambda: 9222)
-        monkeypatch.setattr(cdp.subprocess, "Popen", lambda *a, **k: FakeProc())
+        monkeypatch.setattr(
+            cdp.subprocess,
+            "Popen",
+            self._popen_only_fake(FakeProc, real_popen),
+        )
         monkeypatch.setattr(cdp, "_fetch_json", fake_fetch)
         monkeypatch.setattr(cdp.time, "sleep", fake_sleep)
         monkeypatch.setattr(cdp.time, "time", lambda: clock["t"])
@@ -724,6 +757,7 @@ class TestLaunchWaitExitZero:
         exe = tmp_path / "chrome.exe"
         exe.write_bytes(b"")
         profile = tmp_path / "profile"
+        real_popen = cdp.subprocess.Popen
 
         class FakeProc:
             stdout = io.BytesIO(b"boom")
@@ -734,6 +768,9 @@ class TestLaunchWaitExitZero:
             def kill(self) -> None:
                 return None
 
+            def communicate(self, input=None, timeout=None):  # noqa: A002
+                return (b"boom", b"")
+
             def __enter__(self) -> FakeProc:
                 return self
 
@@ -742,7 +779,11 @@ class TestLaunchWaitExitZero:
 
         monkeypatch.setattr(cdp, "find_chromium_executable", lambda: exe)
         monkeypatch.setattr(cdp, "_free_port", lambda: 9222)
-        monkeypatch.setattr(cdp.subprocess, "Popen", lambda *a, **k: FakeProc())
+        monkeypatch.setattr(
+            cdp.subprocess,
+            "Popen",
+            self._popen_only_fake(FakeProc, real_popen),
+        )
         monkeypatch.setattr(cdp.time, "sleep", lambda _s: None)
         monkeypatch.setattr(
             cdp,

--- a/tests/test_cdp_browser.py
+++ b/tests/test_cdp_browser.py
@@ -614,6 +614,12 @@ class TestLaunchWaitExitZero:
             def terminate(self) -> None:
                 return None
 
+            def __enter__(self) -> FakeProc:
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                return None
+
         class FakeWs:
             def recv(self) -> str:
                 raise ConnectionError("closed")
@@ -681,6 +687,12 @@ class TestLaunchWaitExitZero:
             def kill(self) -> None:
                 return None
 
+            def __enter__(self) -> FakeProc:
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                return None
+
         def fake_fetch(url: str, timeout: float = 2) -> dict:
             raise urllib.error.URLError("never")
 
@@ -720,6 +732,12 @@ class TestLaunchWaitExitZero:
                 return 1
 
             def kill(self) -> None:
+                return None
+
+            def __enter__(self) -> FakeProc:
+                return self
+
+            def __exit__(self, *args: object) -> None:
                 return None
 
         monkeypatch.setattr(cdp, "find_chromium_executable", lambda: exe)

--- a/tests/test_cdp_browser.py
+++ b/tests/test_cdp_browser.py
@@ -13,9 +13,11 @@ GitHub Actions: run the manual "CDP smoke" workflow after a suspected browser re
 
 from __future__ import annotations
 
+import io
 import os
 import sys
 import tempfile
+import urllib.error
 from pathlib import Path
 
 import pytest
@@ -582,6 +584,156 @@ def test_launch_goto_title() -> None:
         import shutil
 
         shutil.rmtree(profile, ignore_errors=True)
+
+
+class TestLaunchWaitExitZero:
+    """Windows Chrome launcher often exits 0 before CDP attaches."""
+
+    def test_exit_zero_waits_for_cdp_then_attaches(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        import auth.cdp_browser as cdp
+
+        exe = tmp_path / "chrome.exe"
+        exe.write_bytes(b"")
+        profile = tmp_path / "profile"
+        version_hits = {"n": 0}
+
+        class FakeProc:
+            stdout = io.BytesIO(b"")
+
+            def poll(self) -> int:
+                return 0
+
+            def kill(self) -> None:
+                return None
+
+            def wait(self, timeout: float | None = None) -> int:
+                return 0
+
+            def terminate(self) -> None:
+                return None
+
+        class FakeWs:
+            def recv(self) -> str:
+                raise ConnectionError("closed")
+
+            def close(self) -> None:
+                return None
+
+            def send(self, _data: str) -> None:
+                return None
+
+        def fake_fetch(url: str, timeout: float = 2) -> dict | list:
+            if "/json/version" in url:
+                version_hits["n"] += 1
+                if version_hits["n"] < 2:
+                    raise urllib.error.URLError("not ready")
+                return {
+                    "webSocketDebuggerUrl": "ws://127.0.0.1:9222/devtools/browser/x"
+                }
+            if "/json/list" in url:
+                return [{"type": "page", "id": "T1", "url": "about:blank"}]
+            return {}
+
+        monkeypatch.setattr(cdp, "find_chromium_executable", lambda: exe)
+        monkeypatch.setattr(cdp, "_free_port", lambda: 9222)
+        monkeypatch.setattr(cdp.subprocess, "Popen", lambda *a, **k: FakeProc())
+        monkeypatch.setattr(cdp, "_fetch_json", fake_fetch)
+        monkeypatch.setattr(cdp.time, "sleep", lambda _s: None)
+        monkeypatch.setattr(
+            cdp.websocket, "create_connection", lambda *a, **k: FakeWs()
+        )
+        monkeypatch.setattr(
+            cdp.CdpContext,
+            "_send",
+            lambda self, method, params=None, timeout=60: {"result": {}},
+        )
+        monkeypatch.setattr(
+            cdp.CdpContext,
+            "_attach_page",
+            lambda self, target_id: _FakePage(f"S-{target_id}"),
+        )
+        monkeypatch.setattr(cdp.CdpContext, "add_init_script", lambda self, _s: None)
+
+        ctx = launch_persistent_profile(profile, headless=False)
+        assert version_hits["n"] >= 2
+        assert len(ctx.pages) == 1
+        ctx.close = lambda: None  # type: ignore[method-assign]
+
+    def test_exit_zero_without_cdp_times_out(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        import auth.cdp_browser as cdp
+
+        exe = tmp_path / "chrome.exe"
+        exe.write_bytes(b"")
+        profile = tmp_path / "profile"
+        lock_calls: list[Path] = []
+        clock = {"t": 0.0}
+
+        class FakeProc:
+            stdout = io.BytesIO(b"")
+
+            def poll(self) -> int:
+                return 0
+
+            def kill(self) -> None:
+                return None
+
+        def fake_fetch(url: str, timeout: float = 2) -> dict:
+            raise urllib.error.URLError("never")
+
+        def fake_sleep(_s: float) -> None:
+            # Jump past the 30s CDP wait so each attempt ends quickly.
+            clock["t"] += 40.0
+
+        monkeypatch.setattr(cdp, "find_chromium_executable", lambda: exe)
+        monkeypatch.setattr(cdp, "_free_port", lambda: 9222)
+        monkeypatch.setattr(cdp.subprocess, "Popen", lambda *a, **k: FakeProc())
+        monkeypatch.setattr(cdp, "_fetch_json", fake_fetch)
+        monkeypatch.setattr(cdp.time, "sleep", fake_sleep)
+        monkeypatch.setattr(cdp.time, "time", lambda: clock["t"])
+        monkeypatch.setattr(
+            cdp,
+            "release_chromium_profile_lock",
+            lambda p: lock_calls.append(Path(p)) or [],
+        )
+
+        with pytest.raises(RuntimeError, match="did not start CDP"):
+            launch_persistent_profile(profile, headless=False)
+        assert lock_calls, "exit 0 without CDP should release profile lock and retry"
+
+    def test_nonzero_exit_still_raises_immediately(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        import auth.cdp_browser as cdp
+
+        exe = tmp_path / "chrome.exe"
+        exe.write_bytes(b"")
+        profile = tmp_path / "profile"
+
+        class FakeProc:
+            stdout = io.BytesIO(b"boom")
+
+            def poll(self) -> int:
+                return 1
+
+            def kill(self) -> None:
+                return None
+
+        monkeypatch.setattr(cdp, "find_chromium_executable", lambda: exe)
+        monkeypatch.setattr(cdp, "_free_port", lambda: 9222)
+        monkeypatch.setattr(cdp.subprocess, "Popen", lambda *a, **k: FakeProc())
+        monkeypatch.setattr(cdp.time, "sleep", lambda _s: None)
+        monkeypatch.setattr(
+            cdp,
+            "_fetch_json",
+            lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not fetch")),
+        )
+
+        with pytest.raises(RuntimeError, match="exited immediately \\(code 1\\)"):
+            launch_persistent_profile(profile, headless=False)
 
 
 class TestBrowserSessionGone:


### PR DESCRIPTION
## Summary
- Windows Chrome/Edge launcher often exits with code 0 before CDP attaches; `launch_persistent_profile` treated that as fatal and closed Battle.net (and other) Connect windows immediately.
- Wait for `/json/version` on exit 0 (same rule as teardown); if still no CDP, release profile lock and retry once.
- Unit tests for exit 0 success, timeout+retry, and non-zero immediate fail.

## Test plan
- [x] `pytest tests/test_cdp_browser.py::TestLaunchWaitExitZero` green locally
- [ ] CI green on PR
- [ ] After merge + retag v0.8.35: frozen Battle.net Connect window stays open for login
