### PR TITLE
fix: Install & restart blocked by tray watchdog respawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Fixed
 
+- In-app Install & restart on Windows/macOS: stop the tray server watchdog from respawning BAKLOG while files are being replaced (`applying.lock`), launch the apply helper detached from the server process tree, and tree-kill tray/server before copying. Fixes the stuck "Installing update and restarting…" state where the UI never came back on a new build. (Re-released same version.)
 - Battle.net Connect: verify the library session with an in-page `games-and-subs` fetch (real browser cookies + Origin) so arriving on the Games page completes Connect/Reconnect instead of hanging while an external probe keeps getting 401. URL-decode `XSRF-TOKEN` when probing from Python.
 - In-app update: suppress and prune expected `/api/update/status` and `/api/update/apply-result` network errors across Install & restart (sessionStorage survives the relaunch; boot clears the flag). Stops sticky "Server unreachable" entries from dominating bug bundles after a successful update.
 - Vitest forks pass `--no-experimental-webstorage` so Node 25 no longer shadows happy-dom `localStorage` (update-dismiss tests).

--- a/packaging/apply_update.ps1
+++ b/packaging/apply_update.ps1
@@ -32,6 +32,8 @@ function Write-ApplyResult {
         finished_at = (Get-Date).ToUniversalTime().ToString("o")
     }
     $payload | ConvertTo-Json | Set-Content -LiteralPath $resultPath -Encoding UTF8
