### PR TITLE
fix: stabilize Install & restart and Battle.net Connect for 0.8.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [Unreleased]
 
+## [0.8.38] - 2026-07-31
+
+### Fixed
+
+- In-app Install & restart on Windows: root cause of the 0.8.36→0.8.37 apply failure. Launching the apply helper with `DETACHED_PROCESS` made `powershell.exe` exit immediately with rc=0 (no console host), so nothing was applied while the server still shut down and `applying.lock` blocked the tray watchdog. Drop `DETACHED_PROCESS`, use `CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP`, kill tray/server with a self-excluding process walk (never `taskkill /T` on ourselves), always write `apply-result.json` / clear the lock / relaunch the tray on failure, use .NET zip extraction, and require an `apply-started.json` handshake before shutting the server down. Apply progress goes to `%TEMP%\BAKLOG-update\apply.log`; lock TTL shortened to 120s with heartbeats.
+- Battle.net Connect diagnostics: per-message rate-limited logging teed to `<data>/connect-battlenet.log` (visible under Tray launches), drop forbidden Origin/Referer from the in-page probe, broaden the network sniffer to any `account.battle.net/api` 200, and fall back to `Network.getCookies` with explicit urls when the CDP cookie dump is empty.
+- Bug bundles / `/api/diagnostics`: include update phase, apply result, applying-lock age, and apply log tail so the next stuck-update report is conclusive.
+
 ## [0.8.37] - 2026-07-31
 
 ### Fixed

--- a/auth/cdp_browser.py
+++ b/auth/cdp_browser.py
@@ -1138,6 +1138,39 @@ class CdpContext:
             )
         return out
 
+    def cookies_for_urls(
+        self,
+        urls: list[str],
+        *,
+        page: CdpPage | None = None,
+    ) -> list[dict[str, Any]]:
+        """Network.getCookies scoped to urls on a live page session."""
+        sid: str | None = None
+        if page is not None and not getattr(page, "is_closed", False):
+            sid = getattr(page, "_session_id", None) or None
+        if not sid:
+            sid = self._first_page_session()
+        if not sid or not urls:
+            return []
+        try:
+            result = self._send(
+                "Network.getCookies",
+                {"urls": list(urls)},
+                session_id=sid,
+            )
+        except Exception:
+            return []
+        out: list[dict[str, Any]] = []
+        for c in result.get("cookies") or []:
+            out.append(
+                {
+                    "name": c.get("name", ""),
+                    "value": c.get("value", ""),
+                    "domain": c.get("domain", ""),
+                }
+            )
+        return out
+
     def new_page(self) -> CdpPage:
         result = self._send("Target.createTarget", {"url": "about:blank"})
         target_id = result.get("targetId", "")

--- a/auth/connect_extractors.py
+++ b/auth/connect_extractors.py
@@ -14,8 +14,10 @@ HUMBLE_LIBRARY_URL = "https://www.humblebundle.com/home/library"
 HUMBLE_ORDERS_API = "https://www.humblebundle.com/api/v1/user/order"
 BATTLENET_GAMES_URL = "https://account.battle.net/games"
 BATTLENET_ACCOUNT_API = "https://account.battle.net/api/games-and-subs"
-_BATTLENET_LOG_INTERVAL_SEC = 8.0
-_battlenet_last_log_at = 0.0
+# Per-message-key dedupe interval (same key suppressed this long).
+_BATTLENET_LOG_INTERVAL_SEC = 4.0
+_battlenet_last_log_by_key: dict[str, float] = {}
+_battlenet_log_path: Any | None = None
 
 
 def pick_gog_al_from_cookies(cookies: list[dict]) -> str:
@@ -208,13 +210,34 @@ def _battlenet_xsrf_from_cookies(cookies: list[dict]) -> str:
     return ""
 
 
-def _battlenet_log(message: str) -> None:
-    global _battlenet_last_log_at
+def _battlenet_log(message: str, *, key: str | None = None) -> None:
+    """Rate-limited stderr + optional on-disk tee for frozen Tray builds."""
+    global _battlenet_log_path
     now = time.time()
-    if now - _battlenet_last_log_at < _BATTLENET_LOG_INTERVAL_SEC:
+    dedupe_key = key or message
+    last = _battlenet_last_log_by_key.get(dedupe_key, 0.0)
+    if now - last < _BATTLENET_LOG_INTERVAL_SEC:
         return
-    _battlenet_last_log_at = now
-    print(f"[battlenet] {message}", file=sys.stderr, flush=True)
+    _battlenet_last_log_by_key[dedupe_key] = now
+    # Cap key map growth.
+    if len(_battlenet_last_log_by_key) > 64:
+        cutoff = now - (_BATTLENET_LOG_INTERVAL_SEC * 4)
+        stale = [k for k, t in _battlenet_last_log_by_key.items() if t < cutoff]
+        for k in stale:
+            _battlenet_last_log_by_key.pop(k, None)
+    line = f"[battlenet] {message}"
+    print(line, file=sys.stderr, flush=True)
+    try:
+        if _battlenet_log_path is None:
+            from shared.install_paths import data_root
+
+            _battlenet_log_path = data_root() / "connect-battlenet.log"
+        path = _battlenet_log_path
+        if path is not None:
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(f"{time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())} {line}\n")
+    except Exception:  # noqa: BLE001
+        pass
 
 
 def _battlenet_cookie_count(cookies: list[dict]) -> tuple[int, bool]:
@@ -232,15 +255,16 @@ def _battlenet_cookie_count(cookies: list[dict]) -> tuple[int, bool]:
 
 
 class BattleNetGamesAndSubsSniffer:
-    """Treat a live SPA games-and-subs 200 as session proof (any tab)."""
+    """Treat a live account.battle.net/api 200 as session proof (any tab)."""
 
-    URL_SUBSTR = "account.battle.net/api/games-and-subs"
+    URL_SUBSTR = "account.battle.net/api/"
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self.verified = False
         self.cookie_header = ""
         self.status = 0
+        self.last_url = ""
 
     def attach(self, context: Any) -> None:
         def on_request(request: Any) -> None:
@@ -252,6 +276,7 @@ class BattleNetGamesAndSubsSniffer:
             if cookie:
                 with self._lock:
                     self.cookie_header = str(cookie).strip()
+                    self.last_url = getattr(request, "url", None) or url
 
         def on_response(response: Any) -> None:
             url = (getattr(response, "url", None) or "").lower()
@@ -268,6 +293,7 @@ class BattleNetGamesAndSubsSniffer:
             with self._lock:
                 self.verified = True
                 self.status = status
+                self.last_url = getattr(response, "url", None) or url
                 if cookie:
                     self.cookie_header = str(cookie).strip()
 
@@ -295,10 +321,31 @@ def build_battlenet_games_sniffer() -> BattleNetGamesAndSubsSniffer:
     return BattleNetGamesAndSubsSniffer()
 
 
+def _battlenet_cookies_via_urls(context: Any, page: Any | None) -> list[dict]:
+    """Prefer Network.getCookies with explicit urls on the live page session."""
+    getter = getattr(context, "cookies_for_urls", None)
+    if not callable(getter):
+        return []
+    urls = [
+        "https://account.battle.net/",
+        "https://account.battle.net/games",
+        BATTLENET_ACCOUNT_API,
+        "https://battle.net/",
+    ]
+    page_url = (getattr(page, "url", None) or "") if page is not None else ""
+    if page_url.startswith("http"):
+        urls.insert(0, page_url)
+    try:
+        cookies = getter(urls, page=page)
+    except Exception:  # noqa: BLE001
+        return []
+    return cookies if isinstance(cookies, list) else []
+
+
 def _battlenet_probe_status(page: Any, *, xsrf: str = "") -> dict[str, Any]:
-    """In-page games-and-subs probe; returns {ok, status}."""
+    """In-page games-and-subs probe; returns {ok, status, href, origin}."""
     if page is None:
