### PR TITLE
fix: complete Battle.net Connect when Games SPA loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [Unreleased]
 
+### Fixed
+
+- Battle.net Connect: when the Games SPA already loads `games-and-subs` successfully, complete Connect from that network 200 (sniffer) instead of hanging on a failing external/in-page probe; re-select the live Games tab each poll; add Origin/Referer to the in-page probe; rate-limited stderr diagnostics for probe status/URL/cookies.
+
 ## [0.8.36] - 2026-07-31
 
 ### Fixed

--- a/auth/connect_extractors.py
+++ b/auth/connect_extractors.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 import queue
+import sys
 import threading
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -12,6 +14,8 @@ HUMBLE_LIBRARY_URL = "https://www.humblebundle.com/home/library"
 HUMBLE_ORDERS_API = "https://www.humblebundle.com/api/v1/user/order"
 BATTLENET_GAMES_URL = "https://account.battle.net/games"
 BATTLENET_ACCOUNT_API = "https://account.battle.net/api/games-and-subs"
+_BATTLENET_LOG_INTERVAL_SEC = 8.0
+_battlenet_last_log_at = 0.0
 
 
 def pick_gog_al_from_cookies(cookies: list[dict]) -> str:
@@ -204,16 +208,107 @@ def _battlenet_xsrf_from_cookies(cookies: list[dict]) -> str:
     return ""
 
 
-def _battlenet_probe_via_page(page: Any, *, xsrf: str = "") -> bool:
-    """Verify games-and-subs via in-page fetch (real jar + origin), like PSN/XBL."""
+def _battlenet_log(message: str) -> None:
+    global _battlenet_last_log_at
+    now = time.time()
+    if now - _battlenet_last_log_at < _BATTLENET_LOG_INTERVAL_SEC:
+        return
+    _battlenet_last_log_at = now
+    print(f"[battlenet] {message}", file=sys.stderr, flush=True)
+
+
+def _battlenet_cookie_count(cookies: list[dict]) -> tuple[int, bool]:
+    count = 0
+    has_xsrf = False
+    for c in cookies:
+        domain = (c.get("domain") or "").lstrip(".")
+        if not domain.endswith("battle.net"):
+            continue
+        if c.get("name") and c.get("value") is not None:
+            count += 1
+            if c.get("name") == "XSRF-TOKEN":
+                has_xsrf = True
+    return count, has_xsrf
+
+
+class BattleNetGamesAndSubsSniffer:
+    """Treat a live SPA games-and-subs 200 as session proof (any tab)."""
+
+    URL_SUBSTR = "account.battle.net/api/games-and-subs"
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.verified = False
+        self.cookie_header = ""
+        self.status = 0
+
+    def attach(self, context: Any) -> None:
+        def on_request(request: Any) -> None:
+            url = (getattr(request, "url", None) or "").lower()
+            if self.URL_SUBSTR not in url:
+                return
+            headers = getattr(request, "headers", {}) or {}
+            cookie = headers.get("cookie") or headers.get("Cookie") or ""
+            if cookie:
+                with self._lock:
+                    self.cookie_header = str(cookie).strip()
+
+        def on_response(response: Any) -> None:
+            url = (getattr(response, "url", None) or "").lower()
+            if self.URL_SUBSTR not in url:
+                return
+            status = int(getattr(response, "status", 0) or 0)
+            if status != 200:
+                return
+            cookie = ""
+            req = getattr(response, "request", None)
+            if req is not None:
+                headers = getattr(req, "headers", {}) or {}
+                cookie = headers.get("cookie") or headers.get("Cookie") or ""
+            with self._lock:
+                self.verified = True
+                self.status = status
+                if cookie:
+                    self.cookie_header = str(cookie).strip()
+
+        context.on("request", on_request)
+        context.on("response", on_response)
+
+    def snapshot(self) -> tuple[bool, str, int]:
+        with self._lock:
+            return self.verified, self.cookie_header, self.status
+
+    def creds_from(self, context: Any) -> dict[str, str] | None:
+        verified, sniffed, _status = self.snapshot()
+        if not verified:
+            return None
+        cookies = context.cookies()
+        header = _cookie_header(cookies, (".battle.net", "battle.net"))
+        if not header:
+            header = sniffed
+        if not header:
+            return None
+        return {"BATTLENET_COOKIE": header}
+
+
+def build_battlenet_games_sniffer() -> BattleNetGamesAndSubsSniffer:
+    return BattleNetGamesAndSubsSniffer()
+
+
+def _battlenet_probe_status(page: Any, *, xsrf: str = "") -> dict[str, Any]:
+    """In-page games-and-subs probe; returns {ok, status}."""
     if page is None:
