### PR TITLE
fix: complete Battle.net Connect without browser_cookie3 import gate (0.8.39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [Unreleased]
 
+## [0.8.39] - 2026-07-31
+
+### Fixed
+
+- Battle.net Connect hang on the Games page in frozen builds: `extract_battlenet_session` imported `battlenet_client` (and thus `browser_cookie3`) before sniffer/in-page success paths, so a missing frozen dependency returned `None` forever and never wrote `connect-battlenet.log`. Sniffer and in-page probe now run first; `browser_cookie3` is lazy-imported only inside `from_browser()`; Connect completes when the Games SPA proves the session; connect logging always tees under the data dir.
+
 ## [0.8.38] - 2026-07-31
 
 ### Fixed

--- a/auth/connect_extractors.py
+++ b/auth/connect_extractors.py
@@ -211,7 +211,7 @@ def _battlenet_xsrf_from_cookies(cookies: list[dict]) -> str:
 
 
 def _battlenet_log(message: str, *, key: str | None = None) -> None:
-    """Rate-limited stderr + optional on-disk tee for frozen Tray builds."""
+    """Rate-limited stderr + on-disk tee for frozen Tray builds."""
     global _battlenet_log_path
     now = time.time()
     dedupe_key = key or message
@@ -234,10 +234,35 @@ def _battlenet_log(message: str, *, key: str | None = None) -> None:
             _battlenet_log_path = data_root() / "connect-battlenet.log"
         path = _battlenet_log_path
         if path is not None:
+            path.parent.mkdir(parents=True, exist_ok=True)
             with path.open("a", encoding="utf-8") as fh:
                 fh.write(f"{time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())} {line}\n")
     except Exception:  # noqa: BLE001
         pass
+
+
+def _battlenet_resolve_cookie_header(
+    context: Any,
+    page: Any | None,
+    sniffer: BattleNetGamesAndSubsSniffer | None,
+) -> str:
+    """Build a Cookie header from CDP dump, url-scoped dump, then sniffer."""
+    try:
+        cookies = context.cookies()
+    except Exception:  # noqa: BLE001
+        cookies = []
+    header = _cookie_header(cookies, (".battle.net", "battle.net"))
+    if header:
+        return header
+    scoped = _battlenet_cookies_via_urls(context, page)
+    header = _cookie_header(scoped, (".battle.net", "battle.net"))
+    if header:
+        return header
+    if sniffer is not None:
+        _verified, sniffed, _status = sniffer.snapshot()
+        if sniffed:
+            return sniffed
+    return ""
 
 
 def _battlenet_cookie_count(cookies: list[dict]) -> tuple[int, bool]:
@@ -410,30 +435,33 @@ def extract_battlenet_session(
     *,
     sniffer: BattleNetGamesAndSubsSniffer | None = None,
 ) -> dict[str, str] | None:
-    try:
-        from clients.battlenet_client import BattleNetAuthError, probe_session
-    except Exception as exc:
-        print(f"[battlenet] import failed: {exc}", file=sys.stderr, flush=True)
-        return None
+    """Complete Connect from sniffer / in-page proof; external probe is last resort.
 
+    Do **not** import ``battlenet_client`` (and ``browser_cookie3``) before the
+    Games SPA success paths — a failed frozen import used to return None forever
+    and skip all logging.
+    """
     if sniffer is not None:
         sniffed_creds = sniffer.creds_from(context)
         if sniffed_creds:
             _battlenet_log("account.battle.net/api 200 sniffer — session ready", key="sniffer-ready")
             return sniffed_creds
 
-    cookies = context.cookies()
+    try:
+        cookies = context.cookies()
+    except Exception:  # noqa: BLE001
+        cookies = []
     header = _cookie_header(cookies, (".battle.net", "battle.net"))
     xsrf = _battlenet_xsrf_from_cookies(cookies)
     cookie_count, has_xsrf = _battlenet_cookie_count(cookies)
     page_url = (getattr(page, "url", None) or "") if page is not None else ""
     sniffer_verified = False
     sniffer_status = 0
+    sniffed_header = ""
     if sniffer is not None:
-        sniffer_verified, _sniffed, sniffer_status = sniffer.snapshot()
+        sniffer_verified, sniffed_header, sniffer_status = sniffer.snapshot()
 
     # Prefer in-page fetch: HttpOnly session cookies + browser Origin/Referer.
-    # Do not set forbidden Origin/Referer headers — browsers ignore them.
     if page is not None:
         probe = _battlenet_probe_status(page, xsrf=xsrf)
         _battlenet_log(
@@ -445,26 +473,33 @@ def extract_battlenet_session(
             key="poll",
         )
         if probe.get("ok"):
+            header = _battlenet_resolve_cookie_header(context, page, sniffer)
             if header:
+                _battlenet_log("in-page 200 — session ready", key="inpage-ready")
                 return {"BATTLENET_COOKIE": header}
-            # Probe worked but first CDP dump was empty — retry + url-scoped dump.
-            cookies = context.cookies()
-            header = _cookie_header(cookies, (".battle.net", "battle.net"))
-            if not header:
-                scoped = _battlenet_cookies_via_urls(context, page)
-                header = _cookie_header(scoped, (".battle.net", "battle.net"))
-            if header:
-                return {"BATTLENET_COOKIE": header}
-            if sniffer is not None:
-                _verified, sniffed, _status = sniffer.snapshot()
-                if sniffed:
-                    return {"BATTLENET_COOKIE": sniffed}
             _battlenet_log("in-page 200 but cookie dump empty — waiting", key="empty-cookies")
             return None
+
+    # Sniffer saw API 200 but first creds_from had no header — retry dump now.
+    if sniffer_verified:
+        header = _battlenet_resolve_cookie_header(context, page, sniffer)
+        if header:
+            _battlenet_log("sniffer verified + cookies — session ready", key="sniffer-retry")
+            return {"BATTLENET_COOKIE": header}
 
     if not _battlenet_has_session(context):
         return None
     if not header:
+        header = sniffed_header or _battlenet_resolve_cookie_header(context, page, sniffer)
+    if not header:
+        return None
+
+    # External probe only — needs battlenet_client (requests). Never gate above on this.
+    try:
+        from clients.battlenet_client import BattleNetAuthError, probe_session
+    except Exception as exc:  # noqa: BLE001
+        _battlenet_log(f"external probe import failed: {exc}", key="import-fail")
+        # In-page/sniffer already failed; without external probe we cannot verify.
         return None
     try:
         probe_session(header)

--- a/auth/runner.py
+++ b/auth/runner.py
@@ -147,11 +147,14 @@ def _battlenet_live_page(page, context):
 def _extract_battlenet_inline(page, context, session: AuthSession | None = None) -> dict[str, str]:
     """Open account.battle.net/games and save cookies only after the library API works."""
     from auth.connect_extractors import (
+        _battlenet_log,
         battlenet_connect_hint,
         build_battlenet_games_sniffer,
         extract_battlenet_session,
     )
     from auth.connect_loop import run_connect_poll
+
+    _battlenet_log("connect poll start", key="enter")
 
     sniffer = build_battlenet_games_sniffer()
     sniffer.attach(context)

--- a/clients/battlenet_client.py
+++ b/clients/battlenet_client.py
@@ -15,17 +15,13 @@ import re
 from typing import ClassVar
 from urllib.parse import unquote
 
-import browser_cookie3 as bc3
 import requests
 
 ACCOUNT_URL = "https://account.battle.net/api/games-and-subs"
 
-_BROWSER_LOADERS: dict[str, object] = {
-    "edge": bc3.edge,
-    "chrome": bc3.chrome,
-    "brave": bc3.brave,
-    "firefox": bc3.firefox,
-}
+# Names only — browser_cookie3 is imported inside from_browser() so
+# probe_session / BattleNetClient(cookie) work in frozen builds without it.
+_BROWSER_LOADER_NAMES: tuple[str, ...] = ("edge", "chrome", "brave", "firefox")
 
 
 class BattleNetAuthError(Exception):
@@ -46,7 +42,7 @@ def probe_session(cookie_header: str) -> dict:
 
 
 class BattleNetClient:
-    SUPPORTED_BROWSERS: ClassVar[tuple[str, ...]] = tuple(_BROWSER_LOADERS.keys())
+    SUPPORTED_BROWSERS: ClassVar[tuple[str, ...]] = _BROWSER_LOADER_NAMES
 
     def __init__(self, cookie_header: str, user_agent: str | None = None):
         cookie = (cookie_header or "").strip()
@@ -76,8 +72,22 @@ class BattleNetClient:
 
     @classmethod
     def from_browser(cls, browser: str = "edge", **kw) -> BattleNetClient:
+        try:
+            import browser_cookie3 as bc3
+        except Exception as e:  # noqa: BLE001
+            raise BattleNetAuthError(
+                f"browser_cookie3 is unavailable ({e}). Paste the Cookie header "
+                "into BATTLENET_COOKIE in .env and run with --browser env, or use "
+                "Connect on the Connections tab."
+            ) from e
+        loaders = {
+            "edge": bc3.edge,
+            "chrome": bc3.chrome,
+            "brave": bc3.brave,
+            "firefox": bc3.firefox,
+        }
         name = (browser or "edge").strip().lower()
-        loader = _BROWSER_LOADERS.get(name)
+        loader = loaders.get(name)
         if loader is None:
             supported = ", ".join(cls.SUPPORTED_BROWSERS)
             raise BattleNetAuthError(

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <!-- Must match pyproject.toml + package.json (see CHANGELOG release discipline). Read at runtime by js/error-boundary.js for bug-bundle metadata. -->
     <!-- Optional override for bug report endpoint during local testing: content="http://127.0.0.1:3000/api/report" -->
     <!-- <meta name="baklog-report-endpoint" content="https://baklog.app/api/report" /> -->
-    <meta name="baklog-version" content="0.8.38" />
+    <meta name="baklog-version" content="0.8.39" />
     <meta name="theme-color" content="#0f172a" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog",
-  "version": "0.8.38",
+  "version": "0.8.39",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["auth*", "clients*", "fetchers*", "enrichers*", "shared*"]
 
 [project]
 name = "steam-backlog"
-version = "0.8.38"
+version = "0.8.39"
 description = "Local multi-store game library dashboard and fetchers"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_battlenet_connect_loop.py
+++ b/tests/test_battlenet_connect_loop.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from auth.connect_extractors import (
     BattleNetGamesAndSubsSniffer,
@@ -267,3 +270,77 @@ def test_battlenet_live_page_prefers_games_tab() -> None:
     ctx = MagicMock()
     ctx.pages = [blank, login, games]
     assert _battlenet_live_page(blank, ctx) is games
+
+
+def test_extract_succeeds_when_battlenet_client_import_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Frozen builds must not gate sniffer/in-page on browser_cookie3 import."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _block_client(name, *args, **kwargs):
+        if name == "clients.battlenet_client" or name.startswith("clients.battlenet_client"):
+            raise ImportError("simulated frozen missing browser_cookie3")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _block_client)
+    ctx = _FakeContext(SESSION_COOKIES)
+    page = _FakePage({"ok": True, "status": 200})
+    creds = extract_battlenet_session(ctx, page)
+    assert creds is not None
+    assert "BA-tassession=sess" in creds["BATTLENET_COOKIE"]
+
+
+def test_extract_sniffer_succeeds_without_battlenet_client_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _block_client(name, *args, **kwargs):
+        if name == "clients.battlenet_client" or (
+            isinstance(name, str) and name.startswith("clients.battlenet_client")
+        ):
+            raise ImportError("simulated frozen missing browser_cookie3")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _block_client)
+    ctx = _FakeContext(SESSION_COOKIES)
+    sniffer = BattleNetGamesAndSubsSniffer()
+    sniffer.attach(ctx)
+    req = MagicMock()
+    req.url = "https://account.battle.net/api/games-and-subs"
+    req.headers = {"cookie": "BA-tassession=sess"}
+    resp = MagicMock()
+    resp.url = req.url
+    resp.status = 200
+    resp.request = req
+    ctx.response_handlers[0](resp)
+    creds = extract_battlenet_session(ctx, None, sniffer=sniffer)
+    assert creds is not None
+    assert "BA-tassession=sess" in creds["BATTLENET_COOKIE"]
+
+
+def test_battlenet_log_creates_file(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from auth import connect_extractors as ce
+
+    monkeypatch.setenv("BAKLOG_DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(ce, "_battlenet_log_path", None)
+    monkeypatch.setattr(ce, "_battlenet_last_log_by_key", {})
+    ce._battlenet_log("connect poll start", key="enter")
+    log = tmp_path / "connect-battlenet.log"
+    assert log.is_file()
+    assert "connect poll start" in log.read_text(encoding="utf-8")
+
+
+def test_probe_session_import_does_not_need_browser_cookie3() -> None:
+    """probe_session must load without importing browser_cookie3 at module level."""
+    import clients.battlenet_client as mod
+
+    src = Path(mod.__file__).read_text(encoding="utf-8")
+    # Top-level import removed; only lazy inside from_browser.
+    assert "import browser_cookie3 as bc3" not in src.split("def from_browser")[0]
+    assert "import browser_cookie3 as bc3" in src


### PR DESCRIPTION
## Summary
- Battle.net Connect no longer imports `battlenet_client`/`browser_cookie3` before sniffer and in-page Games SPA success paths (root cause of frozen 0.8.38 hang with no `connect-battlenet.log`).
- Lazy-import `browser_cookie3` only in `from_browser()`; harden cookie dump fallbacks; always tee connect enter/poll lines to the data dir.
- Bump to 0.8.39.

## Test plan
- [ ] CI green
- [ ] Install 0.8.39 Setup.exe
- [ ] Connect Battle.net → Games page → Connected
- [ ] Confirm `%LOCALAPPDATA%\BAKLOG-Data\connect-battlenet.log` has poll lines


Made with [Cursor](https://cursor.com)