### PR TITLE
fix: stop Battle.net Connect false-complete (0.8.40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [Unreleased]
 
+## [0.8.40] - 2026-07-31
+
+### Fixed
+
+- Battle.net Connect no longer false-completes from a stale Chrome profile: sniffer matches `games-and-subs` only (not any `/api/`), in-page 401 ignores sniffer/external cookies and keeps the login window open, Connect always clears the Battle.net browser profile on start, and a post-connect `probe_browser_session` vetoes `mark_connected` when the saved cookie still gets 401.
+
 ## [0.8.39] - 2026-07-31
 
 ### Fixed

--- a/auth/connect_extractors.py
+++ b/auth/connect_extractors.py
@@ -280,9 +280,9 @@ def _battlenet_cookie_count(cookies: list[dict]) -> tuple[int, bool]:
 
 
 class BattleNetGamesAndSubsSniffer:
-    """Treat a live account.battle.net/api 200 as session proof (any tab)."""
+    """Treat a live games-and-subs 200 as session proof (any tab)."""
 
-    URL_SUBSTR = "account.battle.net/api/"
+    URL_SUBSTR = "account.battle.net/api/games-and-subs"
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
@@ -328,6 +328,10 @@ class BattleNetGamesAndSubsSniffer:
     def snapshot(self) -> tuple[bool, str, int]:
         with self._lock:
             return self.verified, self.cookie_header, self.status
+
+    def matched_url(self) -> str:
+        with self._lock:
+            return self.last_url
 
     def creds_from(self, context: Any) -> dict[str, str] | None:
         verified, sniffed, _status = self.snapshot()
@@ -435,18 +439,15 @@ def extract_battlenet_session(
     *,
     sniffer: BattleNetGamesAndSubsSniffer | None = None,
 ) -> dict[str, str] | None:
-    """Complete Connect from sniffer / in-page proof; external probe is last resort.
+    """Complete Connect from games-and-subs proof; external probe is last resort.
 
     Do **not** import ``battlenet_client`` (and ``browser_cookie3``) before the
     Games SPA success paths — a failed frozen import used to return None forever
     and skip all logging.
-    """
-    if sniffer is not None:
-        sniffed_creds = sniffer.creds_from(context)
-        if sniffed_creds:
-            _battlenet_log("account.battle.net/api 200 sniffer — session ready", key="sniffer-ready")
-            return sniffed_creds
 
+    If the in-page probe returns 401, never complete from sniffer/external stale
+    cookies — keep polling so the user can sign in.
+    """
     try:
         cookies = context.cookies()
     except Exception:  # noqa: BLE001
@@ -458,10 +459,13 @@ def extract_battlenet_session(
     sniffer_verified = False
     sniffer_status = 0
     sniffed_header = ""
+    sniffer_url = ""
     if sniffer is not None:
         sniffer_verified, sniffed_header, sniffer_status = sniffer.snapshot()
+        sniffer_url = sniffer.matched_url()
 
-    # Prefer in-page fetch: HttpOnly session cookies + browser Origin/Referer.
+    # In-page probe first when we have a page: authoritative for "need login".
+    probe: dict[str, Any] | None = None
     if page is not None:
         probe = _battlenet_probe_status(page, xsrf=xsrf)
         _battlenet_log(
@@ -469,9 +473,16 @@ def extract_battlenet_session(
             f"url={page_url!r} href={probe.get('href')!r} origin={probe.get('origin')!r} "
             f"cookies={cookie_count} xsrf={has_xsrf} "
             f"sniffer_ok={sniffer_verified} sniffer_status={sniffer_status} "
-            f"header_empty={not bool(header)}",
+            f"sniffer_url={sniffer_url!r} header_empty={not bool(header)}",
             key="poll",
         )
+        if int(probe.get("status") or 0) == 401:
+            if sniffer_verified:
+                _battlenet_log(
+                    f"in-page 401 — ignoring sniffer (url={sniffer_url!r})",
+                    key="ignore-sniffer-401",
+                )
+            return None
         if probe.get("ok"):
             header = _battlenet_resolve_cookie_header(context, page, sniffer)
             if header:
@@ -480,12 +491,23 @@ def extract_battlenet_session(
             _battlenet_log("in-page 200 but cookie dump empty — waiting", key="empty-cookies")
             return None
 
-    # Sniffer saw API 200 but first creds_from had no header — retry dump now.
-    if sniffer_verified:
-        header = _battlenet_resolve_cookie_header(context, page, sniffer)
-        if header:
-            _battlenet_log("sniffer verified + cookies — session ready", key="sniffer-retry")
-            return {"BATTLENET_COOKIE": header}
+    # Sniffer: games-and-subs 200 only (narrow URL). Skip if page said 401 above.
+    if sniffer is not None:
+        sniffed_creds = sniffer.creds_from(context)
+        if sniffed_creds:
+            _battlenet_log(
+                f"games-and-subs sniffer 200 — session ready url={sniffer.matched_url()!r}",
+                key="sniffer-ready",
+            )
+            return sniffed_creds
+        if sniffer_verified:
+            header = _battlenet_resolve_cookie_header(context, page, sniffer)
+            if header:
+                _battlenet_log(
+                    f"sniffer verified + cookies — session ready url={sniffer_url!r}",
+                    key="sniffer-retry",
+                )
+                return {"BATTLENET_COOKIE": header}
 
     if not _battlenet_has_session(context):
         return None
@@ -499,14 +521,11 @@ def extract_battlenet_session(
         from clients.battlenet_client import BattleNetAuthError, probe_session
     except Exception as exc:  # noqa: BLE001
         _battlenet_log(f"external probe import failed: {exc}", key="import-fail")
-        # In-page/sniffer already failed; without external probe we cannot verify.
         return None
     try:
         probe_session(header)
     except BattleNetAuthError as exc:
         _battlenet_log(f"external probe rejected: {exc}", key="external-reject")
-        # Stale/expired cookies from a prior session — keep the connect window
-        # open so the user can sign in with fresh credentials.
         return None
     _battlenet_log("external probe accepted", key="external-ok")
     return {"BATTLENET_COOKIE": header}

--- a/auth/manager.py
+++ b/auth/manager.py
@@ -707,6 +707,10 @@ def start_browser_auth(provider: str, *, fresh: bool = False) -> str:
         # Reconnect: drop the old profile cookies so the sign-in window starts
         # logged out instead of resurrecting the stale/expired session.
         clear_browser_session(provider)
+    elif provider == "battlenet":
+        # Stale jar + broad API traffic caused false Connect before login.
+        # Always start Battle.net Connect from a clean profile.
+        clear_browser_session(provider)
     elif provider in PRESERVE_PROFILE_ON_RECONNECT:
         # Keep profile on reconnect (connected/expired) but drop ghost cookies
         # when starting from disconnected so connect cannot auto-complete on a

--- a/auth/session_probe.py
+++ b/auth/session_probe.py
@@ -16,7 +16,7 @@ from clients.gog_client import GOG_AUTH_MESSAGE, GogAuthError, GogClient
 ProbeResult = Literal["ok", "auth_fail", "unreachable"]
 
 # Providers that have a probe implementation in this module.
-PROBEABLE_BROWSER = frozenset({"gog", "xbox_wishlist"})
+PROBEABLE_BROWSER = frozenset({"gog", "xbox_wishlist", "battlenet"})
 
 # Cheap/no-browser providers eligible for silent hourly health checks.
 PROBEABLE_QUIET = frozenset({"gog", "epic", "steam", "itch", "itad", "psn"})
@@ -25,6 +25,8 @@ PROBEABLE_QUIET = frozenset({"gog", "epic", "steam", "itch", "itad", "psn"})
 # the session via the live page before closing, so a headless probe miss must
 # never veto the connect (xbox.com serves signed-out SSR to headless Chrome
 # inconsistently). For these, the probe is advisory — logged, never blocking.
+# Battle.net is NOT advisory: a 401 on the same cookie must veto a false sniffer
+# complete even though headed success paths are otherwise trusted.
 ADVISORY_BROWSER_PROBE = frozenset({"xbox_wishlist", "ea"})
 
 
@@ -34,7 +36,31 @@ def probe_browser_session(provider: str, creds: dict[str, str]) -> str | None:
         return probe_gog_session(creds.get("GOG_AL", ""))
     if provider == "xbox_wishlist":
         return probe_xbox_wishlist_session(creds)
+    if provider == "battlenet":
+        return probe_battlenet_session(creds.get("BATTLENET_COOKIE", ""))
     return None
+
+
+def probe_battlenet_session(cookie: str) -> str | None:
+    """Verify games-and-subs accepts the captured cookie (lazy client import)."""
+    token = (cookie or "").strip()
+    if not token:
+        return (
+            "No Battle.net session cookie captured — sign in at "
+            "account.battle.net and try Connect again."
+        )
+    try:
+        from clients.battlenet_client import BattleNetAuthError, probe_session
+    except Exception as exc:  # noqa: BLE001
+        return f"Could not verify Battle.net session: {exc}"
+    try:
+        probe_session(token)
+        return None
+    except BattleNetAuthError as exc:
+        return str(exc) or (
+            "Battle.net rejected the session. Reconnect and wait until "
+            "your Games list loads."
+        )
 
 
 def probe_xbox_wishlist_session(_creds: dict[str, str]) -> str | None:

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <!-- Must match pyproject.toml + package.json (see CHANGELOG release discipline). Read at runtime by js/error-boundary.js for bug-bundle metadata. -->
     <!-- Optional override for bug report endpoint during local testing: content="http://127.0.0.1:3000/api/report" -->
     <!-- <meta name="baklog-report-endpoint" content="https://baklog.app/api/report" /> -->
-    <meta name="baklog-version" content="0.8.39" />
+    <meta name="baklog-version" content="0.8.40" />
     <meta name="theme-color" content="#0f172a" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog",
-  "version": "0.8.39",
+  "version": "0.8.40",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["auth*", "clients*", "fetchers*", "enrichers*", "shared*"]
 
 [project]
 name = "steam-backlog"
-version = "0.8.39"
+version = "0.8.40"
 description = "Local multi-store game library dashboard and fetchers"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_auth_manager_profile.py
+++ b/tests/test_auth_manager_profile.py
@@ -90,6 +90,21 @@ def test_plain_connect_does_not_clear_browser_session(
     assert cleared == []
 
 
+def test_battlenet_plain_connect_clears_browser_session(
+    profile_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Battle.net always clears profile so stale cookies cannot false-complete."""
+    cleared: list[str] = []
+    monkeypatch.setattr(
+        auth_manager, "clear_browser_session", lambda p: cleared.append(p)
+    )
+    done = _stub_browser_worker(monkeypatch)
+
+    auth_manager.start_browser_auth("battlenet")
+    assert done.wait(timeout=3.0)
+    assert cleared == ["battlenet"]
+
+
 def test_clear_browser_session_removes_profile_dir(
     profile_env: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_battlenet_connect_loop.py
+++ b/tests/test_battlenet_connect_loop.py
@@ -77,29 +77,28 @@ def test_extract_prefers_in_page_probe() -> None:
     assert "XSRF-TOKEN=tok%3D%3D" in creds["BATTLENET_COOKIE"]
 
 
-def test_extract_falls_back_to_external_probe_when_page_fails() -> None:
+def test_extract_in_page_401_does_not_use_external_probe() -> None:
+    """Stale jar: in-page 401 must keep polling — never complete via external probe."""
     ctx = _FakeContext(SESSION_COOKIES)
     page = _FakePage({"ok": False, "status": 401})
     with patch(
         "clients.battlenet_client.probe_session",
         return_value={"modernGames": []},
     ) as probe:
-        creds = extract_battlenet_session(ctx, page)
-        probe.assert_called_once()
-    assert creds is not None
-    assert "BATTLENET_COOKIE" in creds
+        assert extract_battlenet_session(ctx, page) is None
+        probe.assert_not_called()
 
 
 def test_extract_returns_none_when_external_probe_rejects() -> None:
     from clients.battlenet_client import BattleNetAuthError
 
     ctx = _FakeContext(SESSION_COOKIES)
-    page = _FakePage({"ok": False, "status": 401})
+    # No page: only external probe path remains.
     with patch(
         "clients.battlenet_client.probe_session",
         side_effect=BattleNetAuthError("401"),
     ):
-        assert extract_battlenet_session(ctx, page) is None
+        assert extract_battlenet_session(ctx, None) is None
 
 
 def test_extract_without_page_uses_external_probe() -> None:
@@ -121,7 +120,7 @@ def test_extract_in_page_ok_but_empty_cookies_waits() -> None:
         probe.assert_not_called()
 
 
-def test_sniffer_200_yields_creds_without_in_page_probe() -> None:
+def test_sniffer_200_without_page_yields_creds() -> None:
     ctx = _FakeContext(SESSION_COOKIES)
     sniffer = BattleNetGamesAndSubsSniffer()
     sniffer.attach(ctx)
@@ -136,13 +135,32 @@ def test_sniffer_200_yields_creds_without_in_page_probe() -> None:
     resp.request = req
     ctx.response_handlers[0](resp)
 
-    page = _FakePage({"ok": False, "status": 401})
     with patch("clients.battlenet_client.probe_session") as probe:
-        creds = extract_battlenet_session(ctx, page, sniffer=sniffer)
+        creds = extract_battlenet_session(ctx, None, sniffer=sniffer)
         probe.assert_not_called()
-        assert page.evaluate_calls == 0
     assert creds is not None
     assert "BA-tassession=sess" in creds["BATTLENET_COOKIE"]
+
+
+def test_in_page_401_ignores_sniffer_verified() -> None:
+    """Stale profile: sniffer must not false-complete when games-and-subs is 401."""
+    ctx = _FakeContext(SESSION_COOKIES)
+    sniffer = BattleNetGamesAndSubsSniffer()
+    sniffer.attach(ctx)
+    req = MagicMock()
+    req.url = "https://account.battle.net/api/games-and-subs"
+    req.headers = {"cookie": "XSRF-TOKEN=tok%3D%3D; BA-tassession=sess"}
+    resp = MagicMock()
+    resp.url = req.url
+    resp.status = 200
+    resp.request = req
+    ctx.response_handlers[0](resp)
+
+    page = _FakePage({"ok": False, "status": 401})
+    with patch("clients.battlenet_client.probe_session") as probe:
+        assert extract_battlenet_session(ctx, page, sniffer=sniffer) is None
+        probe.assert_not_called()
+        assert page.evaluate_calls == 1
 
 
 def test_sniffer_cookie_header_used_when_cdp_dump_empty() -> None:
@@ -209,7 +227,7 @@ def test_stale_page_fails_live_page_succeeds() -> None:
     assert "BATTLENET_COOKIE" in creds
 
 
-def test_sniffer_matches_any_account_api_200() -> None:
+def test_sniffer_ignores_non_games_and_subs_api_200() -> None:
     ctx = _FakeContext(SESSION_COOKIES)
     sniffer = BattleNetGamesAndSubsSniffer()
     sniffer.attach(ctx)
@@ -221,11 +239,33 @@ def test_sniffer_matches_any_account_api_200() -> None:
     resp.status = 200
     resp.request = req
     ctx.response_handlers[0](resp)
-    with patch("clients.battlenet_client.probe_session") as probe:
+    assert sniffer.snapshot()[0] is False
+    with patch(
+        "clients.battlenet_client.probe_session",
+        return_value={"modernGames": []},
+    ) as probe:
+        # No page + no games-and-subs sniffer → may fall through to external.
         creds = extract_battlenet_session(ctx, None, sniffer=sniffer)
-        probe.assert_not_called()
+        probe.assert_called_once()
     assert creds is not None
-    assert "BA-tassession=sess" in creds["BATTLENET_COOKIE"]
+
+
+def test_non_games_api_200_does_not_complete_when_in_page_401() -> None:
+    ctx = _FakeContext(SESSION_COOKIES)
+    sniffer = BattleNetGamesAndSubsSniffer()
+    sniffer.attach(ctx)
+    req = MagicMock()
+    req.url = "https://account.battle.net/api/account-info"
+    req.headers = {"cookie": "BA-tassession=sess"}
+    resp = MagicMock()
+    resp.url = req.url
+    resp.status = 200
+    resp.request = req
+    ctx.response_handlers[0](resp)
+    page = _FakePage({"ok": False, "status": 401})
+    with patch("clients.battlenet_client.probe_session") as probe:
+        assert extract_battlenet_session(ctx, page, sniffer=sniffer) is None
+        probe.assert_not_called()
 
 
 def test_cookies_for_urls_fallback_when_dump_empty() -> None:
@@ -344,3 +384,20 @@ def test_probe_session_import_does_not_need_browser_cookie3() -> None:
     # Top-level import removed; only lazy inside from_browser.
     assert "import browser_cookie3 as bc3" not in src.split("def from_browser")[0]
     assert "import browser_cookie3 as bc3" in src
+
+
+def test_probe_browser_session_battlenet_ok_and_401() -> None:
+    from auth.session_probe import probe_browser_session
+    from clients.battlenet_client import BattleNetAuthError
+
+    with patch(
+        "clients.battlenet_client.probe_session",
+        return_value={"modernGames": []},
+    ):
+        assert probe_browser_session("battlenet", {"BATTLENET_COOKIE": "ok"}) is None
+    with patch(
+        "clients.battlenet_client.probe_session",
+        side_effect=BattleNetAuthError("401"),
+    ):
+        err = probe_browser_session("battlenet", {"BATTLENET_COOKIE": "bad"})
+    assert err == "401"

--- a/tests/test_session_probe.py
+++ b/tests/test_session_probe.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from auth.session_probe import (
     PROBEABLE_QUIET,
+    probe_battlenet_session,
     probe_browser_session,
     probe_epic_session_quiet,
     probe_gog_session,
@@ -16,6 +17,7 @@ from auth.session_probe import (
     probe_steam_session_quiet,
     probe_xbox_wishlist_session,
 )
+from clients.battlenet_client import BattleNetAuthError
 from clients.gog_client import GOG_AUTH_MESSAGE, GogAuthError
 
 
@@ -83,6 +85,46 @@ class TestProbeXboxWishlistSession:
         ) as mock:
             assert probe_browser_session("xbox_wishlist", {"XBOX_WISHLIST_PROFILE": "ready"}) is None
         mock.assert_called_once()
+
+
+class TestProbeBattlenetSession:
+    def test_empty_cookie(self) -> None:
+        err = probe_battlenet_session("")
+        assert err is not None
+        assert "No Battle.net session" in err
+
+    def test_ok_when_probe_succeeds(self) -> None:
+        with patch(
+            "clients.battlenet_client.probe_session",
+            return_value={"modernGames": []},
+        ):
+            assert probe_battlenet_session("XSRF-TOKEN=x; BA-tassession=y") is None
+
+    def test_error_on_401(self) -> None:
+        with patch(
+            "clients.battlenet_client.probe_session",
+            side_effect=BattleNetAuthError("Battle.net rejected the session (401)."),
+        ):
+            err = probe_battlenet_session("stale")
+        assert err is not None
+        assert "401" in err
+
+    def test_probe_browser_session_routes_battlenet(self) -> None:
+        with patch(
+            "auth.session_probe.probe_battlenet_session",
+            return_value=None,
+        ) as mock:
+            assert probe_browser_session("battlenet", {"BATTLENET_COOKIE": "c"}) is None
+        mock.assert_called_once_with("c")
+
+    def test_probe_browser_session_battlenet_401(self) -> None:
+        with patch(
+            "auth.session_probe.probe_battlenet_session",
+            return_value="Battle.net rejected the session (401).",
+        ):
+            err = probe_browser_session("battlenet", {"BATTLENET_COOKIE": "bad"})
+        assert err is not None
+        assert "401" in err
 
 
 class TestQuietProbes:


### PR DESCRIPTION
## Summary
- Narrow Battle.net sniffer to `games-and-subs` only; ignore sniffer/external cookies when the in-page probe returns 401 (stale profile false-complete).
- Always clear the Battle.net browser profile on Connect start; post-connect `probe_browser_session` vetoes `mark_connected` on 401.
- Bump to **0.8.40** with unit tests for the false-complete cases.

## Test plan
- [ ] CI green on this PR
- [ ] In-app update 0.8.39 → 0.8.40
- [ ] Battle.net Connect from disconnected shows login (does not close in ~4s)
- [ ] After real login + Games list, Connect completes and fetch works

Made with [Cursor](https://cursor.com)