### PR TITLE
fix: apply_update.ps1 SHA256 without Get-FileHash

### DIFF
--- a/packaging/apply_update.ps1
+++ b/packaging/apply_update.ps1
@@ -43,8 +43,19 @@ function Test-SafeChildPath([string]$Root, [string]$Relative) {
 }
 
 function Get-FileSha256([string]$Path) {
-    $hash = Get-FileHash -Path $Path -Algorithm SHA256
-    return $hash.Hash.ToLowerInvariant()
+    # Prefer .NET so -NoProfile / minimal runners still work (Get-FileHash may be absent).
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $stream = [System.IO.File]::OpenRead($Path)
+        try {
+            $hashBytes = $sha.ComputeHash($stream)
+            return ([System.BitConverter]::ToString($hashBytes) -replace "-", "").ToLowerInvariant()
+        } finally {
+            $stream.Dispose()
+        }
+    } finally {
+        $sha.Dispose()
+    }
 }
 
 function Restore-InstallFromBackup([string]$InstallDir, [string]$BackupDir) {


### PR DESCRIPTION
## Summary
- Replace `Get-FileHash` with .NET `SHA256` in `apply_update.ps1` so Install & restart (and the release pytest smoke) work under `-NoProfile` on GHA Windows.

## Test plan
- [x] `pytest tests/test_apply_update_ps1.py` locally
- [ ] CI green
- [ ] Re-run `replace_release_tag.ps1 -Version 0.8.36 -Force` after merge