### PR TITLE
chore: bump version to 0.8.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,13 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [Unreleased]
 
+## [0.8.36] - 2026-07-31
+
 ### Fixed
 
 - Battle.net Connect: verify the library session with an in-page `games-and-subs` fetch (real browser cookies + Origin) so arriving on the Games page completes Connect/Reconnect instead of hanging while an external probe keeps getting 401. URL-decode `XSRF-TOKEN` when probing from Python.
 - In-app update: suppress and prune expected `/api/update/status` and `/api/update/apply-result` network errors across Install & restart (sessionStorage survives the relaunch; boot clears the flag). Stops sticky "Server unreachable" entries from dominating bug bundles after a successful update.
+- Vitest forks pass `--no-experimental-webstorage` so Node 25 no longer shadows happy-dom `localStorage` (update-dismiss tests).
 
 ## [0.8.35] - 2026-07-28
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <!-- Must match pyproject.toml + package.json (see CHANGELOG release discipline). Read at runtime by js/error-boundary.js for bug-bundle metadata. -->
     <!-- Optional override for bug report endpoint during local testing: content="http://127.0.0.1:3000/api/report" -->
     <!-- <meta name="baklog-report-endpoint" content="https://baklog.app/api/report" /> -->
-    <meta name="baklog-version" content="0.8.35" />
+    <meta name="baklog-version" content="0.8.36" />
     <meta name="theme-color" content="#0f172a" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "steam-backlog",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "steam-backlog",
-      "version": "0.8.35",
+      "version": "0.8.36",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["auth*", "clients*", "fetchers*", "enrichers*", "shared*"]
 
 [project]
 name = "steam-backlog"
-version = "0.8.35"
+version = "0.8.36"
 description = "Local multi-store game library dashboard and fetchers"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` / `package.json` / `index.html` meta to **0.8.36**.
- Promote CHANGELOG Unreleased notes (Battle.net in-page connect + update NetworkError suppress/prune + vitest webstorage fix).

## Test plan
- [ ] CI green on this PR (required before tag)
- [ ] After merge: tag `v0.8.36` and confirm `release.yml` publishes assets
- [ ] Owner: frozen 0.8.35 → in-app update to 0.8.36

No tag until CI is green.