-        return {"ok": False, "status": 0}
+        return {"ok": False, "status": 0, "href": "", "origin": ""}
     xsrf_js = json.dumps(xsrf or "")
     try:
         result = page.evaluate(
@@ -306,8 +353,6 @@ def _battlenet_probe_status(page: Any, *, xsrf: str = "") -> dict[str, Any]:
                 try {{
                     const headers = {{
                         Accept: 'application/json, text/plain, */*',
-                        Origin: 'https://account.battle.net',
-                        Referer: 'https://account.battle.net/games',
                     }};
                     let xsrf = {xsrf_js};
                     if (!xsrf) {{
@@ -325,21 +370,33 @@ def _battlenet_probe_status(page: Any, *, xsrf: str = "") -> dict[str, Any]:
                         credentials: 'include',
                         headers,
                     }});
-                    return {{ ok: res.status === 200, status: res.status }};
+                    return {{
+                        ok: res.status === 200,
+                        status: res.status,
+                        href: String(location.href || ''),
+                        origin: String(location.origin || ''),
+                    }};
                 }} catch (e) {{
-                    return {{ ok: false, status: 0 }};
+                    return {{
+                        ok: false,
+                        status: 0,
+                        href: String(location.href || ''),
+                        origin: String(location.origin || ''),
+                    }};
                 }}
             }}""",
             timeout=20,
         )
     except Exception:  # noqa: BLE001
-        return {"ok": False, "status": 0}
+        return {"ok": False, "status": 0, "href": "", "origin": ""}
     if isinstance(result, dict):
         return {
             "ok": bool(result.get("ok")),
             "status": int(result.get("status") or 0),
+            "href": str(result.get("href") or ""),
+            "origin": str(result.get("origin") or ""),
         }
-    return {"ok": False, "status": 0}
+    return {"ok": False, "status": 0, "href": "", "origin": ""}
 
 
 def _battlenet_probe_via_page(page: Any, *, xsrf: str = "") -> bool:
@@ -362,7 +419,7 @@ def extract_battlenet_session(
     if sniffer is not None:
         sniffed_creds = sniffer.creds_from(context)
         if sniffed_creds:
-            _battlenet_log("games-and-subs sniffer 200 — session ready")
+            _battlenet_log("account.battle.net/api 200 sniffer — session ready", key="sniffer-ready")
             return sniffed_creds
 
     cookies = context.cookies()
@@ -370,28 +427,39 @@ def extract_battlenet_session(
     xsrf = _battlenet_xsrf_from_cookies(cookies)
     cookie_count, has_xsrf = _battlenet_cookie_count(cookies)
     page_url = (getattr(page, "url", None) or "") if page is not None else ""
+    sniffer_verified = False
+    sniffer_status = 0
+    if sniffer is not None:
+        sniffer_verified, _sniffed, sniffer_status = sniffer.snapshot()
 
-    # Prefer in-page fetch: HttpOnly session cookies + correct Origin/Referer.
-    # External requests.Session often 401s even when the Games SPA is loaded.
+    # Prefer in-page fetch: HttpOnly session cookies + browser Origin/Referer.
+    # Do not set forbidden Origin/Referer headers — browsers ignore them.
     if page is not None:
         probe = _battlenet_probe_status(page, xsrf=xsrf)
         _battlenet_log(
-            f"in-page probe ok={probe.get('ok')} status={probe.get('status')} "
-            f"url={page_url!r} cookies={cookie_count} xsrf={has_xsrf}"
+            f"poll ok={probe.get('ok')} status={probe.get('status')} "
+            f"url={page_url!r} href={probe.get('href')!r} origin={probe.get('origin')!r} "
+            f"cookies={cookie_count} xsrf={has_xsrf} "
+            f"sniffer_ok={sniffer_verified} sniffer_status={sniffer_status} "
+            f"header_empty={not bool(header)}",
+            key="poll",
         )
         if probe.get("ok"):
             if header:
                 return {"BATTLENET_COOKIE": header}
-            # Probe worked but first CDP dump was empty — retry once.
+            # Probe worked but first CDP dump was empty — retry + url-scoped dump.
             cookies = context.cookies()
             header = _cookie_header(cookies, (".battle.net", "battle.net"))
+            if not header:
+                scoped = _battlenet_cookies_via_urls(context, page)
+                header = _cookie_header(scoped, (".battle.net", "battle.net"))
             if header:
                 return {"BATTLENET_COOKIE": header}
             if sniffer is not None:
                 _verified, sniffed, _status = sniffer.snapshot()
                 if sniffed:
                     return {"BATTLENET_COOKIE": sniffed}
-            _battlenet_log("in-page 200 but cookie dump empty — waiting")
+            _battlenet_log("in-page 200 but cookie dump empty — waiting", key="empty-cookies")
             return None
 
     if not _battlenet_has_session(context):
@@ -401,11 +469,11 @@ def extract_battlenet_session(
     try:
         probe_session(header)
     except BattleNetAuthError as exc:
-        _battlenet_log(f"external probe rejected: {exc}")
+        _battlenet_log(f"external probe rejected: {exc}", key="external-reject")
         # Stale/expired cookies from a prior session — keep the connect window
         # open so the user can sign in with fresh credentials.
         return None
-    _battlenet_log("external probe accepted")
+    _battlenet_log("external probe accepted", key="external-ok")
     return {"BATTLENET_COOKIE": header}
 
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <!-- Must match pyproject.toml + package.json (see CHANGELOG release discipline). Read at runtime by js/error-boundary.js for bug-bundle metadata. -->
     <!-- Optional override for bug report endpoint during local testing: content="http://127.0.0.1:3000/api/report" -->
     <!-- <meta name="baklog-report-endpoint" content="https://baklog.app/api/report" /> -->
-    <meta name="baklog-version" content="0.8.37" />
+    <meta name="baklog-version" content="0.8.38" />
     <meta name="theme-color" content="#0f172a" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <script>

--- a/js/error-boundary.js
+++ b/js/error-boundary.js
@@ -441,6 +441,13 @@ export async function fetchBugBundleServerContext() {
       platform: data.platform ?? null,
       running_from_temp: data.running_from_temp ?? null,
       version: data.version ?? null,
+      update: data.update ?? null,
+      apply_result: data.apply_result ?? null,
+      apply_started: data.apply_started ?? null,
+      applying_lock_age_sec: data.applying_lock_age_sec ?? null,
+      apply_log_tail: data.apply_log_tail ?? null,
+      install_source: data.install_source ?? null,
+      arp_version: data.arp_version ?? null,
     };
   } catch (_) {
     return null;

--- a/js/update-check.js
+++ b/js/update-check.js
@@ -341,7 +341,7 @@ export function renderUpdateModalHtml(parsed) {
     ? '<button type="button" class="update-modal-apply bg-sky-700 hover:bg-sky-600 px-3 py-2 rounded text-sm">Update now</button>'
     : "";
   return (
-    `<div class="update-modal-panel bg-slate-800 border border-slate-600 rounded-lg shadow-xl max-w-lg w-full mx-4 p-5" role="dialog" aria-modal="true" aria-labelledby="updateModalTitle">` +
+    `<div class="update-modal-panel bg-slate-800 border border-slate-600 rounded-lg shadow-xl max-w-lg w-full mx-4 p-6" role="dialog" aria-modal="true" aria-labelledby="updateModalTitle">` +
     `<h2 id="updateModalTitle" class="text-lg font-semibold text-slate-100">Update available: v${escapeHtml(parsed.latest || "")}</h2>` +
     `<p class="text-sm text-slate-400 mt-1">You have v${escapeHtml(parsed.current)}.</p>` +
     renderApplyBlockedHint(parsed) +
@@ -356,7 +356,7 @@ export function renderUpdateModalHtml(parsed) {
 
 function renderInstallConfirmModalHtml(hints = _installHints) {
   return (
-    `<div class="update-modal-panel bg-slate-800 border border-slate-600 rounded-lg shadow-xl max-w-md w-full mx-4 p-5" role="dialog" aria-modal="true" aria-labelledby="updateInstallTitle">` +
+    `<div class="update-modal-panel bg-slate-800 border border-slate-600 rounded-lg shadow-xl max-w-md w-full mx-4 p-6" role="dialog" aria-modal="true" aria-labelledby="updateInstallTitle">` +
     '<h2 id="updateInstallTitle" class="text-lg font-semibold text-slate-100">Install and restart?</h2>' +
     '<p class="text-sm text-slate-400 mt-2">The update is downloaded and verified. BAKLOG will restart to finish installing. Your library data stays where it is.</p>' +
     renderSetupArpFootnote(hints) +

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog",
-  "version": "0.8.37",
+  "version": "0.8.38",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/packaging/apply_update.ps1
+++ b/packaging/apply_update.ps1
@@ -9,11 +9,47 @@ $ErrorActionPreference = "Stop"
 
 $script:UpdateRoot = [System.IO.Path]::GetFullPath((Join-Path $env:TEMP "BAKLOG-update"))
 New-Item -ItemType Directory -Path $script:UpdateRoot -Force | Out-Null
+$script:ApplyLog = Join-Path $script:UpdateRoot "apply.log"
+$script:KilledApps = $false
+$script:InstallDir = $null
+$script:BackupDir = $null
+$script:CopyStarted = $false
+$script:ResultWritten = $false
+$script:Version = ""
 
-function Fail([string]$Message) {
-    Write-ApplyResult -Ok $false -ErrorMessage $Message -Restored $false
-    Write-Error $Message
-    exit 1
+function Write-ApplyLog([string]$Message) {
+    $ts = (Get-Date).ToUniversalTime().ToString("o")
+    $line = "[$ts] $Message"
+    try {
+        Add-Content -LiteralPath $script:ApplyLog -Value $line -Encoding UTF8 -ErrorAction SilentlyContinue
+    } catch {}
+    Write-Host $line
+}
+
+function Write-ApplyStarted {
+    $path = Join-Path $script:UpdateRoot "apply-started.json"
+    $payload = @{
+        pid = $PID
+        written_at = (Get-Date).ToUniversalTime().ToString("o")
+        version = $script:Version
+    }
+    $payload | ConvertTo-Json | Set-Content -LiteralPath $path -Encoding UTF8
+}
+
+function Clear-ApplyStarted {
+    Remove-Item -LiteralPath (Join-Path $script:UpdateRoot "apply-started.json") -Force -ErrorAction SilentlyContinue
+}
+
+function Touch-ApplyingLock {
+    $path = Join-Path $script:UpdateRoot "applying.lock"
+    if (Test-Path -LiteralPath $path) {
+        (Get-Item -LiteralPath $path).LastWriteTimeUtc = [DateTime]::UtcNow
+    } else {
+        @{
+            version = $script:Version
+            written_at = (Get-Date).ToUniversalTime().ToString("o")
+        } | ConvertTo-Json | Set-Content -LiteralPath $path -Encoding UTF8
+    }
 }
 
 function Write-ApplyResult {
@@ -23,6 +59,8 @@ function Write-ApplyResult {
         [string]$Version = "",
         [bool]$Restored = $false
     )
+    if ($script:ResultWritten) { return }
+    $script:ResultWritten = $true
     $resultPath = Join-Path $script:UpdateRoot "apply-result.json"
     $payload = @{
         ok = $Ok
@@ -34,6 +72,8 @@ function Write-ApplyResult {
     $payload | ConvertTo-Json | Set-Content -LiteralPath $resultPath -Encoding UTF8
     # Allow the tray watchdog to resume auto-restart after apply finishes.
     Remove-Item -LiteralPath (Join-Path $script:UpdateRoot "applying.lock") -Force -ErrorAction SilentlyContinue
+    Clear-ApplyStarted
+    Write-ApplyLog ("result ok=$Ok version=$Version error=$ErrorMessage restored=$Restored")
 }
 
 function Test-SafeChildPath([string]$Root, [string]$Relative) {
@@ -43,7 +83,7 @@ function Test-SafeChildPath([string]$Root, [string]$Relative) {
 }
 
 function Get-FileSha256([string]$Path) {
-    # Prefer .NET so -NoProfile / minimal runners still work (Get-FileHash may be absent).
+    # Prefer .NET so -NoProfile / minimal runners still work (Microsoft.PowerShell.Utility hash cmdlets may be absent).
     $sha = [System.Security.Cryptography.SHA256]::Create()
     try {
         $stream = [System.IO.File]::OpenRead($Path)
@@ -56,6 +96,14 @@ function Get-FileSha256([string]$Path) {
     } finally {
         $sha.Dispose()
     }
+}
+
+function Expand-ZipDotNet([string]$ZipPath, [string]$Destination) {
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    if (Test-Path -LiteralPath $Destination) {
+        [System.IO.Directory]::CreateDirectory($Destination) | Out-Null
+    }
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($ZipPath, $Destination)
 }
 
 function Restore-InstallFromBackup([string]$InstallDir, [string]$BackupDir) {
@@ -73,136 +121,232 @@ function Remove-OldBackups([string]$InstallParent, [string]$KeepBackup) {
         ForEach-Object { Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue }
 }
 
-if (-not (Test-Path -LiteralPath $ManifestPath)) {
-    Fail "Manifest not found"
+function Get-AncestorPidSet([int]$StartPid) {
+    $set = @{}
+    $set[$StartPid] = $true
+    $current = $StartPid
+    for ($i = 0; $i -lt 32; $i++) {
+        $proc = Get-CimInstance Win32_Process -Filter "ProcessId=$current" -ErrorAction SilentlyContinue
+        if (-not $proc) { break }
+        $parent = [int]$proc.ParentProcessId
+        if ($parent -le 0 -or $set.ContainsKey($parent)) { break }
+        $set[$parent] = $true
+        $current = $parent
+    }
+    return $set
 }
 
-try {
-    $manifest = Get-Content -LiteralPath $ManifestPath -Raw -Encoding UTF8 | ConvertFrom-Json
-} catch {
-    Fail "Manifest JSON invalid"
+function Get-DescendantPids([int]$RootPid, $ExcludeSet) {
+    $out = New-Object System.Collections.Generic.List[int]
+    $queue = New-Object System.Collections.Generic.Queue[int]
+    $seen = @{}
+    $queue.Enqueue($RootPid)
+    $seen[$RootPid] = $true
+    while ($queue.Count -gt 0) {
+        $currentPid = $queue.Dequeue()
+        if (-not $ExcludeSet.ContainsKey($currentPid)) {
+            $out.Add($currentPid) | Out-Null
+        }
+        $children = Get-CimInstance Win32_Process -Filter "ParentProcessId=$currentPid" -ErrorAction SilentlyContinue
+        foreach ($child in $children) {
+            $cid = [int]$child.ProcessId
+            if ($seen.ContainsKey($cid)) { continue }
+            $seen[$cid] = $true
+            if ($ExcludeSet.ContainsKey($cid)) { continue }
+            $queue.Enqueue($cid)
+        }
+    }
+    return $out
 }
 
-$installDir = [string]$manifest.install_dir
-$zipPath = [string]$manifest.zip_path
-$expectedSha = ([string]$manifest.sha256).ToLowerInvariant()
-$version = [string]$manifest.version
-$serverPid = [int]$manifest.server_pid
-$trayPid = [int]$manifest.tray_pid
-
-if (-not $installDir -or -not (Test-Path -LiteralPath $installDir)) {
-    Fail "Install dir missing"
-}
-if (-not (Test-Path -LiteralPath (Join-Path $installDir "BAKLOG.exe"))) {
-    Fail "Install dir is not a BAKLOG bundle"
-}
-if (-not $zipPath -or -not (Test-Path -LiteralPath $zipPath)) {
-    Fail "Update zip missing"
-}
-if ($expectedSha -notmatch '^[0-9a-f]{64}$') {
-    Fail "Expected sha256 invalid"
-}
-
-$actualSha = Get-FileSha256 $zipPath
-if ($actualSha -ne $expectedSha) {
-    Fail "Update zip sha256 mismatch"
-}
-
-$zipFull = [System.IO.Path]::GetFullPath($zipPath)
-if (-not $zipFull.StartsWith($script:UpdateRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
-    Fail "Zip path outside trusted update workspace"
+function Stop-ProcessTreeExcludingSelf([int]$RootPid) {
+    if ($RootPid -le 0) { return }
+    $exclude = Get-AncestorPidSet -StartPid $PID
+    $exclude[$PID] = $true
+    $targets = Get-DescendantPids -RootPid $RootPid -ExcludeSet $exclude
+    # Kill leaves first (reverse of BFS discovery order is approximate; force each).
+    for ($i = $targets.Count - 1; $i -ge 0; $i--) {
+        $tid = $targets[$i]
+        if ($tid -eq $PID) { continue }
+        if ($exclude.ContainsKey($tid)) { continue }
+        Stop-Process -Id $tid -Force -ErrorAction SilentlyContinue
+    }
 }
 
 function Wait-ProcessGone([int]$ProcessId, [int]$TimeoutSec) {
     if ($ProcessId -le 0) { return }
+    if ($ProcessId -eq $PID) { return }
     $deadline = (Get-Date).AddSeconds($TimeoutSec)
     while ((Get-Date) -lt $deadline) {
         if (-not (Get-Process -Id $ProcessId -ErrorAction SilentlyContinue)) { return }
         Start-Sleep -Milliseconds 250
     }
-    Stop-Process -Id $ProcessId -Force -ErrorAction SilentlyContinue
+    if ($ProcessId -ne $PID) {
+        Stop-Process -Id $ProcessId -Force -ErrorAction SilentlyContinue
+    }
 }
 
-function Kill-ProcessTree([int]$ProcessId) {
-    if ($ProcessId -le 0) { return }
-    # Tree-kill the process and all its children (fetchers, browser windows, etc.)
-    taskkill /F /T /PID $ProcessId 2>&1 | Out-Null
+function Start-TrayIfPresent {
+    if (-not $script:InstallDir) { return }
+    $trayExePath = Join-Path $script:InstallDir "BAKLOG Tray.exe"
+    if (Test-Path -LiteralPath $trayExePath) {
+        Write-ApplyLog "relaunching tray: $trayExePath"
+        Start-Process -FilePath $trayExePath -WorkingDirectory $script:InstallDir | Out-Null
+    } else {
+        Write-ApplyLog "tray exe missing; cannot relaunch"
+    }
 }
 
-# Apply is launched detached from BAKLOG.exe. Stop the tray tree first (it owns
-# the server); waiting alone used to leave the tray watchdog free to respawn
-# BAKLOG.exe and lock install files during copy.
-Kill-ProcessTree -ProcessId $trayPid
-Kill-ProcessTree -ProcessId $serverPid
-Wait-ProcessGone -ProcessId $serverPid -TimeoutSec 45
-Wait-ProcessGone -ProcessId $trayPid -TimeoutSec 15
-Kill-ProcessTree -ProcessId $trayPid
-Kill-ProcessTree -ProcessId $serverPid
-
-$staging = Join-Path $script:UpdateRoot ("staging-" + [Guid]::NewGuid().ToString("n"))
-New-Item -ItemType Directory -Path $staging | Out-Null
-$backupDir = $null
+# --- main ---
+Write-ApplyLog "apply_update.ps1 start pid=$PID manifest=$ManifestPath"
+Write-ApplyStarted
+Touch-ApplyingLock
 
 try {
-    Expand-Archive -LiteralPath $zipPath -DestinationPath $staging -Force
-
-    $bundleRoot = $null
-    $bundleExe = Get-ChildItem -Path $staging -Recurse -Filter "BAKLOG.exe" -File |
-        Where-Object {
-            Test-Path -LiteralPath (Join-Path $_.Directory.FullName "BAKLOG Tray.exe")
-        } |
-        Select-Object -First 1
-    if ($bundleExe) {
-        $bundleRoot = $bundleExe.Directory.FullName
+    if (-not (Test-Path -LiteralPath $ManifestPath)) {
+        throw "Manifest not found"
     }
-    if (-not $bundleRoot) {
-        Fail "Extracted bundle layout invalid"
-    }
-
-    $installParent = [System.IO.Path]::GetDirectoryName($installDir)
-    $backupDir = Join-Path $installParent ("BAKLOG-backup-" + (Get-Date -Format "yyyyMMdd-HHmmss"))
-    Copy-Item -LiteralPath $installDir -Destination $backupDir -Recurse -Force
 
     try {
-        Get-ChildItem -LiteralPath $bundleRoot -Force | ForEach-Object {
-            $dest = Join-Path $installDir $_.Name
-            if ($_.PSIsContainer) {
-                if (Test-Path -LiteralPath $dest) {
-                    Remove-Item -LiteralPath $dest -Recurse -Force
-                }
-                Copy-Item -LiteralPath $_.FullName -Destination $dest -Recurse -Force
-            } else {
-                Copy-Item -LiteralPath $_.FullName -Destination $dest -Force
-            }
-        }
+        $manifest = Get-Content -LiteralPath $ManifestPath -Raw -Encoding UTF8 | ConvertFrom-Json
     } catch {
-        $restored = Restore-InstallFromBackup -InstallDir $installDir -BackupDir $backupDir
-        Write-ApplyResult -Ok $false -ErrorMessage $_.Exception.Message -Version $version -Restored $restored
-        exit 1
+        throw "Manifest JSON invalid"
     }
 
-    $trayExePath = Join-Path $installDir "BAKLOG Tray.exe"
-    if (-not (Test-Path -LiteralPath $trayExePath)) {
-        $restored = Restore-InstallFromBackup -InstallDir $installDir -BackupDir $backupDir
-        Write-ApplyResult -Ok $false -ErrorMessage "Updated bundle missing tray launcher" -Version $version -Restored $restored
-        exit 1
+    $installDir = [string]$manifest.install_dir
+    $zipPath = [string]$manifest.zip_path
+    $expectedSha = ([string]$manifest.sha256).ToLowerInvariant()
+    $script:Version = [string]$manifest.version
+    $serverPid = [int]$manifest.server_pid
+    $trayPid = [int]$manifest.tray_pid
+    $script:InstallDir = $installDir
+
+    Write-ApplyStarted
+    Touch-ApplyingLock
+    Write-ApplyLog "validate install=$installDir version=$($script:Version) trayPid=$trayPid serverPid=$serverPid"
+
+    if (-not $installDir -or -not (Test-Path -LiteralPath $installDir)) {
+        throw "Install dir missing"
+    }
+    if (-not (Test-Path -LiteralPath (Join-Path $installDir "BAKLOG.exe"))) {
+        throw "Install dir is not a BAKLOG bundle"
+    }
+    if (-not $zipPath -or -not (Test-Path -LiteralPath $zipPath)) {
+        throw "Update zip missing"
+    }
+    if ($expectedSha -notmatch '^[0-9a-f]{64}$') {
+        throw "Expected sha256 invalid"
     }
 
-    Remove-OldBackups -InstallParent $installParent -KeepBackup $backupDir
-    Write-ApplyResult -Ok $true -Version $version -Restored $false
-    # Drop ready package so the relaunched app does not rehydrate Install & restart.
-    $versionDir = Join-Path $script:UpdateRoot $version
-    if (Test-Path -LiteralPath $versionDir) {
-        Remove-Item -LiteralPath (Join-Path $versionDir "ready.json") -Force -ErrorAction SilentlyContinue
-        Remove-Item -LiteralPath (Join-Path $versionDir "package.zip") -Force -ErrorAction SilentlyContinue
-        Remove-Item -LiteralPath (Join-Path $versionDir "apply-manifest.json") -Force -ErrorAction SilentlyContinue
-        try { Remove-Item -LiteralPath $versionDir -Force -ErrorAction SilentlyContinue } catch {}
+    $actualSha = Get-FileSha256 $zipPath
+    if ($actualSha -ne $expectedSha) {
+        throw "Update zip sha256 mismatch"
     }
-    Start-Process -FilePath $trayExePath -WorkingDirectory $installDir | Out-Null
-} finally {
-    if (Test-Path -LiteralPath $staging) {
-        Remove-Item -LiteralPath $staging -Recurse -Force -ErrorAction SilentlyContinue
+
+    $zipFull = [System.IO.Path]::GetFullPath($zipPath)
+    if (-not $zipFull.StartsWith($script:UpdateRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Zip path outside trusted update workspace"
     }
+
+    # Apply helper is a descendant of tray→server. Never tree-kill via the OS
+    # task-kill utility — it would kill this script. Walk Win32_Process and skip
+    # our own PID/ancestors.
+    Write-ApplyLog "killing tray/server trees (excluding apply pid=$PID)"
+    Stop-ProcessTreeExcludingSelf -RootPid $trayPid
+    Stop-ProcessTreeExcludingSelf -RootPid $serverPid
+    $script:KilledApps = $true
+    Wait-ProcessGone -ProcessId $serverPid -TimeoutSec 45
+    Wait-ProcessGone -ProcessId $trayPid -TimeoutSec 15
+    Stop-ProcessTreeExcludingSelf -RootPid $trayPid
+    Stop-ProcessTreeExcludingSelf -RootPid $serverPid
+    Touch-ApplyingLock
+    Write-ApplyLog "kill phase complete"
+
+    $staging = Join-Path $script:UpdateRoot ("staging-" + [Guid]::NewGuid().ToString("n"))
+    New-Item -ItemType Directory -Path $staging | Out-Null
+    try {
+        Write-ApplyLog "extracting zip to $staging"
+        Expand-ZipDotNet -ZipPath $zipPath -Destination $staging
+        Touch-ApplyingLock
+
+        $bundleRoot = $null
+        $bundleExe = Get-ChildItem -Path $staging -Recurse -Filter "BAKLOG.exe" -File |
+            Where-Object {
+                Test-Path -LiteralPath (Join-Path $_.Directory.FullName "BAKLOG Tray.exe")
+            } |
+            Select-Object -First 1
+        if ($bundleExe) {
+            $bundleRoot = $bundleExe.Directory.FullName
+        }
+        if (-not $bundleRoot) {
+            throw "Extracted bundle layout invalid"
+        }
+
+        $installParent = [System.IO.Path]::GetDirectoryName($installDir)
+        $script:BackupDir = Join-Path $installParent ("BAKLOG-backup-" + (Get-Date -Format "yyyyMMdd-HHmmss"))
+        Write-ApplyLog "backup to $($script:BackupDir)"
+        Copy-Item -LiteralPath $installDir -Destination $script:BackupDir -Recurse -Force
+        Touch-ApplyingLock
+
+        try {
+            $script:CopyStarted = $true
+            Write-ApplyLog "copying bundle overlay"
+            Get-ChildItem -LiteralPath $bundleRoot -Force | ForEach-Object {
+                $dest = Join-Path $installDir $_.Name
+                if ($_.PSIsContainer) {
+                    if (Test-Path -LiteralPath $dest) {
+                        Remove-Item -LiteralPath $dest -Recurse -Force
+                    }
+                    Copy-Item -LiteralPath $_.FullName -Destination $dest -Recurse -Force
+                } else {
+                    Copy-Item -LiteralPath $_.FullName -Destination $dest -Force
+                }
+            }
+        } catch {
+            $restored = Restore-InstallFromBackup -InstallDir $installDir -BackupDir $script:BackupDir
+            Write-ApplyResult -Ok $false -ErrorMessage $_.Exception.Message -Version $script:Version -Restored $restored
+            Start-TrayIfPresent
+            exit 1
+        }
+
+        $trayExePath = Join-Path $installDir "BAKLOG Tray.exe"
+        if (-not (Test-Path -LiteralPath $trayExePath)) {
+            $restored = Restore-InstallFromBackup -InstallDir $installDir -BackupDir $script:BackupDir
+            Write-ApplyResult -Ok $false -ErrorMessage "Updated bundle missing tray launcher" -Version $script:Version -Restored $restored
+            Start-TrayIfPresent
+            exit 1
+        }
+
+        Remove-OldBackups -InstallParent $installParent -KeepBackup $script:BackupDir
+        Write-ApplyResult -Ok $true -Version $script:Version -Restored $false
+        # Drop ready package so the relaunched app does not rehydrate Install & restart.
+        $versionDir = Join-Path $script:UpdateRoot $script:Version
+        if (Test-Path -LiteralPath $versionDir) {
+            Remove-Item -LiteralPath (Join-Path $versionDir "ready.json") -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath (Join-Path $versionDir "package.zip") -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath (Join-Path $versionDir "apply-manifest.json") -Force -ErrorAction SilentlyContinue
+            try { Remove-Item -LiteralPath $versionDir -Force -ErrorAction SilentlyContinue } catch {}
+        }
+        Write-ApplyLog "starting tray"
+        Start-Process -FilePath $trayExePath -WorkingDirectory $installDir | Out-Null
+    } finally {
+        if (Test-Path -LiteralPath $staging) {
+            Remove-Item -LiteralPath $staging -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+} catch {
+    $msg = $_.Exception.Message
+    if (-not $msg) { $msg = "$_" }
+    Write-ApplyLog "FATAL: $msg"
+    $restored = $false
+    if ($script:CopyStarted -and $script:BackupDir -and $script:InstallDir) {
+        $restored = Restore-InstallFromBackup -InstallDir $script:InstallDir -BackupDir $script:BackupDir
+    }
+    Write-ApplyResult -Ok $false -ErrorMessage $msg -Version $script:Version -Restored $restored
+    if ($script:KilledApps) {
+        Start-TrayIfPresent
+    }
+    exit 1
 }
 
 exit 0

--- a/packaging/apply_update.sh
+++ b/packaging/apply_update.sh
@@ -1,18 +1,65 @@
 #!/usr/bin/env bash
 # Apply a verified BAKLOG release zip over an existing install (macOS).
 # Invoked by the local server after security checks — not for manual arbitrary use.
-set -euo pipefail
+set -uo pipefail
 
 UPDATE_ROOT="${TMPDIR:-/tmp}/BAKLOG-update"
 mkdir -p "$UPDATE_ROOT"
+APPLY_LOG="$UPDATE_ROOT/apply.log"
+KILLED_APPS=0
+INSTALL_DIR=""
+BACKUP_DIR=""
+COPY_STARTED=0
+RESULT_WRITTEN=0
+VERSION=""
+
+write_apply_log() {
+  local ts
+  ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  echo "[$ts] $*" | tee -a "$APPLY_LOG" >&2
+}
+
+write_apply_started() {
+  cat >"$UPDATE_ROOT/apply-started.json" <<EOF
+{
+  "pid": $$,
+  "written_at": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+  "version": "$VERSION"
+}
+EOF
+}
+
+clear_apply_started() {
+  rm -f "$UPDATE_ROOT/apply-started.json"
+}
+
+touch_applying_lock() {
+  if [[ -f "$UPDATE_ROOT/applying.lock" ]]; then
+    touch "$UPDATE_ROOT/applying.lock"
+  else
+    cat >"$UPDATE_ROOT/applying.lock" <<EOF
+{
+  "version": "$VERSION",
+  "written_at": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+}
+EOF
+  fi
+}
 
 write_apply_result() {
   local ok="$1"
   local err="${2:-}"
   local version="${3:-}"
   local restored="${4:-false}"
+  if [[ "$RESULT_WRITTEN" -eq 1 ]]; then
+    return 0
+  fi
+  RESULT_WRITTEN=1
   local finished
   finished="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  # Escape quotes in error for JSON
+  err="${err//\\/\\\\}"
+  err="${err//\"/\\\"}"
   cat >"$UPDATE_ROOT/apply-result.json" <<EOF
 {
   "ok": $ok,
@@ -23,11 +70,16 @@ write_apply_result() {
 }
 EOF
   rm -f "$UPDATE_ROOT/applying.lock"
+  clear_apply_started
+  write_apply_log "result ok=$ok version=$version error=$err restored=$restored"
 }
 
 fail() {
-  write_apply_result false "$1" "" false
-  echo "apply_update.sh: $*" >&2
+  write_apply_result false "$1" "$VERSION" false
+  write_apply_log "fail: $*"
+  if [[ "$KILLED_APPS" -eq 1 ]]; then
+    start_tray_if_present
+  fi
   exit 1
 }
 
@@ -67,6 +119,62 @@ remove_old_backups() {
   done
 }
 
+start_tray_if_present() {
+  if [[ -z "$INSTALL_DIR" ]]; then
+    return 0
+  fi
+  if [[ -x "$INSTALL_DIR/BAKLOG Tray" ]]; then
+    write_apply_log "relaunching tray"
+    (
+      cd "$INSTALL_DIR"
+      exec "./BAKLOG Tray" >/dev/null 2>&1 &
+    )
+  else
+    write_apply_log "tray binary missing; cannot relaunch"
+  fi
+}
+
+wait_pid_gone() {
+  local pid="$1"
+  local timeout="$2"
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 0
+  [[ "$pid" -le 0 ]] && return 0
+  [[ "$pid" -eq $$ ]] && return 0
+  local i=0
+  while kill -0 "$pid" 2>/dev/null; do
+    if (( i >= timeout * 4 )); then
+      kill -TERM "$pid" 2>/dev/null || true
+      sleep 1
+      kill -KILL "$pid" 2>/dev/null || true
+      return 0
+    fi
+    sleep 0.25
+    i=$((i + 1))
+  done
+}
+
+kill_pid_tree() {
+  local pid="$1"
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 0
+  [[ "$pid" -le 0 ]] && return 0
+  [[ "$pid" -eq $$ ]] && return 0
+  # Best-effort: kill descendants then the root (tray owns the server child).
+  # Skip our own PID so a new-session helper is never self-killed.
+  if command -v pkill >/dev/null 2>&1; then
+    pkill -TERM -P "$pid" 2>/dev/null || true
+  fi
+  kill -TERM "$pid" 2>/dev/null || true
+  sleep 0.5
+  if command -v pkill >/dev/null 2>&1; then
+    pkill -KILL -P "$pid" 2>/dev/null || true
+  fi
+  kill -KILL "$pid" 2>/dev/null || true
+}
+
+write_apply_log "apply_update.sh start pid=$$"
+write_apply_started
+touch_applying_lock
+
 MANIFEST_PATH="${1:-}"
 [[ -n "$MANIFEST_PATH" && -f "$MANIFEST_PATH" ]] || fail "Manifest not found"
 
@@ -78,6 +186,10 @@ SERVER_PID="$(json_field_int "$MANIFEST_PATH" server_pid)"
 TRAY_PID="$(json_field_int "$MANIFEST_PATH" tray_pid)"
 SERVER_PID="${SERVER_PID:-0}"
 TRAY_PID="${TRAY_PID:-0}"
+
+write_apply_started
+touch_applying_lock
+write_apply_log "validate install=$INSTALL_DIR version=$VERSION"
 
 [[ -n "$INSTALL_DIR" && -d "$INSTALL_DIR" ]] || fail "Install dir missing"
 [[ -f "$INSTALL_DIR/BAKLOG" ]] || fail "Install dir is not a BAKLOG bundle"
@@ -100,54 +212,28 @@ case "$ZIP_FULL" in
   *) fail "Zip path outside trusted update workspace" ;;
 esac
 
-wait_pid_gone() {
-  local pid="$1"
-  local timeout="$2"
-  [[ "$pid" =~ ^[0-9]+$ ]] || return 0
-  [[ "$pid" -le 0 ]] && return 0
-  local i=0
-  while kill -0 "$pid" 2>/dev/null; do
-    if (( i >= timeout * 4 )); then
-      kill -TERM "$pid" 2>/dev/null || true
-      sleep 1
-      kill -KILL "$pid" 2>/dev/null || true
-      return 0
-    fi
-    sleep 0.25
-    i=$((i + 1))
-  done
-}
-
-kill_pid_tree() {
-  local pid="$1"
-  [[ "$pid" =~ ^[0-9]+$ ]] || return 0
-  [[ "$pid" -le 0 ]] && return 0
-  # Best-effort: kill descendants then the root (tray owns the server child).
-  if command -v pkill >/dev/null 2>&1; then
-    pkill -TERM -P "$pid" 2>/dev/null || true
-  fi
-  kill -TERM "$pid" 2>/dev/null || true
-  sleep 0.5
-  if command -v pkill >/dev/null 2>&1; then
-    pkill -KILL -P "$pid" 2>/dev/null || true
-  fi
-  kill -KILL "$pid" 2>/dev/null || true
-}
-
-# Apply runs in a new session. Stop tray/server before copying so the tray
-# watchdog cannot respawn BAKLOG over locked install files.
+write_apply_log "killing tray/server trees"
 kill_pid_tree "$TRAY_PID"
 kill_pid_tree "$SERVER_PID"
+KILLED_APPS=1
 wait_pid_gone "$SERVER_PID" 45
 wait_pid_gone "$TRAY_PID" 15
 kill_pid_tree "$TRAY_PID"
 kill_pid_tree "$SERVER_PID"
+touch_applying_lock
 
 STAGING="$UPDATE_ROOT/staging-$$-$RANDOM"
 mkdir -p "$STAGING"
-trap 'rm -rf "$STAGING"' EXIT
+cleanup_staging() {
+  rm -rf "$STAGING"
+}
+trap cleanup_staging EXIT
 
-unzip -q "$ZIP_PATH" -d "$STAGING"
+write_apply_log "extracting zip"
+if ! unzip -q "$ZIP_PATH" -d "$STAGING"; then
+  fail "Failed to extract update zip"
+fi
+touch_applying_lock
 
 BUNDLE_ROOT=""
 while IFS= read -r -d '' candidate; do
@@ -161,8 +247,12 @@ done < <(find "$STAGING" -name BAKLOG -type f -print0)
 
 INSTALL_PARENT="$(dirname "$INSTALL_DIR")"
 BACKUP_DIR="$INSTALL_PARENT/BAKLOG-backup-$(date +%Y%m%d-%H%M%S)"
+write_apply_log "backup to $BACKUP_DIR"
 cp -R "$INSTALL_DIR" "$BACKUP_DIR"
+touch_applying_lock
 
+COPY_STARTED=1
+write_apply_log "copying bundle overlay"
 if ! (
   shopt -s dotglob nullglob
   for item in "$BUNDLE_ROOT"/*; do
@@ -177,6 +267,7 @@ if ! (
     restored=true
   fi
   write_apply_result false "Failed to copy update files" "$VERSION" "$restored"
+  start_tray_if_present
   exit 1
 fi
 
@@ -186,6 +277,7 @@ if [[ ! -f "$INSTALL_DIR/BAKLOG Tray" ]]; then
     restored=true
   fi
   write_apply_result false "Updated bundle missing tray launcher" "$VERSION" "$restored"
+  start_tray_if_present
   exit 1
 fi
 
@@ -199,6 +291,7 @@ if [[ -d "$VERSION_DIR" ]]; then
   rmdir "$VERSION_DIR" 2>/dev/null || true
 fi
 
+write_apply_log "starting tray"
 cd "$INSTALL_DIR"
 exec "./BAKLOG Tray" >/dev/null 2>&1 &
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["auth*", "clients*", "fetchers*", "enrichers*", "shared*"]
 
 [project]
 name = "steam-backlog"
-version = "0.8.37"
+version = "0.8.38"
 description = "Local multi-store game library dashboard and fetchers"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/shared/server_support.py
+++ b/shared/server_support.py
@@ -307,6 +307,26 @@ def build_diagnostics_payload(
     except Exception:  # noqa: BLE001
         update_status = None
 
+    from shared.update_ready_state import (
+        apply_log_tail,
+        applying_lock_age_sec,
+        default_work_root,
+        read_apply_result,
+        read_apply_started,
+    )
+
+    work_root = default_work_root()
+    apply_result = None
+    try:
+        apply_result = read_apply_result(work_root)
+    except Exception:  # noqa: BLE001
+        apply_result = None
+    apply_started = None
+    try:
+        apply_started = read_apply_started(work_root)
+    except Exception:  # noqa: BLE001
+        apply_started = None
+
     return {
         "version": version,
         "platform": sys.platform,
@@ -320,5 +340,9 @@ def build_diagnostics_payload(
         "apply_supported": _apply_supported_for_runtime(),
         "recommended_artifact": recommended_artifact(runtime_label()),
         "update": update_status,
+        "apply_result": apply_result,
+        "apply_started": apply_started,
+        "applying_lock_age_sec": applying_lock_age_sec(work_root),
+        "apply_log_tail": apply_log_tail(work_root),
         **install_visibility_fields(version),
     }

--- a/shared/update_manager.py
+++ b/shared/update_manager.py
@@ -21,10 +21,12 @@ from shared.update_platform import (
 )
 from shared.update_ready_state import (
     clear_apply_result,
+    clear_apply_started,
     clear_applying_lock,
     clear_ready_state,
     read_apply_result,
     scan_ready_state,
+    wait_for_apply_started,
     write_applying_lock,
     write_ready_state,
 )
@@ -302,6 +304,7 @@ class UpdateManager:
         manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
 
         clear_apply_result(self._work_root)
+        clear_apply_started(self._work_root)
         write_applying_lock(self._work_root, version=artifacts.version)
         self._set_status(phase="applying", can_apply=False, ready=False)
 
@@ -313,8 +316,22 @@ class UpdateManager:
             )
         except OSError as exc:
             clear_applying_lock(self._work_root)
+            clear_apply_started(self._work_root)
             self._set_status(phase="ready", ready=True, can_apply=True, error=str(exc))
             return {"ok": False, "error": f"Failed to launch updater: {exc}"}
+
+        # Do not shut down until the helper proves it started. DETACHED_PROCESS
+        # (and similar launch bugs) used to exit instantly with no apply work,
+        # leaving applying.lock and a dead server.
+        if not wait_for_apply_started(self._work_root):
+            clear_applying_lock(self._work_root)
+            clear_apply_started(self._work_root)
+            msg = (
+                "Updater helper did not start (no apply-started handshake). "
+                "The app was left running; check %TEMP%\\BAKLOG-update\\apply.log."
+            )
+            self._set_status(phase="ready", ready=True, can_apply=True, error=msg)
+            return {"ok": False, "error": msg}
 
         return {"ok": True, "applying": True, "version": artifacts.version}
 

--- a/shared/update_platform.py
+++ b/shared/update_platform.py
@@ -88,50 +88,66 @@ def tray_binary_name(platform: str | None = None) -> str:
     return required_bundle_files(platform)[1]
 
 
+def apply_log_path() -> Path:
+    """Shared apply helper log under the trusted update workspace."""
+    import tempfile
+
+    return Path(tempfile.gettempdir()) / "BAKLOG-update" / "apply.log"
+
+
 def launch_apply_subprocess(*, script: Path, manifest_path: Path, install_dir: Path) -> subprocess.Popen:
     """Launch the platform apply helper after server-side security checks.
 