+    # Allow the tray watchdog to resume auto-restart after apply finishes.
+    Remove-Item -LiteralPath (Join-Path $script:UpdateRoot "applying.lock") -Force -ErrorAction SilentlyContinue
 }
 
 function Test-SafeChildPath([string]$Root, [string]$Relative) {
@@ -116,13 +118,15 @@ function Kill-ProcessTree([int]$ProcessId) {
     taskkill /F /T /PID $ProcessId 2>&1 | Out-Null
 }
 
+# Apply is launched detached from BAKLOG.exe. Stop the tray tree first (it owns
+# the server); waiting alone used to leave the tray watchdog free to respawn
+# BAKLOG.exe and lock install files during copy.
+Kill-ProcessTree -ProcessId $trayPid
+Kill-ProcessTree -ProcessId $serverPid
 Wait-ProcessGone -ProcessId $serverPid -TimeoutSec 45
 Wait-ProcessGone -ProcessId $trayPid -TimeoutSec 15
-
-# Ensure child processes (fetchers, CDP browser windows) are cleaned up
-# before we start moving files — otherwise they can hold file locks.
-Kill-ProcessTree -ProcessId $serverPid
 Kill-ProcessTree -ProcessId $trayPid
+Kill-ProcessTree -ProcessId $serverPid
 
 $staging = Join-Path $script:UpdateRoot ("staging-" + [Guid]::NewGuid().ToString("n"))
 New-Item -ItemType Directory -Path $staging | Out-Null
@@ -132,12 +136,13 @@ try {
     Expand-Archive -LiteralPath $zipPath -DestinationPath $staging -Force
 
     $bundleRoot = $null
-    Get-ChildItem -Path $staging -Recurse -Filter "BAKLOG.exe" -File | ForEach-Object {
-        $parent = $_.Directory.FullName
-        $trayExe = Join-Path $parent "BAKLOG Tray.exe"
-        if (Test-Path -LiteralPath $trayExe) {
-            $script:bundleRoot = $parent
-        }
+    $bundleExe = Get-ChildItem -Path $staging -Recurse -Filter "BAKLOG.exe" -File |
+        Where-Object {
+            Test-Path -LiteralPath (Join-Path $_.Directory.FullName "BAKLOG Tray.exe")
+        } |
+        Select-Object -First 1
+    if ($bundleExe) {
+        $bundleRoot = $bundleExe.Directory.FullName
     }
     if (-not $bundleRoot) {
         Fail "Extracted bundle layout invalid"

--- a/packaging/apply_update.sh
+++ b/packaging/apply_update.sh
@@ -22,6 +22,7 @@ write_apply_result() {
   "finished_at": "$finished"
 }
 EOF
+  rm -f "$UPDATE_ROOT/applying.lock"
 }
 
 fail() {
@@ -117,8 +118,30 @@ wait_pid_gone() {
   done
 }
 
+kill_pid_tree() {
+  local pid="$1"
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 0
+  [[ "$pid" -le 0 ]] && return 0
+  # Best-effort: kill descendants then the root (tray owns the server child).
+  if command -v pkill >/dev/null 2>&1; then
+    pkill -TERM -P "$pid" 2>/dev/null || true
+  fi
+  kill -TERM "$pid" 2>/dev/null || true
+  sleep 0.5
+  if command -v pkill >/dev/null 2>&1; then
+    pkill -KILL -P "$pid" 2>/dev/null || true
+  fi
+  kill -KILL "$pid" 2>/dev/null || true
+}
+
+# Apply runs in a new session. Stop tray/server before copying so the tray
+# watchdog cannot respawn BAKLOG over locked install files.
+kill_pid_tree "$TRAY_PID"
+kill_pid_tree "$SERVER_PID"
 wait_pid_gone "$SERVER_PID" 45
 wait_pid_gone "$TRAY_PID" 15
+kill_pid_tree "$TRAY_PID"
+kill_pid_tree "$SERVER_PID"
 
 STAGING="$UPDATE_ROOT/staging-$$-$RANDOM"
 mkdir -p "$STAGING"

--- a/shared/update_manager.py
+++ b/shared/update_manager.py
@@ -21,9 +21,11 @@ from shared.update_platform import (
 )
 from shared.update_ready_state import (
     clear_apply_result,
+    clear_applying_lock,
     clear_ready_state,
     read_apply_result,
     scan_ready_state,
+    write_applying_lock,
     write_ready_state,
 )
 from shared.update_release import (
@@ -300,6 +302,7 @@ class UpdateManager:
         manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
 
         clear_apply_result(self._work_root)
+        write_applying_lock(self._work_root, version=artifacts.version)
         self._set_status(phase="applying", can_apply=False, ready=False)
 
         try:
@@ -309,6 +312,7 @@ class UpdateManager:
                 install_dir=install_dir,
             )
         except OSError as exc:
+            clear_applying_lock(self._work_root)
             self._set_status(phase="ready", ready=True, can_apply=True, error=str(exc))
             return {"ok": False, "error": f"Failed to launch updater: {exc}"}
 

--- a/shared/update_platform.py
+++ b/shared/update_platform.py
@@ -89,7 +89,12 @@ def tray_binary_name(platform: str | None = None) -> str:
 
 
 def launch_apply_subprocess(*, script: Path, manifest_path: Path, install_dir: Path) -> subprocess.Popen:
-    """Launch the platform apply helper after server-side security checks."""
+    """Launch the platform apply helper after server-side security checks.
+
+    The helper must outlive the shutting-down server (and survive tray tree-kill),
+    so it is started detached / in a new session — not as a child that dies with
+    BAKLOG.exe or gets swept by ``taskkill /T`` on the server PID.
+    """
     platform = sys.platform
     if platform == "win32":
         cmd = [
@@ -102,12 +107,31 @@ def launch_apply_subprocess(*, script: Path, manifest_path: Path, install_dir: P
             "-ManifestPath",
             str(manifest_path),
         ]
-    elif platform == "darwin":
+        # DETACHED_PROCESS + NEW_PROCESS_GROUP: apply is not in the tray→server tree.
+        flags = int(getattr(subprocess, "DETACHED_PROCESS", 0x00000008))
+        flags |= int(getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200))
+        flags |= int(getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000))
+        return subprocess.Popen(  # noqa: S603
+            cmd,
+            cwd=str(install_dir),
+            creationflags=flags,
+            close_fds=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    if platform == "darwin":
         cmd = [
             "/bin/bash",
             str(script),
             str(manifest_path),
         ]
-    else:
-        raise OSError(f"In-app apply is not supported on {platform}")
-    return subprocess.Popen(cmd, cwd=str(install_dir))  # noqa: S603
+        return subprocess.Popen(  # noqa: S603
+            cmd,
+            cwd=str(install_dir),
+            start_new_session=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    raise OSError(f"In-app apply is not supported on {platform}")

--- a/shared/update_ready_state.py
+++ b/shared/update_ready_state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import tempfile
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -12,11 +13,48 @@ from shared.update_release import UpdateSecurityError, verify_file_sha256
 
 READY_FILENAME = "ready.json"
 APPLY_RESULT_FILENAME = "apply-result.json"
+APPLYING_LOCK_FILENAME = "applying.lock"
 PACKAGE_NAME = "package.zip"
+# Stale lock TTL — if apply crashes without clearing, tray may auto-restart again.
+APPLYING_LOCK_MAX_AGE_SEC = 15 * 60
 
 
 def default_work_root() -> Path:
     return (Path(tempfile.gettempdir()) / "BAKLOG-update").resolve()
+
+
+def write_applying_lock(work_root: Path | None = None, *, version: str = "") -> None:
+    """Mark an in-app apply so the tray watchdog does not respawn the server."""
+    root = (work_root or default_work_root()).resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": version,
+        "written_at": datetime.now(UTC).isoformat(),
+    }
+    (root / APPLYING_LOCK_FILENAME).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def clear_applying_lock(work_root: Path | None = None) -> None:
+    path = (work_root or default_work_root()) / APPLYING_LOCK_FILENAME
+    path.unlink(missing_ok=True)
+
+
+def is_update_apply_in_progress(
+    work_root: Path | None = None,
+    *,
+    max_age_sec: float = APPLYING_LOCK_MAX_AGE_SEC,
+) -> bool:
+    """True while Install & restart owns the update workspace (fresh lock only)."""
+    path = (work_root or default_work_root()) / APPLYING_LOCK_FILENAME
+    if not path.is_file():
+        return False
+    try:
+        age = time.time() - path.stat().st_mtime
+    except OSError:
+        return False
+    if age < 0 or age > max_age_sec:
+        return False
+    return True
 
 
 def write_ready_state(
@@ -65,15 +103,16 @@ def read_apply_result(work_root: Path | None = None) -> dict[str, Any] | None:
     if not path.is_file():
         return None
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
+        data = json.loads(path.read_text(encoding="utf-8-sig"))
     except (OSError, json.JSONDecodeError):
         return None
     return data if isinstance(data, dict) else None
 
 
 def clear_apply_result(work_root: Path | None = None) -> None:
-    path = (work_root or default_work_root()) / APPLY_RESULT_FILENAME
-    path.unlink(missing_ok=True)
+    root = work_root or default_work_root()
+    (root / APPLY_RESULT_FILENAME).unlink(missing_ok=True)
+    clear_applying_lock(root)
 
 
 def scan_ready_state(work_root: Path) -> dict[str, Any] | None:

--- a/tests/test_apply_update_ps1.py
+++ b/tests/test_apply_update_ps1.py
@@ -1,0 +1,103 @@
+"""Smoke-test packaging/apply_update.ps1 against a synthetic Windows bundle zip."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+APPLY_PS1 = REPO / "packaging" / "apply_update.ps1"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows apply script only")
+def test_apply_update_ps1_replaces_install_and_writes_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    update_root = tmp_path / "BAKLOG-update"
+    update_root.mkdir()
+    monkeypatch.setenv("TEMP", str(tmp_path))
+    monkeypatch.setenv("TMP", str(tmp_path))
+
+    install = tmp_path / "install" / "BAKLOG"
+    install.mkdir(parents=True)
+    (install / "BAKLOG.exe").write_bytes(b"old-server")
+    (install / "BAKLOG Tray.exe").write_bytes(b"old-tray")
+    (install / "old.txt").write_text("keep-me-gone", encoding="utf-8")
+
+    bundle = tmp_path / "bundle" / "BAKLOG"
+    bundle.mkdir(parents=True)
+    (bundle / "BAKLOG.exe").write_bytes(b"new-server")
+    (bundle / "BAKLOG Tray.exe").write_bytes(b"new-tray")
+    (bundle / "apply_update.ps1").write_text("# new", encoding="utf-8")
+    (bundle / "fresh.txt").write_text("from-update", encoding="utf-8")
+
+    version = "9.9.9-test"
+    version_dir = update_root / version
+    version_dir.mkdir()
+    zip_path = version_dir / "package.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        for path in bundle.rglob("*"):
+            if path.is_file():
+                zf.write(path, arcname=str(Path("BAKLOG") / path.relative_to(bundle)))
+
+    sha256 = hashlib.sha256(zip_path.read_bytes()).hexdigest()
+    manifest = version_dir / "apply-manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "install_dir": str(install),
+                "zip_path": str(zip_path),
+                "sha256": sha256,
+                "version": version,
+                "server_pid": 0,
+                "tray_pid": 0,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (update_root / "applying.lock").write_text('{"version":"9.9.9-test"}', encoding="utf-8")
+
+    # Avoid launching the fake tray binary via Start-Process.
+    script_text = APPLY_PS1.read_text(encoding="utf-8")
+    patched = script_text.replace(
+        "Start-Process -FilePath $trayExePath -WorkingDirectory $installDir | Out-Null",
+        "# test harness: skip Start-Process",
+    )
+    harness = tmp_path / "apply_harness.ps1"
+    harness.write_text(patched, encoding="utf-8")
+
+    proc = subprocess.run(
+        [
+            "powershell.exe",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(harness),
+            "-ManifestPath",
+            str(manifest),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "TEMP": str(tmp_path), "TMP": str(tmp_path)},
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
+
+    assert (install / "BAKLOG.exe").read_bytes() == b"new-server"
+    assert (install / "BAKLOG Tray.exe").read_bytes() == b"new-tray"
+    assert (install / "fresh.txt").read_text(encoding="utf-8") == "from-update"
+    # Overlay copy keeps install-only files; full wipe is not part of apply.
+    assert (install / "old.txt").read_text(encoding="utf-8") == "keep-me-gone"
+
+    result_path = update_root / "apply-result.json"
+    assert result_path.is_file()
+    result = json.loads(result_path.read_text(encoding="utf-8-sig"))
+    assert result["ok"] is True
+    assert result["version"] == version
+    assert not (update_root / "applying.lock").exists()

--- a/tests/test_tray_app.py
+++ b/tests/test_tray_app.py
@@ -266,6 +266,29 @@ def test_server_watchdog_notifies_on_owned_child_death(monkeypatch):
     assert notified[0][0] == "BAKLOG server stopped"
 
 
+def test_server_watchdog_skips_restart_while_apply_in_progress(monkeypatch):
+    starts: list[float] = []
+
+    monkeypatch.setattr(tray_app, "_port_open", lambda timeout=0.3: False)
+    monkeypatch.setattr(tray_app, "is_update_apply_in_progress", lambda: True)
+    monkeypatch.setattr(
+        tray_app.ServerController,
+        "start",
+        lambda self: starts.append(time.monotonic()) or True,
+    )
+
+    class DeadProc:
+        def poll(self):
+            return 1
+
+    ctl = tray_app.ServerController()
+    ctl.proc = DeadProc()
+    icon = MagicMock()
+    tray_app._start_server_watchdog(icon, ctl)
+    time.sleep(2.5)
+    assert starts == []
+
+
 def test_open_data_folder_opens_data_root(monkeypatch, tmp_path):
     opened: dict[str, str] = {}
     monkeypatch.setattr(tray_app, "data_root", lambda: tmp_path)

--- a/tests/test_update_applying_lock.py
+++ b/tests/test_update_applying_lock.py
@@ -1,0 +1,46 @@
+"""Applying lock coordinates tray watchdog with Install & restart."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from shared.update_ready_state import (
+    APPLYING_LOCK_FILENAME,
+    clear_apply_result,
+    clear_applying_lock,
+    is_update_apply_in_progress,
+    write_applying_lock,
+)
+
+
+def test_write_and_clear_applying_lock(tmp_path: Path) -> None:
+    assert is_update_apply_in_progress(tmp_path) is False
+    write_applying_lock(tmp_path, version="0.8.37")
+    lock = tmp_path / APPLYING_LOCK_FILENAME
+    assert lock.is_file()
+    data = json.loads(lock.read_text(encoding="utf-8"))
+    assert data["version"] == "0.8.37"
+    assert is_update_apply_in_progress(tmp_path) is True
+    clear_applying_lock(tmp_path)
+    assert is_update_apply_in_progress(tmp_path) is False
+
+
+def test_stale_applying_lock_ignored(tmp_path: Path) -> None:
+    write_applying_lock(tmp_path, version="0.8.37")
+    lock = tmp_path / APPLYING_LOCK_FILENAME
+    stale = time.time() - 3600
+    # Touch mtime into the past beyond the default TTL.
+    import os
+
+    os.utime(lock, (stale, stale))
+    assert is_update_apply_in_progress(tmp_path, max_age_sec=60) is False
+
+
+def test_clear_apply_result_also_clears_lock(tmp_path: Path) -> None:
+    write_applying_lock(tmp_path, version="0.8.37")
+    (tmp_path / "apply-result.json").write_text('{"ok": true}', encoding="utf-8")
+    clear_apply_result(tmp_path)
+    assert not (tmp_path / APPLYING_LOCK_FILENAME).exists()
+    assert not (tmp_path / "apply-result.json").exists()

--- a/tests/test_update_platform.py
+++ b/tests/test_update_platform.py
@@ -58,11 +58,11 @@ def test_launch_apply_subprocess_darwin(monkeypatch: pytest.MonkeyPatch, tmp_pat
     manifest.write_text("{}", encoding="utf-8")
     install = tmp_path / "install"
     install.mkdir()
-    calls: list[list[str]] = []
+    calls: list[dict] = []
 
     class FakePopen:
         def __init__(self, cmd, **kwargs):
-            calls.append(cmd)
+            calls.append({"cmd": cmd, "kwargs": kwargs})
 
         def __enter__(self):
             return self
@@ -73,8 +73,9 @@ def test_launch_apply_subprocess_darwin(monkeypatch: pytest.MonkeyPatch, tmp_pat
     monkeypatch.setattr("shared.update_platform.subprocess.Popen", FakePopen)
     launch_apply_subprocess(script=script, manifest_path=manifest, install_dir=install)
     assert calls
-    assert calls[0][0] == "/bin/bash"
-    assert str(script) in calls[0]
+    assert calls[0]["cmd"][0] == "/bin/bash"
+    assert str(script) in calls[0]["cmd"]
+    assert calls[0]["kwargs"].get("start_new_session") is True
 
 
 @pytest.mark.no_leak_check
@@ -86,11 +87,11 @@ def test_launch_apply_subprocess_win32(monkeypatch: pytest.MonkeyPatch, tmp_path
     manifest.write_text("{}", encoding="utf-8")
     install = tmp_path / "install"
     install.mkdir()
-    calls: list[list[str]] = []
+    calls: list[dict] = []
 
     class FakePopen:
         def __init__(self, cmd, **kwargs):
-            calls.append(cmd)
+            calls.append({"cmd": cmd, "kwargs": kwargs})
 
         def __enter__(self):
             return self
@@ -101,5 +102,8 @@ def test_launch_apply_subprocess_win32(monkeypatch: pytest.MonkeyPatch, tmp_path
     monkeypatch.setattr("shared.update_platform.subprocess.Popen", FakePopen)
     launch_apply_subprocess(script=script, manifest_path=manifest, install_dir=install)
     assert calls
-    assert "powershell.exe" in calls[0]
-    assert "-ManifestPath" in calls[0]
+    assert "powershell.exe" in calls[0]["cmd"]
+    assert "-ManifestPath" in calls[0]["cmd"]
+    flags = int(calls[0]["kwargs"].get("creationflags") or 0)
+    assert flags & 0x00000008  # DETACHED_PROCESS
+    assert flags & 0x00000200  # CREATE_NEW_PROCESS_GROUP

--- a/tray_app.py
+++ b/tray_app.py
@@ -44,6 +44,7 @@ from shared.startup import (
     toggle_startup,
 )
 from shared.tray_lock import acquire_tray_lock
+from shared.update_ready_state import is_update_apply_in_progress
 
 HOST = "127.0.0.1"
 PORT = int(os.environ.get("PORT", "8765"))
@@ -413,6 +414,10 @@ def _start_server_watchdog(icon, controller: ServerController) -> threading.Thre
                 controller.proc = None
 
             if not controller.is_running():
+                # Install & restart shuts the server down on purpose. Do not
+                # respawn it while the apply helper still needs the install dir.
+                if is_update_apply_in_progress():
+                    continue
                 now = time.monotonic()
                 # First crash or last restart was long ago -> one-shot restart
                 if last_restart_time == 0 or (now - last_restart_time) >= RESTART_COOLDOWN:


### PR DESCRIPTION
## Summary
- Tray watchdog no longer respawns BAKLOG during Install & restart (`applying.lock`).
- Apply helper launches detached; tray/server are tree-killed before copy.
- Keeps version **0.8.36** for a same-version re-release after CI is green.

## Test plan
- [ ] CI green (pytest/vitest/Windows+macOS smoke)
- [ ] After merge + `replace_release_tag.ps1 -Version 0.8.36 -Force`, download fresh Setup/zip
- [ ] Manual install of new 0.8.36 (0.8.35 cannot self-heal)
- [ ] Confirm later in-app update path relaunches on a new build