-        return False
+        return {"ok": False, "status": 0}
     xsrf_js = json.dumps(xsrf or "")
     try:
         result = page.evaluate(
             f"""async () => {{
                 try {{
-                    const headers = {{ Accept: 'application/json, text/plain, */*' }};
+                    const headers = {{
+                        Accept: 'application/json, text/plain, */*',
+                        Origin: 'https://account.battle.net',
+                        Referer: 'https://account.battle.net/games',
+                    }};
                     let xsrf = {xsrf_js};
                     if (!xsrf) {{
                         const m = document.cookie.match(/(?:^|;\\s*)XSRF-TOKEN=([^;]+)/);
@@ -238,29 +333,66 @@ def _battlenet_probe_via_page(page: Any, *, xsrf: str = "") -> bool:
             timeout=20,
         )
     except Exception:  # noqa: BLE001
-        return False
-    return isinstance(result, dict) and bool(result.get("ok"))
+        return {"ok": False, "status": 0}
+    if isinstance(result, dict):
+        return {
+            "ok": bool(result.get("ok")),
+            "status": int(result.get("status") or 0),
+        }
+    return {"ok": False, "status": 0}
 
 
-def extract_battlenet_session(context: Any, page: Any | None = None) -> dict[str, str] | None:
+def _battlenet_probe_via_page(page: Any, *, xsrf: str = "") -> bool:
+    """Verify games-and-subs via in-page fetch (real jar + origin), like PSN/XBL."""
+    return bool(_battlenet_probe_status(page, xsrf=xsrf).get("ok"))
+
+
+def extract_battlenet_session(
+    context: Any,
+    page: Any | None = None,
+    *,
+    sniffer: BattleNetGamesAndSubsSniffer | None = None,
+) -> dict[str, str] | None:
     try:
         from clients.battlenet_client import BattleNetAuthError, probe_session
     except Exception as exc:
-        import sys
         print(f"[battlenet] import failed: {exc}", file=sys.stderr, flush=True)
         return None
+
+    if sniffer is not None:
+        sniffed_creds = sniffer.creds_from(context)
+        if sniffed_creds:
+            _battlenet_log("games-and-subs sniffer 200 — session ready")
+            return sniffed_creds
 
     cookies = context.cookies()
     header = _cookie_header(cookies, (".battle.net", "battle.net"))
     xsrf = _battlenet_xsrf_from_cookies(cookies)
+    cookie_count, has_xsrf = _battlenet_cookie_count(cookies)
+    page_url = (getattr(page, "url", None) or "") if page is not None else ""
 
     # Prefer in-page fetch: HttpOnly session cookies + correct Origin/Referer.
     # External requests.Session often 401s even when the Games SPA is loaded.
-    if page is not None and _battlenet_probe_via_page(page, xsrf=xsrf):
-        if header:
-            return {"BATTLENET_COOKIE": header}
-        # Probe worked but CDP cookie dump was empty — wait for next poll.
-        return None
+    if page is not None:
+        probe = _battlenet_probe_status(page, xsrf=xsrf)
+        _battlenet_log(
+            f"in-page probe ok={probe.get('ok')} status={probe.get('status')} "
+            f"url={page_url!r} cookies={cookie_count} xsrf={has_xsrf}"
+        )
+        if probe.get("ok"):
+            if header:
+                return {"BATTLENET_COOKIE": header}
+            # Probe worked but first CDP dump was empty — retry once.
+            cookies = context.cookies()
+            header = _cookie_header(cookies, (".battle.net", "battle.net"))
+            if header:
+                return {"BATTLENET_COOKIE": header}
+            if sniffer is not None:
+                _verified, sniffed, _status = sniffer.snapshot()
+                if sniffed:
+                    return {"BATTLENET_COOKIE": sniffed}
+            _battlenet_log("in-page 200 but cookie dump empty — waiting")
+            return None
 
     if not _battlenet_has_session(context):
         return None
@@ -268,10 +400,12 @@ def extract_battlenet_session(context: Any, page: Any | None = None) -> dict[str
         return None
     try:
         probe_session(header)
-    except BattleNetAuthError:
+    except BattleNetAuthError as exc:
+        _battlenet_log(f"external probe rejected: {exc}")
         # Stale/expired cookies from a prior session — keep the connect window
         # open so the user can sign in with fresh credentials.
         return None
+    _battlenet_log("external probe accepted")
     return {"BATTLENET_COOKIE": header}
 
 

--- a/auth/runner.py
+++ b/auth/runner.py
@@ -130,27 +130,57 @@ def _cookie_header(cookies: list[dict], domains: tuple[str, ...]) -> str:
 BATTLENET_GAMES_URL = "https://account.battle.net/games"
 
 
+def _battlenet_live_page(page, context):
+    """Prefer the Games SPA tab over blank OAuth popups / stale login tabs."""
+    pages = _connect_pages(page, context)
+    for pg in pages:
+        url = (getattr(pg, "url", None) or "").lower()
+        if "account.battle.net" in url and "/games" in url:
+            return pg
+    for pg in pages:
+        url = (getattr(pg, "url", None) or "").lower()
+        if "battle.net" in url and not is_blank_browser_url(url):
+            return pg
+    return _drive_connect_page(page, context)
+
+
 def _extract_battlenet_inline(page, context, session: AuthSession | None = None) -> dict[str, str]:
     """Open account.battle.net/games and save cookies only after the library API works."""
-    from auth.connect_extractors import battlenet_connect_hint, extract_battlenet_session
+    from auth.connect_extractors import (
+        battlenet_connect_hint,
+        build_battlenet_games_sniffer,
+        extract_battlenet_session,
+    )
     from auth.connect_loop import run_connect_poll
+
+    sniffer = build_battlenet_games_sniffer()
+    sniffer.attach(context)
 
     try:
         page.goto(BATTLENET_GAMES_URL, wait_until="domcontentloaded", timeout=25_000)
     except Exception:  # noqa: BLE001
         pass
 
+    def _check() -> dict[str, str] | None:
+        live = _battlenet_live_page(page, context)
+        return extract_battlenet_session(context, live, sniffer=sniffer)
+
+    def _hint() -> str:
+        live = _battlenet_live_page(page, context)
+        return battlenet_connect_hint(live)
+
     def _on_signed_in(_creds: dict[str, str]) -> None:
         if session:
-            session.emit("signed_in", {"url": page.url or BATTLENET_GAMES_URL})
+            live = _battlenet_live_page(page, context)
+            session.emit("signed_in", {"url": getattr(live, "url", None) or BATTLENET_GAMES_URL})
 
     return run_connect_poll(
         context=context,
         session=session,
         deadline=time.time() + SUCCESS_WAIT_SEC,
         poll_sec=POLL_SEC,
-        check=lambda: extract_battlenet_session(context, page),
-        hint=lambda: battlenet_connect_hint(page),
+        check=_check,
+        hint=_hint,
         on_signed_in=_on_signed_in,
         timeout_message=(
             "Could not verify a Battle.net library session — sign in at account.battle.net/games, "

--- a/tests/test_battlenet_connect_loop.py
+++ b/tests/test_battlenet_connect_loop.py
@@ -1,19 +1,21 @@
-"""Battle.net headed-connect session detection (in-page probe + cookie fallback)."""
+"""Battle.net headed-connect session detection (sniffer + in-page probe + cookie fallback)."""
 
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from auth.connect_extractors import (
+    BattleNetGamesAndSubsSniffer,
     _battlenet_probe_via_page,
     extract_battlenet_session,
 )
 
 
 class _FakePage:
-    def __init__(self, result: Any) -> None:
+    def __init__(self, result: Any, *, url: str = "https://account.battle.net/games") -> None:
         self._result = result
+        self.url = url
         self.evaluate_calls = 0
 
     def evaluate(self, _expr: str, *, timeout: float = 60) -> Any:
@@ -26,9 +28,17 @@ class _FakePage:
 class _FakeContext:
     def __init__(self, cookies: list[dict]) -> None:
         self._cookies = cookies
+        self.request_handlers: list = []
+        self.response_handlers: list = []
 
     def cookies(self) -> list[dict]:
         return list(self._cookies)
+
+    def on(self, event: str, handler) -> None:
+        if event == "request":
+            self.request_handlers.append(handler)
+        elif event == "response":
+            self.response_handlers.append(handler)
 
 
 SESSION_COOKIES = [
@@ -106,3 +116,102 @@ def test_extract_in_page_ok_but_empty_cookies_waits() -> None:
     with patch("clients.battlenet_client.probe_session") as probe:
         assert extract_battlenet_session(ctx, page) is None
         probe.assert_not_called()
+
+
+def test_sniffer_200_yields_creds_without_in_page_probe() -> None:
+    ctx = _FakeContext(SESSION_COOKIES)
+    sniffer = BattleNetGamesAndSubsSniffer()
+    sniffer.attach(ctx)
+    assert ctx.response_handlers
+
+    req = MagicMock()
+    req.url = "https://account.battle.net/api/games-and-subs"
+    req.headers = {"cookie": "XSRF-TOKEN=tok%3D%3D; BA-tassession=sess"}
+    resp = MagicMock()
+    resp.url = req.url
+    resp.status = 200
+    resp.request = req
+    ctx.response_handlers[0](resp)
+
+    page = _FakePage({"ok": False, "status": 401})
+    with patch("clients.battlenet_client.probe_session") as probe:
+        creds = extract_battlenet_session(ctx, page, sniffer=sniffer)
+        probe.assert_not_called()
+        assert page.evaluate_calls == 0
+    assert creds is not None
+    assert "BA-tassession=sess" in creds["BATTLENET_COOKIE"]
+
+
+def test_sniffer_cookie_header_used_when_cdp_dump_empty() -> None:
+    ctx = _FakeContext([])
+    sniffer = BattleNetGamesAndSubsSniffer()
+    sniffer.attach(ctx)
+    req = MagicMock()
+    req.url = "https://account.battle.net/api/games-and-subs?x=1"
+    req.headers = {"cookie": "BA-tassession=from-network; XSRF-TOKEN=abc"}
+    resp = MagicMock()
+    resp.url = req.url
+    resp.status = 200
+    resp.request = req
+    ctx.response_handlers[0](resp)
+
+    with patch("clients.battlenet_client.probe_session") as probe:
+        creds = extract_battlenet_session(ctx, None, sniffer=sniffer)
+        probe.assert_not_called()
+    assert creds == {
+        "BATTLENET_COOKIE": "BA-tassession=from-network; XSRF-TOKEN=abc"
+    }
+
+
+def test_in_page_ok_uses_sniffed_cookie_when_dump_empty() -> None:
+    ctx = _FakeContext([])
+    sniffer = BattleNetGamesAndSubsSniffer()
+    sniffer.attach(ctx)
+    # Sniffer saw the request cookie but response may arrive after probe.
+    ctx.request_handlers[0](
+        MagicMock(
+            url="https://account.battle.net/api/games-and-subs",
+            headers={"cookie": "BA-tassession=sniffed"},
+        )
+    )
+    # Mark verified via response without cookie on request object.
+    resp = MagicMock()
+    resp.url = "https://account.battle.net/api/games-and-subs"
+    resp.status = 200
+    resp.request = MagicMock(headers={})
+    ctx.response_handlers[0](resp)
+
+    page = _FakePage({"ok": True, "status": 200})
+    with patch("clients.battlenet_client.probe_session") as probe:
+        creds = extract_battlenet_session(ctx, page, sniffer=sniffer)
+        probe.assert_not_called()
+    assert creds == {"BATTLENET_COOKIE": "BA-tassession=sniffed"}
+
+
+def test_stale_page_fails_live_page_succeeds() -> None:
+    from clients.battlenet_client import BattleNetAuthError
+
+    ctx = _FakeContext(SESSION_COOKIES)
+    stale = _FakePage({"ok": False, "status": 0}, url="about:blank")
+    live = _FakePage({"ok": True, "status": 200}, url="https://account.battle.net/games")
+    with patch(
+        "clients.battlenet_client.probe_session",
+        side_effect=BattleNetAuthError("401"),
+    ):
+        assert extract_battlenet_session(ctx, stale) is None
+    with patch("clients.battlenet_client.probe_session") as probe:
+        creds = extract_battlenet_session(ctx, live)
+        probe.assert_not_called()
+    assert creds is not None
+    assert "BATTLENET_COOKIE" in creds
+
+
+def test_battlenet_live_page_prefers_games_tab() -> None:
+    from auth.runner import _battlenet_live_page
+
+    blank = MagicMock(url="about:blank", is_closed=False)
+    games = MagicMock(url="https://account.battle.net/games", is_closed=False)
+    login = MagicMock(url="https://account.battle.net/login", is_closed=False)
+    ctx = MagicMock()
+    ctx.pages = [blank, login, games]
+    assert _battlenet_live_page(blank, ctx) is games


### PR DESCRIPTION
## Summary
- Treat a live SPA `games-and-subs` **200** as Connect success (network sniffer), including Cookie header when CDP dump is empty.
- Re-select the Games tab each poll (avoid stale blank/login tabs).
- In-page probe sends Origin/Referer; rate-limited stderr diagnostics for probe status/URL/cookies.

## Test plan
- [x] `pytest tests/test_battlenet_connect_loop.py tests/test_battlenet_client.py` (20 passed)
- [ ] Frozen 0.8.36+ owner E2E: Connect Battle.net → Games list visible → Connected within ~30s → library fetch succeeds