-    The helper must outlive the shutting-down server (and survive tray tree-kill),
-    so it is started detached / in a new session — not as a child that dies with
-    BAKLOG.exe or gets swept by ``taskkill /T`` on the server PID.
+    On Windows, do **not** use DETACHED_PROCESS: powershell.exe exits immediately
+    with rc=0 when started that way (no console host), so the apply never runs.
+    CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP keeps the helper alive; the apply
+    script must exclude its own PID when killing the tray/server tree.
+    stdout/stderr append to apply.log for frozen-build diagnostics.
     """
     platform = sys.platform
-    if platform == "win32":
-        cmd = [
-            "powershell.exe",
-            "-NoProfile",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-File",
-            str(script),
-            "-ManifestPath",
-            str(manifest_path),
-        ]
-        # DETACHED_PROCESS + NEW_PROCESS_GROUP: apply is not in the tray→server tree.
-        flags = int(getattr(subprocess, "DETACHED_PROCESS", 0x00000008))
-        flags |= int(getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200))
-        flags |= int(getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000))
-        return subprocess.Popen(  # noqa: S603
-            cmd,
-            cwd=str(install_dir),
-            creationflags=flags,
-            close_fds=True,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-    if platform == "darwin":
-        cmd = [
-            "/bin/bash",
-            str(script),
-            str(manifest_path),
-        ]
-        return subprocess.Popen(  # noqa: S603
-            cmd,
-            cwd=str(install_dir),
-            start_new_session=True,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
+    log_path = apply_log_path()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_file = open(log_path, "a", encoding="utf-8")  # noqa: SIM115
+    try:
+        if platform == "win32":
+            cmd = [
+                "powershell.exe",
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                str(script),
+                "-ManifestPath",
+                str(manifest_path),
+            ]
+            # DETACHED_PROCESS (0x8) makes powershell exit instantly — never use it.
+            flags = int(getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200))
+            flags |= int(getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000))
+            return subprocess.Popen(  # noqa: S603
+                cmd,
+                cwd=str(install_dir),
+                creationflags=flags,
+                close_fds=True,
+                stdin=subprocess.DEVNULL,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+            )
+        if platform == "darwin":
+            cmd = [
+                "/bin/bash",
+                str(script),
+                str(manifest_path),
+            ]
+            return subprocess.Popen(  # noqa: S603
+                cmd,
+                cwd=str(install_dir),
+                start_new_session=True,
+                stdin=subprocess.DEVNULL,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+            )
+    except Exception:
+        log_file.close()
+        raise
+    log_file.close()
     raise OSError(f"In-app apply is not supported on {platform}")

--- a/shared/update_ready_state.py
+++ b/shared/update_ready_state.py
@@ -14,9 +14,14 @@ from shared.update_release import UpdateSecurityError, verify_file_sha256
 READY_FILENAME = "ready.json"
 APPLY_RESULT_FILENAME = "apply-result.json"
 APPLYING_LOCK_FILENAME = "applying.lock"
+APPLY_STARTED_FILENAME = "apply-started.json"
+APPLY_LOG_FILENAME = "apply.log"
 PACKAGE_NAME = "package.zip"
-# Stale lock TTL — if apply crashes without clearing, tray may auto-restart again.
-APPLYING_LOCK_MAX_AGE_SEC = 15 * 60
+# Stale lock TTL — apply script heartbeats the lock; keep short so a dead helper
+# cannot suppress the tray watchdog for long.
+APPLYING_LOCK_MAX_AGE_SEC = 120
+# How long the server waits for apply-started.json before aborting shutdown.
+APPLY_STARTED_WAIT_SEC = 8.0
 
 
 def default_work_root() -> Path:
@@ -39,6 +44,16 @@ def clear_applying_lock(work_root: Path | None = None) -> None:
     path.unlink(missing_ok=True)
 
 
+def applying_lock_age_sec(work_root: Path | None = None) -> float | None:
+    path = (work_root or default_work_root()) / APPLYING_LOCK_FILENAME
+    if not path.is_file():
+        return None
+    try:
+        return max(0.0, time.time() - path.stat().st_mtime)
+    except OSError:
+        return None
+
+
 def is_update_apply_in_progress(
     work_root: Path | None = None,
     *,
@@ -55,6 +70,53 @@ def is_update_apply_in_progress(
     if age < 0 or age > max_age_sec:
         return False
     return True
+
+
+def clear_apply_started(work_root: Path | None = None) -> None:
+    root = work_root or default_work_root()
+    (root / APPLY_STARTED_FILENAME).unlink(missing_ok=True)
+
+
+def read_apply_started(work_root: Path | None = None) -> dict[str, Any] | None:
+    root = (work_root or default_work_root()).resolve()
+    path = root / APPLY_STARTED_FILENAME
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def wait_for_apply_started(
+    work_root: Path | None = None,
+    *,
+    timeout_sec: float = APPLY_STARTED_WAIT_SEC,
+    poll_sec: float = 0.1,
+) -> bool:
+    """Block until apply-started.json appears or timeout. Returns True if seen."""
+    root = work_root or default_work_root()
+    deadline = time.monotonic() + max(0.0, timeout_sec)
+    while time.monotonic() < deadline:
+        if read_apply_started(root) is not None:
+            return True
+        time.sleep(poll_sec)
+    return read_apply_started(root) is not None
+
+
+def apply_log_tail(work_root: Path | None = None, *, max_chars: int = 4000) -> str:
+    root = work_root or default_work_root()
+    path = root / APPLY_LOG_FILENAME
+    if not path.is_file():
+        return ""
+    try:
+        text = path.read_text(encoding="utf-8-sig", errors="replace")
+    except OSError:
+        return ""
+    if len(text) <= max_chars:
+        return text
+    return text[-max_chars:]
 
 
 def write_ready_state(
@@ -113,6 +175,7 @@ def clear_apply_result(work_root: Path | None = None) -> None:
     root = work_root or default_work_root()
     (root / APPLY_RESULT_FILENAME).unlink(missing_ok=True)
     clear_applying_lock(root)
+    clear_apply_started(root)
 
 
 def scan_ready_state(work_root: Path) -> dict[str, Any] | None:

--- a/tailwind.css
+++ b/tailwind.css
@@ -1,4 +1,4 @@
-/*! tailwindcss v4.3.0 | MIT License | https://tailwindcss.com */
+/*! tailwindcss v4.3.1 | MIT License | https://tailwindcss.com */
 @layer properties;
 @layer theme, base, components, utilities;
 @layer theme {
@@ -31,9 +31,13 @@
     --color-sky-400: oklch(74.6% 0.16 232.661);
     --color-sky-500: oklch(68.5% 0.169 237.323);
     --color-sky-600: oklch(58.8% 0.158 241.966);
+    --color-sky-700: oklch(50% 0.134 242.749);
+    --color-violet-200: oklch(89.4% 0.057 293.283);
     --color-purple-400: oklch(71.4% 0.203 305.504);
     --color-rose-100: oklch(94.1% 0.03 12.58);
+    --color-rose-200: oklch(89.2% 0.058 10.001);
     --color-rose-300: oklch(81% 0.117 11.638);
+    --color-rose-500: oklch(64.5% 0.246 16.439);
     --color-rose-600: oklch(58.6% 0.253 17.585);
     --color-rose-700: oklch(51.4% 0.222 16.935);
     --color-rose-800: oklch(45.5% 0.188 13.697);
@@ -52,6 +56,7 @@
     --spacing: 0.25rem;
     --container-sm: 24rem;
     --container-md: 28rem;
+    --container-lg: 32rem;
     --container-2xl: 42rem;
     --text-xs: 0.75rem;
     --text-xs--line-height: calc(1 / 0.75);
@@ -232,6 +237,9 @@
   .collapse {
     visibility: collapse;
   }
+  .invisible {
+    visibility: hidden;
+  }
   .visible {
     visibility: visible;
   }
@@ -262,25 +270,25 @@
     position: sticky;
   }
   .inset-0 {
-    inset: calc(var(--spacing) * 0);
+    inset: 0;
   }
   .top-0 {
-    top: calc(var(--spacing) * 0);
-  }
-  .top-20 {
-    top: calc(var(--spacing) * 20);
+    top: 0;
   }
   .top-full {
     top: 100%;
   }
   .right-0 {
-    right: calc(var(--spacing) * 0);
+    right: 0;
   }
   .bottom-0 {
-    bottom: calc(var(--spacing) * 0);
+    bottom: 0;
   }
   .left-0 {
-    left: calc(var(--spacing) * 0);
+    left: 0;
+  }
+  .isolate {
+    isolation: isolate;
   }
   .z-10 {
     z-index: 10;
@@ -319,7 +327,10 @@
     }
   }
   .m-0 {
-    margin: calc(var(--spacing) * 0);
+    margin: 0;
+  }
+  .mx-4 {
+    margin-inline: calc(var(--spacing) * 4);
   }
   .mx-auto {
     margin-inline: auto;
@@ -328,13 +339,19 @@
     margin-top: calc(var(--spacing) * 0.5);
   }
   .mt-1 {
-    margin-top: calc(var(--spacing) * 1);
+    margin-top: var(--spacing);
   }
   .mt-2 {
     margin-top: calc(var(--spacing) * 2);
   }
   .mt-3 {
     margin-top: calc(var(--spacing) * 3);
+  }
+  .mt-4 {
+    margin-top: calc(var(--spacing) * 4);
+  }
+  .mt-6 {
+    margin-top: calc(var(--spacing) * 6);
   }
   .mt-8 {
     margin-top: calc(var(--spacing) * 8);
@@ -355,7 +372,7 @@
     margin-left: calc(var(--spacing) * 0.5);
   }
   .ml-1 {
-    margin-left: calc(var(--spacing) * 1);
+    margin-left: var(--spacing);
   }
   .ml-2 {
     margin-left: calc(var(--spacing) * 2);
@@ -378,6 +395,9 @@
   .hidden {
     display: none;
   }
+  .hidden\! {
+    display: none !important;
+  }
   .inline {
     display: inline;
   }
@@ -390,11 +410,17 @@
   .table {
     display: table;
   }
+  .table-row {
+    display: table-row;
+  }
   .h-10 {
     height: calc(var(--spacing) * 10);
   }
   .h-full {
     height: 100%;
+  }
+  .max-h-64 {
+    max-height: calc(var(--spacing) * 64);
   }
   .max-h-\[85vh\] {
     max-height: 85vh;
@@ -423,6 +449,9 @@
   .max-w-\[1600px\] {
     max-width: 1600px;
   }
+  .max-w-lg {
+    max-width: var(--container-lg);
+  }
   .max-w-md {
     max-width: var(--container-md);
   }
@@ -430,7 +459,7 @@
     max-width: var(--container-sm);
   }
   .min-w-0 {
-    min-width: calc(var(--spacing) * 0);
+    min-width: 0;
   }
   .min-w-\[180px\] {
     min-width: 180px;
@@ -502,7 +531,7 @@
     gap: calc(var(--spacing) * 0.5);
   }
   .gap-1 {
-    gap: calc(var(--spacing) * 1);
+    gap: var(--spacing);
   }
   .gap-1\.5 {
     gap: calc(var(--spacing) * 1.5);
@@ -519,15 +548,15 @@
   .space-y-0 {
     :where(& > :not(:last-child)) {
       --tw-space-y-reverse: 0;
-      margin-block-start: calc(calc(var(--spacing) * 0) * var(--tw-space-y-reverse));
-      margin-block-end: calc(calc(var(--spacing) * 0) * calc(1 - var(--tw-space-y-reverse)));
+      margin-block-start: 0;
+      margin-block-end: 0;
     }
   }
   .space-y-1 {
     :where(& > :not(:last-child)) {
       --tw-space-y-reverse: 0;
-      margin-block-start: calc(calc(var(--spacing) * 1) * var(--tw-space-y-reverse));
-      margin-block-end: calc(calc(var(--spacing) * 1) * calc(1 - var(--tw-space-y-reverse)));
+      margin-block-start: calc(var(--spacing) * var(--tw-space-y-reverse));
+      margin-block-end: calc(var(--spacing) * calc(1 - var(--tw-space-y-reverse)));
     }
   }
   .space-y-2 {
@@ -642,6 +671,9 @@
       border-color: color-mix(in oklab, var(--color-rose-700) 60%, transparent);
     }
   }
+  .border-slate-500 {
+    border-color: var(--color-slate-500);
+  }
   .border-slate-600 {
     border-color: var(--color-slate-600);
   }
@@ -675,6 +707,12 @@
       background-color: color-mix(in oklab, var(--color-black) 50%, transparent);
     }
   }
+  .bg-black\/60 {
+    background-color: color-mix(in srgb, #000 60%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-black) 60%, transparent);
+    }
+  }
   .bg-black\/70 {
     background-color: color-mix(in srgb, #000 70%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -693,6 +731,9 @@
   .bg-orange-800 {
     background-color: var(--color-orange-800);
   }
+  .bg-rose-600 {
+    background-color: var(--color-rose-600);
+  }
   .bg-rose-700 {
     background-color: var(--color-rose-700);
   }
@@ -704,6 +745,9 @@
   }
   .bg-sky-600 {
     background-color: var(--color-sky-600);
+  }
+  .bg-sky-700 {
+    background-color: var(--color-sky-700);
   }
   .bg-slate-700 {
     background-color: var(--color-slate-700);
@@ -726,6 +770,12 @@
       background-color: color-mix(in oklab, var(--color-slate-900) 40%, transparent);
     }
   }
+  .bg-slate-900\/80 {
+    background-color: color-mix(in srgb, oklch(20.8% 0.042 265.755) 80%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-slate-900) 80%, transparent);
+    }
+  }
   .bg-transparent {
     background-color: transparent;
   }
@@ -733,7 +783,7 @@
     object-fit: cover;
   }
   .p-0 {
-    padding: calc(var(--spacing) * 0);
+    padding: 0;
   }
   .p-2 {
     padding: calc(var(--spacing) * 2);
@@ -744,8 +794,11 @@
   .p-4 {
     padding: calc(var(--spacing) * 4);
   }
+  .p-6 {
+    padding: calc(var(--spacing) * 6);
+  }
   .px-1 {
-    padding-inline: calc(var(--spacing) * 1);
+    padding-inline: var(--spacing);
   }
   .px-1\.5 {
     padding-inline: calc(var(--spacing) * 1.5);
@@ -766,7 +819,7 @@
     padding-block: calc(var(--spacing) * 0.5);
   }
   .py-1 {
-    padding-block: calc(var(--spacing) * 1);
+    padding-block: var(--spacing);
   }
   .py-1\.5 {
     padding-block: calc(var(--spacing) * 1.5);
@@ -856,6 +909,9 @@
   .whitespace-nowrap {
     white-space: nowrap;
   }
+  .whitespace-pre-wrap {
+    white-space: pre-wrap;
+  }
   .text-amber-100 {
     color: var(--color-amber-100);
   }
@@ -924,6 +980,9 @@
   }
   .text-slate-600 {
     color: var(--color-slate-600);
+  }
+  .text-violet-200 {
+    color: var(--color-violet-200);
   }
   .text-white {
     color: var(--color-white);
@@ -1005,6 +1064,9 @@
     -webkit-user-select: all;
     user-select: all;
   }
+  .block-1 {
+    block-size: var(--spacing);
+  }
   .backdrop\:bg-black\/60 {
     &::backdrop {
       background-color: color-mix(in srgb, #000 60%, transparent);
@@ -1048,6 +1110,13 @@
       }
     }
   }
+  .hover\:bg-rose-500 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-rose-500);
+      }
+    }
+  }
   .hover\:bg-rose-600 {
     &:hover {
       @media (hover: hover) {
@@ -1066,6 +1135,13 @@
     &:hover {
       @media (hover: hover) {
         background-color: var(--color-sky-500);
+      }
+    }
+  }
+  .hover\:bg-sky-600 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-sky-600);
       }
     }
   }
@@ -1110,6 +1186,13 @@
         @supports (color: color-mix(in lab, red, red)) {
           background-color: color-mix(in oklab, var(--color-slate-700) 60%, transparent);
         }
+      }
+    }
+  }
+  .hover\:text-rose-200 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-rose-200);
       }
     }
   }

--- a/tests/test_apply_update_ps1.py
+++ b/tests/test_apply_update_ps1.py
@@ -16,36 +16,50 @@ REPO = Path(__file__).resolve().parents[1]
 APPLY_PS1 = REPO / "packaging" / "apply_update.ps1"
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="Windows apply script only")
-def test_apply_update_ps1_replaces_install_and_writes_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def _skip_start_process(script_text: str) -> str:
+    return script_text.replace(
+        "Start-Process -FilePath $trayExePath -WorkingDirectory $script:InstallDir | Out-Null",
+        "# test harness: skip Start-Process",
+    ).replace(
+        "Start-Process -FilePath $trayExePath -WorkingDirectory $installDir | Out-Null",
+        "# test harness: skip Start-Process",
+    )
+
+
+def _make_bundle_zip(tmp_path: Path, *, include_tray: bool = True) -> tuple[Path, str]:
     update_root = tmp_path / "BAKLOG-update"
-    update_root.mkdir()
-    monkeypatch.setenv("TEMP", str(tmp_path))
-    monkeypatch.setenv("TMP", str(tmp_path))
-
-    install = tmp_path / "install" / "BAKLOG"
-    install.mkdir(parents=True)
-    (install / "BAKLOG.exe").write_bytes(b"old-server")
-    (install / "BAKLOG Tray.exe").write_bytes(b"old-tray")
-    (install / "old.txt").write_text("keep-me-gone", encoding="utf-8")
-
+    update_root.mkdir(exist_ok=True)
     bundle = tmp_path / "bundle" / "BAKLOG"
     bundle.mkdir(parents=True)
     (bundle / "BAKLOG.exe").write_bytes(b"new-server")
-    (bundle / "BAKLOG Tray.exe").write_bytes(b"new-tray")
+    if include_tray:
+        (bundle / "BAKLOG Tray.exe").write_bytes(b"new-tray")
     (bundle / "apply_update.ps1").write_text("# new", encoding="utf-8")
     (bundle / "fresh.txt").write_text("from-update", encoding="utf-8")
 
     version = "9.9.9-test"
     version_dir = update_root / version
-    version_dir.mkdir()
+    version_dir.mkdir(exist_ok=True)
     zip_path = version_dir / "package.zip"
     with zipfile.ZipFile(zip_path, "w") as zf:
         for path in bundle.rglob("*"):
             if path.is_file():
                 zf.write(path, arcname=str(Path("BAKLOG") / path.relative_to(bundle)))
-
     sha256 = hashlib.sha256(zip_path.read_bytes()).hexdigest()
+    return zip_path, sha256
+
+
+def _run_apply(
+    tmp_path: Path,
+    *,
+    install: Path,
+    zip_path: Path,
+    sha256: str,
+    version: str = "9.9.9-test",
+) -> subprocess.CompletedProcess[str]:
+    update_root = tmp_path / "BAKLOG-update"
+    version_dir = update_root / version
+    version_dir.mkdir(parents=True, exist_ok=True)
     manifest = version_dir / "apply-manifest.json"
     manifest.write_text(
         json.dumps(
@@ -61,17 +75,9 @@ def test_apply_update_ps1_replaces_install_and_writes_result(tmp_path: Path, mon
         encoding="utf-8",
     )
     (update_root / "applying.lock").write_text('{"version":"9.9.9-test"}', encoding="utf-8")
-
-    # Avoid launching the fake tray binary via Start-Process.
-    script_text = APPLY_PS1.read_text(encoding="utf-8")
-    patched = script_text.replace(
-        "Start-Process -FilePath $trayExePath -WorkingDirectory $installDir | Out-Null",
-        "# test harness: skip Start-Process",
-    )
     harness = tmp_path / "apply_harness.ps1"
-    harness.write_text(patched, encoding="utf-8")
-
-    proc = subprocess.run(
+    harness.write_text(_skip_start_process(APPLY_PS1.read_text(encoding="utf-8")), encoding="utf-8")
+    return subprocess.run(
         [
             "powershell.exe",
             "-NoProfile",
@@ -87,6 +93,21 @@ def test_apply_update_ps1_replaces_install_and_writes_result(tmp_path: Path, mon
         text=True,
         env={**os.environ, "TEMP": str(tmp_path), "TMP": str(tmp_path)},
     )
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows apply script only")
+def test_apply_update_ps1_replaces_install_and_writes_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEMP", str(tmp_path))
+    monkeypatch.setenv("TMP", str(tmp_path))
+
+    install = tmp_path / "install" / "BAKLOG"
+    install.mkdir(parents=True)
+    (install / "BAKLOG.exe").write_bytes(b"old-server")
+    (install / "BAKLOG Tray.exe").write_bytes(b"old-tray")
+    (install / "old.txt").write_text("keep-me-gone", encoding="utf-8")
+
+    zip_path, sha256 = _make_bundle_zip(tmp_path)
+    proc = _run_apply(tmp_path, install=install, zip_path=zip_path, sha256=sha256)
     assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
 
     assert (install / "BAKLOG.exe").read_bytes() == b"new-server"
@@ -95,9 +116,85 @@ def test_apply_update_ps1_replaces_install_and_writes_result(tmp_path: Path, mon
     # Overlay copy keeps install-only files; full wipe is not part of apply.
     assert (install / "old.txt").read_text(encoding="utf-8") == "keep-me-gone"
 
+    update_root = tmp_path / "BAKLOG-update"
     result_path = update_root / "apply-result.json"
     assert result_path.is_file()
     result = json.loads(result_path.read_text(encoding="utf-8-sig"))
     assert result["ok"] is True
-    assert result["version"] == version
+    assert result["version"] == "9.9.9-test"
     assert not (update_root / "applying.lock").exists()
+    assert (update_root / "apply-started.json").exists() or not (update_root / "apply-started.json").exists()
+    # Success clears apply-started via Write-ApplyResult.
+    assert not (update_root / "apply-started.json").exists()
+    assert (update_root / "apply.log").is_file()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows apply script only")
+def test_apply_update_ps1_corrupt_zip_writes_result_and_clears_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TEMP", str(tmp_path))
+    monkeypatch.setenv("TMP", str(tmp_path))
+    install = tmp_path / "install" / "BAKLOG"
+    install.mkdir(parents=True)
+    (install / "BAKLOG.exe").write_bytes(b"old-server")
+    (install / "BAKLOG Tray.exe").write_bytes(b"old-tray")
+
+    update_root = tmp_path / "BAKLOG-update"
+    update_root.mkdir()
+    version = "9.9.9-bad"
+    version_dir = update_root / version
+    version_dir.mkdir()
+    zip_path = version_dir / "package.zip"
+    zip_path.write_bytes(b"not-a-zip")
+    sha256 = hashlib.sha256(zip_path.read_bytes()).hexdigest()
+
+    proc = _run_apply(tmp_path, install=install, zip_path=zip_path, sha256=sha256, version=version)
+    assert proc.returncode != 0
+    result = json.loads((update_root / "apply-result.json").read_text(encoding="utf-8-sig"))
+    assert result["ok"] is False
+    assert result["error"]
+    assert not (update_root / "applying.lock").exists()
+    # Install unchanged.
+    assert (install / "BAKLOG.exe").read_bytes() == b"old-server"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows apply script only")
+def test_apply_update_ps1_missing_tray_in_bundle_restores(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TEMP", str(tmp_path))
+    monkeypatch.setenv("TMP", str(tmp_path))
+    install = tmp_path / "install" / "BAKLOG"
+    install.mkdir(parents=True)
+    (install / "BAKLOG.exe").write_bytes(b"old-server")
+    (install / "BAKLOG Tray.exe").write_bytes(b"old-tray")
+
+    # Bundle without tray exe → layout invalid before copy, or missing after.
+    zip_path, sha256 = _make_bundle_zip(tmp_path, include_tray=False)
+    proc = _run_apply(tmp_path, install=install, zip_path=zip_path, sha256=sha256)
+    assert proc.returncode != 0
+    update_root = tmp_path / "BAKLOG-update"
+    result = json.loads((update_root / "apply-result.json").read_text(encoding="utf-8-sig"))
+    assert result["ok"] is False
+    assert "layout invalid" in result["error"].lower() or "tray" in result["error"].lower()
+    assert not (update_root / "applying.lock").exists()
+    assert (install / "BAKLOG.exe").read_bytes() == b"old-server"
+
+
+def test_apply_update_ps1_avoids_module_cmdlets() -> None:
+    text = APPLY_PS1.read_text(encoding="utf-8")
+    assert "Expand-Archive" not in text
+    assert "Get-FileHash" not in text
+    assert "Stop-ProcessTreeExcludingSelf" in text
+    assert "taskkill" not in text.lower()
+    assert "$PID" in text
+    assert "apply-started.json" in text
+    assert "ExtractToDirectory" in text
+
+
+def test_apply_update_ps1_kill_helper_excludes_self() -> None:
+    text = APPLY_PS1.read_text(encoding="utf-8")
+    assert "Get-AncestorPidSet" in text
+    assert "ExcludeSet" in text
+    assert "if ($tid -eq $PID) { continue }" in text or "$PID" in text

--- a/tests/test_battlenet_connect_loop.py
+++ b/tests/test_battlenet_connect_loop.py
@@ -206,6 +206,58 @@ def test_stale_page_fails_live_page_succeeds() -> None:
     assert "BATTLENET_COOKIE" in creds
 
 
+def test_sniffer_matches_any_account_api_200() -> None:
+    ctx = _FakeContext(SESSION_COOKIES)
+    sniffer = BattleNetGamesAndSubsSniffer()
+    sniffer.attach(ctx)
+    req = MagicMock()
+    req.url = "https://account.battle.net/api/account-info"
+    req.headers = {"cookie": "BA-tassession=sess"}
+    resp = MagicMock()
+    resp.url = req.url
+    resp.status = 200
+    resp.request = req
+    ctx.response_handlers[0](resp)
+    with patch("clients.battlenet_client.probe_session") as probe:
+        creds = extract_battlenet_session(ctx, None, sniffer=sniffer)
+        probe.assert_not_called()
+    assert creds is not None
+    assert "BA-tassession=sess" in creds["BATTLENET_COOKIE"]
+
+
+def test_cookies_for_urls_fallback_when_dump_empty() -> None:
+    class Ctx(_FakeContext):
+        def cookies_for_urls(self, urls, *, page=None):
+            assert urls
+            return SESSION_COOKIES
+
+    ctx = Ctx([])
+    page = _FakePage({"ok": True, "status": 200})
+    with patch("clients.battlenet_client.probe_session") as probe:
+        creds = extract_battlenet_session(ctx, page)
+        probe.assert_not_called()
+    assert creds is not None
+    assert "BA-tassession=sess" in creds["BATTLENET_COOKIE"]
+
+
+def test_probe_drops_forbidden_origin_referer_headers() -> None:
+    page = _FakePage({"ok": True, "status": 200, "href": "https://account.battle.net/games", "origin": "https://account.battle.net"})
+    assert _battlenet_probe_via_page(page) is True
+    # Capture the evaluate expression from the last call via a recording page.
+    recorded: list[str] = []
+
+    class RecPage(_FakePage):
+        def evaluate(self, expr: str, *, timeout: float = 60) -> Any:
+            recorded.append(expr)
+            return super().evaluate(expr, timeout=timeout)
+
+    rec = RecPage({"ok": True, "status": 200})
+    _battlenet_probe_via_page(rec)
+    assert recorded
+    assert "Origin:" not in recorded[0]
+    assert "Referer:" not in recorded[0]
+
+
 def test_battlenet_live_page_prefers_games_tab() -> None:
     from auth.runner import _battlenet_live_page
 

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -132,6 +132,7 @@ def test_apply_ready_update_launches_helper_darwin(
             popen_calls.append(cmd)
 
     monkeypatch.setattr("shared.update_manager.launch_apply_subprocess", lambda **kwargs: FakePopen([]))
+    monkeypatch.setattr("shared.update_manager.wait_for_apply_started", lambda *_a, **_k: True)
     result = mgr.apply_ready_update()
     assert result["ok"] is True
 
@@ -177,9 +178,57 @@ def test_apply_ready_update_launches_helper(
         return type("P", (), {})()
 
     monkeypatch.setattr("shared.update_manager.launch_apply_subprocess", fake_launch)
+    monkeypatch.setattr("shared.update_manager.wait_for_apply_started", lambda *_a, **_k: True)
     result = mgr.apply_ready_update()
     assert result["ok"] is True
     assert launched
+
+
+def test_apply_aborts_when_helper_never_starts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr("shared.update_manager.is_frozen", lambda: True)
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr("shared.update_manager.is_running_from_temp_dir", lambda _p: False)
+    monkeypatch.setattr("shared.update_manager.frozen_bundle_dir", lambda: tmp_path)
+    (tmp_path / "BAKLOG.exe").write_text("x", encoding="utf-8")
+    (tmp_path / "apply_update.ps1").write_text("param([string]$ManifestPath)", encoding="utf-8")
+
+    payload_bytes = b"verified"
+    digest = hashlib.sha256(payload_bytes).hexdigest()
+    zip_path = tmp_path / "0.8.26" / "package.zip"
+    zip_path.parent.mkdir(parents=True, exist_ok=True)
+    zip_path.write_bytes(payload_bytes)
+
+    mgr = UpdateManager(
+        current_version=lambda: "0.8.25",
+        has_in_flight_runs=lambda: False,
+        work_root=tmp_path,
+    )
+    with mgr._lock:
+        mgr._status.phase = "ready"
+        mgr._status.ready = True
+        mgr._zip_path = zip_path
+        mgr._artifacts = ReleaseArtifacts(
+            tag="v0.8.26",
+            version="0.8.26",
+            html_url="https://example.com",
+            zip_url="https://github.com/Ogrods/BAKLOG/releases/download/v0.8.26/BAKLOG-win64.zip",
+            sha256=digest,
+        )
+
+    monkeypatch.setattr(
+        "shared.update_manager.launch_apply_subprocess",
+        lambda **kwargs: type("P", (), {})(),
+    )
+    monkeypatch.setattr("shared.update_manager.wait_for_apply_started", lambda *_a, **_k: False)
+    result = mgr.apply_ready_update()
+    assert result["ok"] is False
+    assert "did not start" in result["error"]
+    assert mgr.status_dict()["phase"] == "ready"
+    assert mgr.status_dict()["can_apply"] is True
+    assert not (tmp_path / "applying.lock").exists()
 
 
 def test_apply_rejects_zip_outside_work_root(

--- a/tests/test_update_platform.py
+++ b/tests/test_update_platform.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -105,5 +106,9 @@ def test_launch_apply_subprocess_win32(monkeypatch: pytest.MonkeyPatch, tmp_path
     assert "powershell.exe" in calls[0]["cmd"]
     assert "-ManifestPath" in calls[0]["cmd"]
     flags = int(calls[0]["kwargs"].get("creationflags") or 0)
-    assert flags & 0x00000008  # DETACHED_PROCESS
+    # DETACHED_PROCESS (0x8) makes powershell.exe exit rc=0 instantly — must stay unset.
+    assert not (flags & 0x00000008)
     assert flags & 0x00000200  # CREATE_NEW_PROCESS_GROUP
+    assert flags & 0x08000000  # CREATE_NO_WINDOW
+    assert calls[0]["kwargs"].get("stdout") is not None
+    assert calls[0]["kwargs"].get("stdout") is not subprocess.DEVNULL


### PR DESCRIPTION
## Summary
- Fix Windows in-app update: drop `DETACHED_PROCESS` (powershell exited instantly), self-excluding process kills, apply-started handshake before shutdown, always-write apply-result + apply.log, .NET zip extract.
- Harden Battle.net Connect diagnostics/detection: on-disk connect log, broader account.battle.net/api sniffer, Network.getCookies fallback, drop forbidden Origin/Referer; include update/apply fields in bug bundles.
- Bump to 0.8.38; pad Install & restart confirm modal (`p-6`).

## Test plan
- [ ] CI green (pytest + npm test + Windows smoke)
- [ ] Install 0.8.38 via Setup.exe (0.8.37 cannot self-update)
- [ ] Battle.net Connect → Connected with Games page open
- [ ] Later: in-app update 0.8.38 → 0.8.39 to validate apply path


Made with [Cursor](https://cursor.com)