### PR TITLE
fix: Connect orphans (Xbox/Nintendo) + Epic Cloudflare (0.8.41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [Unreleased]
 
+## [0.8.41] - 2026-07-31
+
+### Fixed
+
+- Xbox / Nintendo wishlist Connect no longer flash-closes from orphaned fetcher Chrome: bounded profile close joins then force-releases holders; launch retry kills only pre-existing PIDs (not the new window); cancel API + UI when Connect stalls.
+- Nintendo wishlist Connect no longer false-completes on an empty guest GraphQL wishlist; requires customer auth proof and logs polls to `connect-nintendo_wishlist.log`.
+- Epic / Epic wishlist Connect: detect Cloudflare managed challenge HTML (`_cf_chl_opt` / Enable JavaScript and cookies), keep polling with a clear wait hint, and launch Epic Connect without `--disable-extensions` to reduce Bot Management flags.
+
 ## [0.8.40] - 2026-07-31
 
 ### Fixed

--- a/auth/cdp_browser.py
+++ b/auth/cdp_browser.py
@@ -289,6 +289,30 @@ def release_chromium_profile_lock(
     return pids
 
 
+def close_browser_bounded(
+    context: Any,
+    *,
+    profile: str | Path | None = None,
+    join_timeout: float = 10.0,
+) -> None:
+    """Close ``context`` without leaving an orphan holding the profile lock.
+
+    ``CdpContext.close`` can hang on a dead CDP socket. Running it on a daemon
+    thread alone is unsafe in short-lived fetcher subprocesses: the interpreter
+    exits before close finishes and Chrome stays alive on ``--user-data-dir``,
+    poisoning the next Connect. Join for ``join_timeout``, then force-release
+    any remaining profile holders.
+    """
+    closer = getattr(context, "close", None)
+    if not callable(closer):
+        return
+    t = threading.Thread(target=closer, daemon=True, name="cdp-close-bounded")
+    t.start()
+    t.join(join_timeout)
+    if profile is not None and pids_holding_chromium_profile(profile):
+        release_chromium_profile_lock(profile, wait_sec=3.0)
+
+
 _BLANK_URLS = frozenset({"", "about:blank", "chrome://newtab/"})
 
 
@@ -1592,6 +1616,7 @@ def launch_persistent_profile(
     window_size: tuple[int, int] | None = None,
     start_minimized: bool = False,
     initial_url: str | None = None,
+    allow_extensions: bool = False,
 ) -> CdpContext:
     """Launch Chrome/Edge with a persistent profile and return a CDP context.
 
@@ -1605,6 +1630,9 @@ def launch_persistent_profile(
 
     When ``initial_url`` is set, the first connect page navigates there after CDP attach
     (used by EA Connect to open the login page immediately).
+
+    ``allow_extensions`` keeps Chrome extensions enabled. Default is off (cleaner
+    OAuth); Epic Connect sets this True to reduce Cloudflare Bot Management flags.
     """
     exe = find_chromium_executable()
     port = _free_port()
@@ -1623,13 +1651,17 @@ def launch_persistent_profile(
         "--remote-allow-origins=http://127.0.0.1,http://localhost,http://[::1]",
         "--no-first-run",
         "--no-default-browser-check",
+    ]
+    if not allow_extensions:
         # Sign-in uses an isolated profile, but extensions synced into that profile
         # (or enterprise policy) can redirect OAuth flows — keep the window clean.
-        "--disable-extensions",
+        # Epic Connect opts out: --disable-extensions worsens CF bot scores.
+        args.append("--disable-extensions")
+    args.append(
         # Omit --disable-blink-features=AutomationControlled: Chrome/Edge show a
         # persistent "unsupported command-line flag" infobar that blocks the login UI.
         "--disable-features=IsolateOrigins,site-per-process",
-    ]
+    )
     if headless:
         mode = "new" if headless is True else str(headless).lower()
         if mode in ("legacy", "old"):
@@ -1652,6 +1684,26 @@ def launch_persistent_profile(
     proc: subprocess.Popen[Any] | None = None
     ws_url = None
     released_pids: list[int] = []
+    # Snapshot holders BEFORE our Popen so recovery never kills the window we
+    # just launched (that was closing the Connect UI under the user).
+    pre_existing = set(pids_holding_chromium_profile(profile))
+    extended_wait = False
+
+    def _release_pre_existing_only() -> list[int]:
+        current = pids_holding_chromium_profile(profile)
+        stale = [p for p in current if p in pre_existing]
+        if stale:
+            print(
+                f"[cdp] releasing {len(stale)} pre-existing profile holder(s) "
+                f"(not our launch): {stale}",
+                file=sys.stderr,
+                flush=True,
+            )
+            _kill_pids(stale, wait_sec=3.0)
+            return stale
+        _clear_stale_chromium_profile_lock_files(profile)
+        return []
+
     for attempt in range(2):
         proc = subprocess.Popen(
             args,
@@ -1680,7 +1732,7 @@ def launch_persistent_profile(
                 except Exception:
                     pass
                 if attempt == 0 and exit_code == 21:
-                    released_pids = release_chromium_profile_lock(profile)
+                    released_pids = _release_pre_existing_only()
                     break
                 hint = (
                     "Close any other window using this profile and try again."
@@ -1706,9 +1758,55 @@ def launch_persistent_profile(
         if ws_url:
             break
         # Exit 0 with no CDP yet often means SingletonLock handoff (Chrome exits
-        # the second instance cleanly). Release the profile lock and relaunch once.
+        # the second instance cleanly). Kill only pre-existing holders — never
+        # the window we just opened. If nothing was holding the profile, extend
+        # the CDP wait once instead of kill-and-relaunch.
         if attempt == 0 and launcher_exited_zero:
-            released_pids = release_chromium_profile_lock(profile)
+            if pre_existing:
+                released_pids = _release_pre_existing_only()
+                print(
+                    f"[cdp] exit-0 no CDP yet; killed pre-existing holders={released_pids}; relaunching",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                continue
+            if not extended_wait:
+                extended_wait = True
+                print(
+                    "[cdp] exit-0 no CDP yet; no pre-existing holders — extending wait +20s",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                deadline = time.time() + 20
+                while time.time() < deadline:
+                    try:
+                        version = _fetch_json(
+                            f"http://127.0.0.1:{port}/json/version", timeout=2
+                        )
+                        ws_url = version.get("webSocketDebuggerUrl")
+                        if ws_url:
+                            break
+                    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError):
+                        pass
+                    time.sleep(0.2)
+                if ws_url:
+                    break
+            # Still no CDP after extend: drop whatever is on our debug port
+            # (our failed attempt) then relaunch — do not blanket-kill the
+            # whole profile (that closed the user's Connect window).
+            print(
+                "[cdp] CDP still missing after extend; clearing debug port and relaunching",
+                file=sys.stderr,
+                flush=True,
+            )
+            port_pids = _pids_listening_on_local_port(port)
+            if port_pids:
+                _kill_pids(port_pids, wait_sec=2.0)
+            if proc is not None:
+                try:
+                    proc.kill()
+                except Exception:
+                    pass
             continue
 
     if not ws_url:

--- a/auth/connect_extractors.py
+++ b/auth/connect_extractors.py
@@ -14,7 +14,7 @@ HUMBLE_LIBRARY_URL = "https://www.humblebundle.com/home/library"
 HUMBLE_ORDERS_API = "https://www.humblebundle.com/api/v1/user/order"
 BATTLENET_GAMES_URL = "https://account.battle.net/games"
 BATTLENET_ACCOUNT_API = "https://account.battle.net/api/games-and-subs"
-# Per-message-key dedupe interval (same key suppressed this long).
+# Per-message-key dedupe interval kept for tests that monkeypatch these.
 _BATTLENET_LOG_INTERVAL_SEC = 4.0
 _battlenet_last_log_by_key: dict[str, float] = {}
 _battlenet_log_path: Any | None = None
@@ -212,33 +212,9 @@ def _battlenet_xsrf_from_cookies(cookies: list[dict]) -> str:
 
 def _battlenet_log(message: str, *, key: str | None = None) -> None:
     """Rate-limited stderr + on-disk tee for frozen Tray builds."""
-    global _battlenet_log_path
-    now = time.time()
-    dedupe_key = key or message
-    last = _battlenet_last_log_by_key.get(dedupe_key, 0.0)
-    if now - last < _BATTLENET_LOG_INTERVAL_SEC:
-        return
-    _battlenet_last_log_by_key[dedupe_key] = now
-    # Cap key map growth.
-    if len(_battlenet_last_log_by_key) > 64:
-        cutoff = now - (_BATTLENET_LOG_INTERVAL_SEC * 4)
-        stale = [k for k, t in _battlenet_last_log_by_key.items() if t < cutoff]
-        for k in stale:
-            _battlenet_last_log_by_key.pop(k, None)
-    line = f"[battlenet] {message}"
-    print(line, file=sys.stderr, flush=True)
-    try:
-        if _battlenet_log_path is None:
-            from shared.install_paths import data_root
+    from auth.connect_log import connect_log
 
-            _battlenet_log_path = data_root() / "connect-battlenet.log"
-        path = _battlenet_log_path
-        if path is not None:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            with path.open("a", encoding="utf-8") as fh:
-                fh.write(f"{time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())} {line}\n")
-    except Exception:  # noqa: BLE001
-        pass
+    connect_log("battlenet", message, key=key)
 
 
 def _battlenet_resolve_cookie_header(

--- a/auth/connect_extractors.py
+++ b/auth/connect_extractors.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import json
 import queue
-import sys
 import threading
-import time
 from collections.abc import Callable
 from typing import Any
 

--- a/auth/connect_log.py
+++ b/auth/connect_log.py
@@ -11,7 +11,6 @@ import re
 import sys
 import time
 from pathlib import Path
-from typing import Any
 
 _LOG_INTERVAL_SEC = 4.0
 _last_log_by_key: dict[str, float] = {}

--- a/auth/connect_log.py
+++ b/auth/connect_log.py
@@ -1,0 +1,60 @@
+"""Rate-limited stderr + on-disk tee for headed Connect flows.
+
+Frozen Tray builds hide the server console, so Connect diagnostics must land
+under the data dir (``connect-<provider>.log``) the same way Battle.net already
+did before this helper was generalized.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+_LOG_INTERVAL_SEC = 4.0
+_last_log_by_key: dict[str, float] = {}
+_log_paths: dict[str, Path | None] = {}
+
+_PROVIDER_SAFE = re.compile(r"[^a-z0-9_-]+")
+
+
+def connect_log(provider: str, message: str, *, key: str | None = None) -> None:
+    """Rate-limited stderr + on-disk tee for frozen Tray builds."""
+    now = time.time()
+    prov = (provider or "unknown").strip().lower() or "unknown"
+    dedupe_key = f"{prov}:{key or message}"
+    last = _last_log_by_key.get(dedupe_key, 0.0)
+    if now - last < _LOG_INTERVAL_SEC:
+        return
+    _last_log_by_key[dedupe_key] = now
+    if len(_last_log_by_key) > 128:
+        cutoff = now - (_LOG_INTERVAL_SEC * 4)
+        stale = [k for k, t in _last_log_by_key.items() if t < cutoff]
+        for k in stale:
+            _last_log_by_key.pop(k, None)
+    line = f"[{prov}] {message}"
+    print(line, file=sys.stderr, flush=True)
+    try:
+        path = _log_paths.get(prov)
+        if path is None and prov not in _log_paths:
+            from shared.install_paths import data_root
+
+            safe = _PROVIDER_SAFE.sub("-", prov).strip("-") or "unknown"
+            path = data_root() / f"connect-{safe}.log"
+            _log_paths[prov] = path
+        if path is not None:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(
+                    f"{time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())} {line}\n"
+                )
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def reset_connect_log_for_tests() -> None:
+    """Clear cached paths / dedupe state (unit tests only)."""
+    _last_log_by_key.clear()
+    _log_paths.clear()

--- a/auth/epic_wishlist_session.py
+++ b/auth/epic_wishlist_session.py
@@ -232,7 +232,12 @@ def wishlist_capture_complete_from_html(html: str) -> bool:
 
 
 def cloudflare_interstitial(html: str, url: str) -> bool:
-    """True only for an active Cloudflare challenge page (not embedded CF scripts)."""
+    """True for an active Cloudflare challenge (page or managed challenge HTML).
+
+    Matches challenge pages and Epic ID managed challenges that dump
+    ``_cf_chl_opt`` / ``Enable JavaScript and cookies`` into the login form —
+    without treating every page that merely loads a generic CF script as blocked.
+    """
     u = (url or "").lower()
     if "/cdn-cgi/challenge" in u:
         return True
@@ -241,7 +246,19 @@ def cloudflare_interstitial(html: str, url: str) -> bool:
         return True
     if "cf_challenge_container" in body or "cf_challenge_text" in body:
         return True
+    # Managed challenge embedded in Epic ID login / XHR error HTML.
+    if "window._cf_chl_opt" in body or "_cf_chl_opt" in body:
+        return True
+    if "cType: 'managed'" in body or 'cType: "managed"' in body:
+        return True
+    if "Enable JavaScript and cookies to continue" in body:
+        return True
     return False
+
+
+EPIC_CF_CONNECT_HINT = (
+    "Complete the Cloudflare check in the browser window, then continue sign-in."
+)
 
 
 def storefront_bounced_to_home(url: str) -> bool:

--- a/auth/manager.py
+++ b/auth/manager.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import sys
 import threading
+import time
 import uuid
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -15,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from auth.registry import PROVIDERS, spec_for
-from auth.runner import AuthSession, run_browser_auth
+from auth.runner import AuthSession, SUCCESS_WAIT_SEC, run_browser_auth
 from auth.secrets import (
     SecretsCorruptError,
     delete_provider_blob,
@@ -687,6 +688,24 @@ def _unfinished_session_for(provider: str) -> AuthSession | None:
     return None
 
 
+def cancel_browser_auth(provider: str) -> bool:
+    """Cancel an in-flight headed sign-in. Returns True when a session was found."""
+    existing = _unfinished_session_for(provider)
+    if existing is None:
+        return False
+    existing.cancel()
+    existing.finish()
+    return True
+
+
+def _session_is_stale(session: AuthSession) -> bool:
+    """True when the session was cancelled or has outlived the connect timeout."""
+    if session.is_cancelled():
+        return True
+    age = time.time() - float(getattr(session, "started_at", 0.0) or 0.0)
+    return age > (SUCCESS_WAIT_SEC + 30)
+
+
 def start_browser_auth(provider: str, *, fresh: bool = False) -> str:
     spec = spec_for(provider)
     if spec.kind == "manual":
@@ -695,14 +714,16 @@ def start_browser_auth(provider: str, *, fresh: bool = False) -> str:
         raise ValueError(f"{provider} does not support browser sign-in")
     existing = _unfinished_session_for(provider)
     if existing is not None:
-        if not fresh:
+        if fresh or _session_is_stale(existing):
+            # Reconnect, Cancel, or a stuck session past the connect timeout:
+            # finish the old gate so the user can retry without waiting.
+            existing.cancel()
+            existing.finish()
+        else:
             raise ValueError(
                 f"A sign-in window for {spec.label} is already open. "
                 "Finish or close it before starting again."
             )
-        # Reconnect with a stale session still running: finish the old one
-        # so the user can retry without waiting for the 5-minute timeout.
-        existing.finish()
     if fresh and _should_clear_on_reconnect(provider):
         # Reconnect: drop the old profile cookies so the sign-in window starts
         # logged out instead of resurrecting the stale/expired session.

--- a/auth/manager.py
+++ b/auth/manager.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from auth.registry import PROVIDERS, spec_for
-from auth.runner import AuthSession, SUCCESS_WAIT_SEC, run_browser_auth
+from auth.runner import SUCCESS_WAIT_SEC, AuthSession, run_browser_auth
 from auth.secrets import (
     SecretsCorruptError,
     delete_provider_blob,

--- a/auth/runner.py
+++ b/auth/runner.py
@@ -83,7 +83,17 @@ _STEALTH_INIT = STEALTH_INIT_SCRIPT
 
 
 class AuthSession:
-    __slots__ = ("id", "provider", "fresh_connect", "events", "_listeners", "_finished", "_lock")
+    __slots__ = (
+        "id",
+        "provider",
+        "fresh_connect",
+        "events",
+        "started_at",
+        "_listeners",
+        "_finished",
+        "_cancelled",
+        "_lock",
+    )
 
     def __init__(self, session_id: str, provider: str, *, fresh_connect: bool = False) -> None:
         self.id = session_id
@@ -92,6 +102,8 @@ class AuthSession:
         self.events: queue.Queue[tuple[str, dict]] = queue.Queue()
         self._listeners: list[Callable[[str, dict], None]] = []
         self._finished = threading.Event()
+        self._cancelled = threading.Event()
+        self.started_at = time.time()
         self._lock = threading.Lock()
 
     def emit(self, event: str, data: dict[str, Any]) -> None:
@@ -107,12 +119,27 @@ class AuthSession:
         with self._lock:
             self._listeners.append(callback)
 
+    def cancel(self) -> None:
+        """Ask the poll loop to abort; finish() is still called by the worker."""
+        self._cancelled.set()
+
+    def is_cancelled(self) -> bool:
+        return self._cancelled.is_set()
+
     def finish(self) -> None:
         self._finished.set()
         self.emit("done", {})
 
     def wait(self, timeout: float | None = None) -> bool:
         return self._finished.wait(timeout)
+
+
+def abort_if_cancelled(session: AuthSession | None) -> None:
+    """Raise ConnectBrowserClosed when the user cancelled this sign-in session."""
+    if session is not None and session.is_cancelled():
+        from auth.cdp_browser import ConnectBrowserClosed
+
+        raise ConnectBrowserClosed()
 
 
 def _cookie_header(cookies: list[dict], domains: tuple[str, ...]) -> str:
@@ -316,6 +343,7 @@ def _extract_epic_inline(page, context, session: AuthSession | None = None) -> d
     the fetcher can reuse it. On any failure the user can still paste the code manually.
     """
     from auth.cdp_browser import abort_if_browser_closed
+    from auth.epic_wishlist_session import EPIC_CF_CONNECT_HINT, cloudflare_interstitial
 
     login_url = spec_for("epic").login_url
     try:
@@ -380,8 +408,26 @@ def _extract_epic_inline(page, context, session: AuthSession | None = None) -> d
                 page.wait_for_timeout(int(POLL_SEC * 1000))
                 continue
 
-        url = (drive.url or "").lower()
+        drive_url = drive.url or ""
+        drive_html = ""
+        try:
+            drive_html = drive.content() if hasattr(drive, "content") else ""
+        except Exception:  # noqa: BLE001
+            drive_html = ""
+        if not drive_html:
+            try:
+                drive_html = page.content()
+            except Exception:  # noqa: BLE001
+                drive_html = ""
         now = time.time()
+        if cloudflare_interstitial(drive_html, drive_url):
+            if session and now - last_hint > 6:
+                last_hint = now
+                session.emit("waiting_for_user", {"message": EPIC_CF_CONNECT_HINT})
+            page.wait_for_timeout(int(POLL_SEC * 1000))
+            continue
+
+        url = drive_url.lower()
         if session and now - last_hint > 10:
             last_hint = now
             if "login" in url or "id.epicgames.com" in url:
@@ -618,6 +664,8 @@ def _extract_epic_wishlist_inline(page, context, session) -> dict[str, str]:
     from auth.cdp_browser import abort_if_browser_closed
     from auth.connect_extractors import build_epic_wishlist_graphql_sniffer
     from auth.epic_wishlist_session import (
+        EPIC_CF_CONNECT_HINT,
+        cloudflare_interstitial,
         storefront_bounced_to_home,
         wishlist_capture_complete_from_html,
     )
@@ -690,11 +738,21 @@ def _extract_epic_wishlist_inline(page, context, session) -> dict[str, str]:
             return {"EPIC_STORE_COOKIE": "ready"}
 
         now = time.time()
+        try:
+            html = page.content()
+        except Exception:  # noqa: BLE001
+            html = ""
+        if cloudflare_interstitial(html, url):
+            if session and now - last_msg > 6:
+                last_msg = now
+                session.emit("waiting_for_user", {"message": EPIC_CF_CONNECT_HINT})
+            page.wait_for_timeout(int(POLL_SEC * 1000))
+            continue
 
         if session and now - last_msg > 8:
             last_msg = now
             if "challenge" in ul or "cloudflare" in ul:
-                msg = "Cloudflare challenge — click the checkbox if shown."
+                msg = EPIC_CF_CONNECT_HINT
             elif _epic_on_login_page(url) or "signin" in ul:
                 msg = (
                     "Sign in to Epic in this window — you'll be returned to your "
@@ -943,6 +1001,7 @@ def _xbox_wishlist_connect_creds(sniffer) -> dict[str, str]:
 
 def _extract_xbox_wishlist_inline(page, context, session) -> dict[str, str]:
     from auth.cdp_browser import abort_if_browser_closed
+    from auth.connect_log import connect_log
     """Open xbox.com/wishlist, wait for MSA sign-in (detected via SSR HTML),
     then capture the Emerald wishlist API token for headless replay. The
     persistent profile remains the fallback credential.
@@ -981,6 +1040,7 @@ def _extract_xbox_wishlist_inline(page, context, session) -> dict[str, str]:
         return _drive_connect_page(page, context)
 
     _attach_sniffer(page)
+    connect_log("xbox_wishlist", "connect poll start", key="enter")
 
     try:
         page.goto(XBOX_WISHLIST_URL, wait_until="domcontentloaded", timeout=20000)
@@ -993,6 +1053,7 @@ def _extract_xbox_wishlist_inline(page, context, session) -> dict[str, str]:
     last_ssr_refresh = 0.0
     while time.time() < deadline:
         abort_if_browser_closed(context)
+        abort_if_cancelled(session)
         for pg in context.pages:
             if not pg.is_closed:
                 _attach_sniffer(pg)
@@ -1019,6 +1080,14 @@ def _extract_xbox_wishlist_inline(page, context, session) -> dict[str, str]:
         dom_signed_in_any, dom_page = _xbox_any_wishlist_dom_signed_in(context)
         dom_signed_in = dom_signed_in_any
         token_ready = bool(sniffer.token)
+        msa_ready = _xbox_has_msa_session(context)
+        connect_log(
+            "xbox_wishlist",
+            f"poll url={url!r} login={on_login} wishlist={on_wishlist} "
+            f"handoff={on_handoff} mid={mid_exchange} done={handoff_done} "
+            f"dom_signed_in={dom_signed_in_any} msa={msa_ready} token={token_ready}",
+            key="poll",
+        )
         if token_ready and dom_signed_in_any and not on_login:
             if session:
                 session.emit(
@@ -1026,6 +1095,7 @@ def _extract_xbox_wishlist_inline(page, context, session) -> dict[str, str]:
                     {"message": "Signed in \u2014 capturing your wishlist session..."},
                 )
             sniffer.dump()
+            connect_log("xbox_wishlist", "token + DOM signed-in — session ready", key="ready")
             return _xbox_wishlist_connect_creds(sniffer)
         # Cookie exchange complete (action=loggedin) but the SPA stalled on the
         # handoff page: drive forward to /wishlist so the Emerald wishlist XHR
@@ -1077,6 +1147,7 @@ def _extract_xbox_wishlist_inline(page, context, session) -> dict[str, str]:
                     {"message": "Signed in \u2014 capturing your wishlist session..."},
                 )
             sniffer.dump()
+            connect_log("xbox_wishlist", "token + DOM signed-in — session ready", key="ready2")
             return _xbox_wishlist_connect_creds(sniffer)
         if state is not None or (dom_signed_in_any and msa_ready and not on_login):
             if session:
@@ -1086,6 +1157,11 @@ def _extract_xbox_wishlist_inline(page, context, session) -> dict[str, str]:
                 )
             _xbox_capture_wishlist_api(dom_page or active, sniffer)
             sniffer.dump()
+            connect_log(
+                "xbox_wishlist",
+                f"SSR/MSA proof — session ready token={bool(sniffer.token)}",
+                key="ready-ssr",
+            )
             return _xbox_wishlist_connect_creds(sniffer)
 
         now = time.time()
@@ -1112,26 +1188,51 @@ NINTENDO_WISHLIST_POLL_SEC = 2.5
 
 
 def _nintendo_wishlist_session_ready(html: str, url: str, api_payloads: list[Any]) -> bool:
-    """True when storefront GraphQL confirms a signed-in wish-list session."""
-    from fetchers.fetch_nintendo_wishlist import _wishlist_graphql_ok, parse_wishlist_sources
+    """True when storefront GraphQL confirms a signed-in wish-list session.
+
+    Empty wishlists still count, but only after customer auth is proven — a guest
+    storefront answering ``wishList.items: []`` must not false-complete Connect.
+    """
+    from fetchers.fetch_nintendo_wishlist import (
+        _customer_graphql_authed,
+        _signed_out,
+        _wishlist_graphql_ok,
+        parse_wishlist_sources,
+    )
 
     u = (url or "").lower()
     if "accounts.nintendo.com/login" in u:
         return False
-    if any(_wishlist_graphql_ok(p) for p in api_payloads):
+    if _signed_out(html, url):
+        return False
+    # Guest Authorization typename in embedded page state.
+    if "GuestAuthorization" in (html or ""):
+        return False
+    graphql_ok = any(_wishlist_graphql_ok(p) for p in api_payloads)
+    customer_ok = any(_customer_graphql_authed(p) for p in api_payloads)
+    if graphql_ok and not customer_ok:
+        # Wishlist answered without a customer id — treat as guest/anonymous.
+        return False
+    if graphql_ok or customer_ok:
         return True
+    # HTML-only parse: require items so empty guest SSR cannot complete.
     return bool(parse_wishlist_sources(html, api_payloads))
 
 
 def _extract_nintendo_wishlist_inline(page, context, session) -> dict[str, str]:
     """Open nintendo.com/us/wish-list/, wait for sign-in, return marker cred."""
     from auth.cdp_browser import abort_if_browser_closed
+    from auth.connect_log import connect_log
     from fetchers.fetch_nintendo_wishlist import (
+        _customer_graphql_authed,
         _drain_nintendo_candidates,
         _is_nintendo_graphql_url,
+        _signed_out,
+        _wishlist_graphql_ok,
     )
 
     candidates: list[Any] = []
+    connect_log("nintendo_wishlist", "connect poll start", key="enter")
 
     def _stash_graphql(response) -> None:
         try:
@@ -1156,17 +1257,29 @@ def _extract_nintendo_wishlist_inline(page, context, session) -> dict[str, str]:
     last_msg = 0.0
     while time.time() < deadline:
         abort_if_browser_closed(context)
+        abort_if_cancelled(session)
         api_payloads = _drain_nintendo_candidates(candidates)
         try:
             html = page.content()
         except Exception:  # noqa: BLE001
             html = ""
         url = page.url or ""
-        if _nintendo_wishlist_session_ready(html, url, api_payloads):
+        graphql_ok = any(_wishlist_graphql_ok(p) for p in api_payloads)
+        customer_ok = any(_customer_graphql_authed(p) for p in api_payloads)
+        signed_out = _signed_out(html, url)
+        ready = _nintendo_wishlist_session_ready(html, url, api_payloads)
+        connect_log(
+            "nintendo_wishlist",
+            f"poll url={url!r} signed_out={signed_out} graphql_ok={graphql_ok} "
+            f"customer_ok={customer_ok} ready={ready}",
+            key="poll",
+        )
+        if ready:
             try:
                 page.wait_for_timeout(800)
             except Exception:  # noqa: BLE001
                 pass
+            connect_log("nintendo_wishlist", "session ready", key="ready")
             return {"NINTENDO_WISHLIST_PROFILE": "ready"}
 
         now = time.time()
@@ -1705,10 +1818,12 @@ def run_browser_auth(provider: str, session: AuthSession) -> dict[str, str] | No
 
     release_chromium_profile_lock(user_data)
 
+    allow_extensions = provider in ("epic", "epic_wishlist")
     with launch_persistent_profile(
         user_data,
         headless=False,
         initial_url=spec.login_url if provider == "ea" else None,
+        allow_extensions=allow_extensions,
     ) as context:
         try:
             context.add_init_script(_STEALTH_INIT)

--- a/auth/xbox_wishlist_session.py
+++ b/auth/xbox_wishlist_session.py
@@ -8,11 +8,10 @@ visible browser.
 
 from __future__ import annotations
 
-import threading
 import time
 from typing import Literal
 
-from auth.cdp_browser import launch_persistent_profile
+from auth.cdp_browser import close_browser_bounded, launch_persistent_profile
 from auth.runner import (
     _STEALTH_INIT,
     XBOX_WISHLIST_POLL_SEC,
@@ -97,7 +96,7 @@ def _capture_once(
             "Could not find __PRELOADED_STATE__ in the xbox.com/wishlist HTML response."
         )
     finally:
-        threading.Thread(target=ctx.close, daemon=True).start()
+        close_browser_bounded(ctx, profile=profile)
 
 
 def capture_xbox_wishlist_preloaded_state(

--- a/clients/amazon_web_client.py
+++ b/clients/amazon_web_client.py
@@ -651,7 +651,7 @@ def sniff_claims(
     dump_path: Path | str | None = None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, Any]]:
     """Replay saved browser profile; return (raw_claims, records, outcome)."""
-    from auth.cdp_browser import launch_persistent_profile
+    from auth.cdp_browser import close_browser_bounded, launch_persistent_profile
     from auth.secrets import profile_dir
 
     profile = profile_dir(PROFILE_KEY)
@@ -765,7 +765,7 @@ def sniff_claims(
 
             return outcome
         finally:
-            threading.Thread(target=ctx.close, daemon=True).start()
+            close_browser_bounded(ctx, profile=profile)
 
     headless_timeout_s = min(timeout_s, 30)
     headed_timeout_s = min(timeout_s, 25)

--- a/clients/amazon_web_client.py
+++ b/clients/amazon_web_client.py
@@ -13,7 +13,6 @@ Filter (codeless / Amazon-fulfilled only):
 from __future__ import annotations
 
 import json
-import threading
 import time
 from pathlib import Path
 from typing import Any

--- a/clients/nintendo_client.py
+++ b/clients/nintendo_client.py
@@ -18,7 +18,6 @@ History is limited to ~2 years per Nintendo support.
 from __future__ import annotations
 
 import json
-import threading
 import time
 from pathlib import Path
 from typing import Any

--- a/clients/nintendo_client.py
+++ b/clients/nintendo_client.py
@@ -306,7 +306,7 @@ class NintendoClient:
             pass
 
     def _fetch_via_browser_profile(self, profile_path: Path) -> list[dict]:
-        from auth.cdp_browser import launch_persistent_profile
+        from auth.cdp_browser import close_browser_bounded, launch_persistent_profile
 
         collected: list[dict[str, Any]] = []
         seen_ids: set[str] = set()
@@ -416,7 +416,7 @@ class NintendoClient:
             self._write_debug(debug)
             return [_map_graphql_item(item) for item in collected]
         finally:
-            threading.Thread(target=context.close, daemon=True).start()
+            close_browser_bounded(context, profile=profile_path)
 
     def _paginate_transactions_ui(self, page) -> None:
         """Click numeric pagination buttons to load additional GraphQL pages."""

--- a/clients/nintendo_vgc.py
+++ b/clients/nintendo_vgc.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import html
 import json
 import re
-import threading
 import time
 from pathlib import Path
 from typing import Any

--- a/clients/nintendo_vgc.py
+++ b/clients/nintendo_vgc.py
@@ -350,7 +350,7 @@ class NintendoVgcClient:
         return self._fetch_via_browser_profile(self._profile_path)
 
     def _fetch_via_browser_profile(self, profile_path: Path) -> list[dict[str, Any]]:
-        from auth.cdp_browser import launch_persistent_profile
+        from auth.cdp_browser import close_browser_bounded, launch_persistent_profile
 
         collected: list[dict[str, Any]] = []
         seen_ids: set[str] = set()
@@ -434,4 +434,4 @@ class NintendoVgcClient:
                 raise NintendoVgcCaptureError("VGC portal returned zero game cards.")
             return collected
         finally:
-            threading.Thread(target=context.close, daemon=True).start()
+            close_browser_bounded(context, profile=profile_path)

--- a/fetchers/fetch_epic_wishlist.py
+++ b/fetchers/fetch_epic_wishlist.py
@@ -306,7 +306,7 @@ def _drain_wishlist_candidates(
 
 
 def _fetch_with_profile_once(*, dump: bool = False, timeout_s: int = 45) -> tuple[str, str, list[Any]]:
-    from auth.cdp_browser import STEALTH_INIT_SCRIPT, launch_persistent_profile
+    from auth.cdp_browser import STEALTH_INIT_SCRIPT, close_browser_bounded, launch_persistent_profile
 
     profile = profile_dir("epic_wishlist")
     if not profile.exists():
@@ -411,7 +411,7 @@ def _fetch_with_profile_once(*, dump: bool = False, timeout_s: int = 45) -> tupl
 
         return html, url, api_payloads
     finally:
-        threading.Thread(target=ctx.close, daemon=True).start()
+        close_browser_bounded(ctx, profile=profile)
 
 
 def _fetch_with_profile(*, dump: bool = False, timeout_s: int = 45) -> tuple[str, str, list[Any]]:

--- a/fetchers/fetch_epic_wishlist.py
+++ b/fetchers/fetch_epic_wishlist.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-import threading
 import time
 from datetime import UTC, datetime
 from pathlib import Path

--- a/fetchers/fetch_humble_wishlist.py
+++ b/fetchers/fetch_humble_wishlist.py
@@ -192,7 +192,7 @@ def _lookup_products(page, slugs: list[str]) -> list[dict]:
 
 def _fetch_wishlist(*, dump: bool = False) -> tuple[list[WishlistItem], bool]:
     """Return (items, signed_out) from the headed Humble wishlist page."""
-    from auth.cdp_browser import STEALTH_INIT_SCRIPT, launch_persistent_profile
+    from auth.cdp_browser import STEALTH_INIT_SCRIPT, close_browser_bounded, launch_persistent_profile
 
     profile = profile_dir("humble")
     if not profile.exists():
@@ -251,7 +251,7 @@ def _fetch_wishlist(*, dump: bool = False) -> tuple[list[WishlistItem], bool]:
 
         return items, False
     finally:
-        threading.Thread(target=ctx.close, daemon=True).start()
+        close_browser_bounded(ctx, profile=profile)
 
 
 def _build_row(item: WishlistItem, hltb: dict | None) -> dict:

--- a/fetchers/fetch_humble_wishlist.py
+++ b/fetchers/fetch_humble_wishlist.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-import threading
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime

--- a/fetchers/fetch_nintendo_wishlist.py
+++ b/fetchers/fetch_nintendo_wishlist.py
@@ -891,7 +891,7 @@ def _fetch_with_profile(
     dump: bool = False,
     timeout_s: int = 45,
 ) -> tuple[str, str, list[Any]]:
-    from auth.cdp_browser import launch_persistent_profile
+    from auth.cdp_browser import close_browser_bounded, launch_persistent_profile
 
     profile = profile_dir("nintendo_wishlist")
     if not profile.exists():
@@ -1072,10 +1072,8 @@ def _fetch_with_profile(
             print(f"  wrote {dump_html()} and {dump_json()}", flush=True)
         return html, url, api_payloads
     finally:
-        # Spawn browser cleanup on a daemon thread so killing the headless
-        # Chrome process never blocks the fetcher from exiting. The OS will
-        # clean up orphaned Chrome when the Python process terminates.
-        threading.Thread(target=ctx.close, daemon=True).start()
+        # Bounded close: never leave an orphan Chrome holding the wishlist profile.
+        close_browser_bounded(ctx, profile=profile)
 
 
 

--- a/fetchers/fetch_nintendo_wishlist.py
+++ b/fetchers/fetch_nintendo_wishlist.py
@@ -18,7 +18,6 @@ import argparse
 import json
 import re
 import sys
-import threading
 import time
 from collections.abc import Iterable
 from dataclasses import dataclass

--- a/fetchers/fetch_ubisoft_wishlist.py
+++ b/fetchers/fetch_ubisoft_wishlist.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import threading
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime

--- a/fetchers/fetch_ubisoft_wishlist.py
+++ b/fetchers/fetch_ubisoft_wishlist.py
@@ -118,7 +118,7 @@ def _wishlist_page_ready(html: str) -> bool:
 
 def _fetch_wishlist_html(timeout_s: int = 45) -> tuple[str, str]:
     """Load the wishlist page with the saved Ubisoft profile, headless."""
-    from auth.cdp_browser import launch_persistent_profile
+    from auth.cdp_browser import close_browser_bounded, launch_persistent_profile
 
     profile = profile_dir("ubisoft")
     if not profile.exists():
@@ -151,7 +151,7 @@ def _fetch_wishlist_html(timeout_s: int = 45) -> tuple[str, str]:
 
 
     finally:
-        threading.Thread(target=ctx.close, daemon=True).start()
+        close_browser_bounded(ctx, profile=profile)
 
 def _classify_kind(name: str, edition: str | None) -> str:
     """Best-effort split between base games and DLC/cosmetics/currency packs.

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <!-- Must match pyproject.toml + package.json (see CHANGELOG release discipline). Read at runtime by js/error-boundary.js for bug-bundle metadata. -->
     <!-- Optional override for bug report endpoint during local testing: content="http://127.0.0.1:3000/api/report" -->
     <!-- <meta name="baklog-report-endpoint" content="https://baklog.app/api/report" /> -->
-    <meta name="baklog-version" content="0.8.40" />
+    <meta name="baklog-version" content="0.8.41" />
     <meta name="theme-color" content="#0f172a" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <script>

--- a/js/connections.js
+++ b/js/connections.js
@@ -688,6 +688,36 @@ function handleLayoutClick(ev) {
     return;
   }
 
+  const cancelBtn = target.closest("[data-cancel-connect]");
+
+  if (cancelBtn?.dataset.provider) {
+    const provider = cancelBtn.dataset.provider;
+    const card = document.querySelector(
+      `.conn-card[data-provider="${provider}"]`,
+    );
+    const log = card?.querySelector(".conn-log");
+    cancelBtn.disabled = true;
+    if (log) {
+      log.classList.remove("hidden");
+      log.textContent = "Cancelling sign-in…";
+    }
+    void (async () => {
+      const ok = await cancelBrowserConnect(provider);
+      if (log) {
+        log.textContent = ok
+          ? "Sign-in cancelled."
+          : "No active sign-in to cancel.";
+      }
+      hideConnectCancelControl(card);
+      try {
+        await refreshConnections();
+      } catch (_) {
+        /* noop */
+      }
+    })();
+    return;
+  }
+
   const saveBtn = target.closest(".conn-save");
 
   if (saveBtn?.dataset.provider) {
@@ -1588,6 +1618,40 @@ async function enableLocalProvider(provider) {
   await refreshConnections();
 }
 
+async function cancelBrowserConnect(provider) {
+  try {
+    const res = await baklogFetch(`/api/auth/${provider}/cancel`, {
+      method: "POST",
+    });
+    const data = await res.json().catch(() => ({}));
+    return res.ok && data.cancelled !== false;
+  } catch {
+    return false;
+  }
+}
+
+function showConnectCancelControl(card, provider, log) {
+  if (!card || !log) return;
+  let cancelBtn = card.querySelector("[data-cancel-connect]");
+  if (!cancelBtn) {
+    cancelBtn = document.createElement("button");
+    cancelBtn.type = "button";
+    cancelBtn.className = "conn-disconnect";
+    cancelBtn.dataset.cancelConnect = "1";
+    cancelBtn.dataset.provider = provider;
+    cancelBtn.title = "Cancel the in-progress sign-in window";
+    cancelBtn.textContent = "Cancel sign-in";
+    log.insertAdjacentElement("afterend", cancelBtn);
+  }
+  cancelBtn.hidden = false;
+  cancelBtn.disabled = false;
+}
+
+function hideConnectCancelControl(card) {
+  const cancelBtn = card?.querySelector("[data-cancel-connect]");
+  if (cancelBtn) cancelBtn.hidden = true;
+}
+
 async function startBrowserConnect(provider) {
   const card = document.querySelector(
     `.conn-card[data-provider="${provider}"]`,
@@ -1630,14 +1694,41 @@ async function startBrowserConnect(provider) {
     return;
   }
 
-  const data = await res.json().catch(() => ({}));
+  let data = await res.json().catch(() => ({}));
 
   if (!res.ok) {
-    if (log) log.textContent = data.error || `Start failed (${res.status})`;
-
-    return;
+    const alreadyOpen = /already open/i.test(String(data.error || ""));
+    if (alreadyOpen) {
+      if (log) {
+        log.textContent =
+          data.error ||
+          "A sign-in window is already open. Cancelling so you can retry…";
+      }
+      showConnectCancelControl(card, provider, log);
+      const cancelled = await cancelBrowserConnect(provider);
+      if (cancelled) {
+        if (log) log.textContent = "Previous sign-in cancelled. Retrying…";
+        hideConnectCancelControl(card);
+        try {
+          res = await baklogFetch(`/api/auth/${provider}/start?fresh=1`, {
+            method: "POST",
+          });
+          data = await res.json().catch(() => ({}));
+        } catch {
+          if (log)
+            log.textContent =
+              "Could not reach the local server (is server.py running?).";
+          return;
+        }
+      }
+    }
+    if (!res.ok) {
+      if (log) log.textContent = data.error || `Start failed (${res.status})`;
+      return;
+    }
   }
 
+  showConnectCancelControl(card, provider, log);
   startPostConnectFastPoll();
 
   const streamUrl = await urlWithStreamTicket(
@@ -1649,6 +1740,7 @@ async function startBrowserConnect(provider) {
   async function finishConnectUi() {
     if (connectUiFinished) return;
     connectUiFinished = true;
+    hideConnectCancelControl(card);
     stopPostConnectFastPoll();
     reconnectProviders.delete(provider);
     renderReconnectBanner();
@@ -1700,6 +1792,7 @@ async function startBrowserConnect(provider) {
     }
 
     connectUiFinished = true;
+    hideConnectCancelControl(card);
     es.close();
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog",
-  "version": "0.8.40",
+  "version": "0.8.41",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["auth*", "clients*", "fetchers*", "enrichers*", "shared*"]
 
 [project]
 name = "steam-backlog"
-version = "0.8.40"
+version = "0.8.41"
 description = "Local multi-store game library dashboard and fetchers"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/server.py
+++ b/server.py
@@ -22,6 +22,7 @@ Endpoints:
     DELETE /api/profiles/<id> -> delete non-active profile
     GET  /api/auth/status     -> per-provider connection state
     POST /api/auth/<p>/start  -> begin CDP browser sign-in (returns session_id)
+    POST /api/auth/<p>/cancel -> cancel an in-flight headed sign-in
     GET  /api/auth/<id>/stream -> SSE auth flow events
     PUT  /api/auth/<p>/credentials -> save form API keys
     POST /api/auth/<p>/disconnect  -> wipe stored credentials
@@ -1395,6 +1396,10 @@ class Handler(SimpleHTTPRequestHandler):
             provider = path[len("/api/auth/") : -len("/disconnect")].strip("/")
             self._handle_auth_disconnect(provider)
             return
+        if path.startswith("/api/auth/") and path.endswith("/cancel"):
+            provider = path[len("/api/auth/") : -len("/cancel")].strip("/")
+            self._handle_auth_cancel(provider)
+            return
         if path.startswith("/api/auth/") and path.endswith("/enable"):
             provider = path[len("/api/auth/") : -len("/enable")].strip("/")
             self._handle_auth_enable(provider)
@@ -2154,6 +2159,17 @@ class Handler(SimpleHTTPRequestHandler):
             _send_json(self, HTTPStatus.NOT_FOUND, {"error": f"unknown provider: {provider}"})
         except Exception as exc:  # noqa: BLE001
             _api_error(self, HTTPStatus.INTERNAL_SERVER_ERROR, "auth_disconnect_failed", exc)
+
+    def _handle_auth_cancel(self, provider: str) -> None:
+        try:
+            from auth.manager import cancel_browser_auth
+
+            cancelled = cancel_browser_auth(provider)
+            _send_json(self, HTTPStatus.OK, {"ok": True, "cancelled": cancelled})
+        except KeyError:
+            _send_json(self, HTTPStatus.NOT_FOUND, {"error": f"unknown provider: {provider}"})
+        except Exception as exc:  # noqa: BLE001
+            _api_error(self, HTTPStatus.INTERNAL_SERVER_ERROR, "auth_cancel_failed", exc)
 
     def _handle_auth_enable(self, provider: str) -> None:
         try:

--- a/tests/test_auth_manager_profile.py
+++ b/tests/test_auth_manager_profile.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -138,3 +139,58 @@ def test_start_browser_auth_rejects_overlapping_provider_session(
         auth_manager.start_browser_auth("steam")
 
     release.set()
+
+
+def test_cancel_browser_auth_finishes_session(
+    profile_env: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow_run(_provider: str, session: object) -> dict[str, str]:
+        started.set()
+        # Cooperative cancel: abort when asked.
+        from auth.runner import abort_if_cancelled
+
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            try:
+                abort_if_cancelled(session)  # type: ignore[arg-type]
+            except Exception:
+                return {}
+            if release.wait(timeout=0.05):
+                break
+        return {"token": "x"}
+
+    monkeypatch.setattr(auth_manager, "run_browser_auth", slow_run)
+    monkeypatch.setattr(auth_manager, "mark_connected", lambda _p, _c: None)
+    monkeypatch.setattr(auth_manager, "mark_invalid", lambda _p, error=None: None)
+
+    auth_manager.start_browser_auth("xbox_wishlist")
+    assert started.wait(timeout=3.0)
+    assert auth_manager.cancel_browser_auth("xbox_wishlist") is True
+    assert auth_manager._unfinished_session_for("xbox_wishlist") is None
+    release.set()
+
+
+def test_stale_session_taken_over_by_plain_connect(
+    profile_env: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    done = _stub_browser_worker(monkeypatch)
+    cleared: list[str] = []
+    monkeypatch.setattr(
+        auth_manager, "clear_browser_session", lambda p: cleared.append(p)
+    )
+
+    # Inject a stale unfinished session older than SUCCESS_WAIT_SEC + 30.
+    from auth.runner import AuthSession, SUCCESS_WAIT_SEC
+
+    stale = AuthSession("staleold", "xbox_wishlist")
+    stale.started_at = time.time() - (SUCCESS_WAIT_SEC + 60)
+    with auth_manager._sessions_lock:
+        auth_manager._active_sessions["staleold"] = stale
+
+    auth_manager.start_browser_auth("xbox_wishlist")
+    assert done.wait(timeout=3.0)
+    assert stale._finished.is_set()
+    assert auth_manager._unfinished_session_for("xbox_wishlist") is not None or done.is_set()

--- a/tests/test_auth_manager_profile.py
+++ b/tests/test_auth_manager_profile.py
@@ -183,7 +183,7 @@ def test_stale_session_taken_over_by_plain_connect(
     )
 
     # Inject a stale unfinished session older than SUCCESS_WAIT_SEC + 30.
-    from auth.runner import AuthSession, SUCCESS_WAIT_SEC
+    from auth.runner import SUCCESS_WAIT_SEC, AuthSession
 
     stale = AuthSession("staleold", "xbox_wishlist")
     stale.started_at = time.time() - (SUCCESS_WAIT_SEC + 60)

--- a/tests/test_battlenet_connect_loop.py
+++ b/tests/test_battlenet_connect_loop.py
@@ -366,10 +366,10 @@ def test_extract_sniffer_succeeds_without_battlenet_client_import(
 
 def test_battlenet_log_creates_file(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     from auth import connect_extractors as ce
+    from auth.connect_log import reset_connect_log_for_tests
 
     monkeypatch.setenv("BAKLOG_DATA_DIR", str(tmp_path))
-    monkeypatch.setattr(ce, "_battlenet_log_path", None)
-    monkeypatch.setattr(ce, "_battlenet_last_log_by_key", {})
+    reset_connect_log_for_tests()
     ce._battlenet_log("connect poll start", key="enter")
     log = tmp_path / "connect-battlenet.log"
     assert log.is_file()

--- a/tests/test_cdp_browser.py
+++ b/tests/test_cdp_browser.py
@@ -17,6 +17,7 @@ import io
 import os
 import sys
 import tempfile
+import time
 import urllib.error
 from pathlib import Path
 
@@ -334,6 +335,32 @@ class TestLaunchArgs:
 
         assert "--disable-extensions" in exc.value.args
 
+    def test_headed_launch_allow_extensions_skips_disable(self, tmp_path: Path) -> None:
+        exe = tmp_path / "chrome.exe"
+        exe.write_bytes(b"")
+        profile = tmp_path / "profile"
+
+        class LaunchArgsCaptured(Exception):
+            def __init__(self, args: list[str]) -> None:
+                self.args = args
+
+        def fake_popen(args, **kwargs):
+            raise LaunchArgsCaptured(list(args))
+
+        import auth.cdp_browser as cdp
+
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setattr(cdp, "find_chromium_executable", lambda: exe)
+        monkeypatch.setattr(cdp, "_free_port", lambda: 9222)
+        monkeypatch.setattr(cdp.subprocess, "Popen", fake_popen)
+        try:
+            with pytest.raises(LaunchArgsCaptured) as exc:
+                launch_persistent_profile(profile, headless=False, allow_extensions=True)
+        finally:
+            monkeypatch.undo()
+
+        assert "--disable-extensions" not in exc.value.args
+
     def test_headed_default_uses_start_maximized(self, tmp_path: Path) -> None:
         exe = tmp_path / "chrome.exe"
         exe.write_bytes(b"")
@@ -377,6 +404,33 @@ class TestProfileLockRelease:
         out = cdp.release_chromium_profile_lock(profile)
         assert out == [4242, 5151]
         assert killed == [4242, 5151]
+
+    def test_close_browser_bounded_force_releases_when_close_hangs(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        import auth.cdp_browser as cdp
+
+        profile = tmp_path / "xbox-profile"
+        profile.mkdir()
+        released: list[Path] = []
+
+        class HangCtx:
+            def close(self) -> None:
+                time.sleep(5.0)
+
+        monkeypatch.setattr(
+            cdp,
+            "pids_holding_chromium_profile",
+            lambda _p: [999] if not released else [],
+        )
+        monkeypatch.setattr(
+            cdp,
+            "release_chromium_profile_lock",
+            lambda p, wait_sec=3.0: released.append(Path(p)) or [999],
+        )
+
+        cdp.close_browser_bounded(HangCtx(), profile=profile, join_timeout=0.05)
+        assert released == [profile]
 
 
 class TestGracefulClose:
@@ -700,7 +754,7 @@ class TestLaunchWaitExitZero:
         exe = tmp_path / "chrome.exe"
         exe.write_bytes(b"")
         profile = tmp_path / "profile"
-        lock_calls: list[Path] = []
+        kill_calls: list[list[int]] = []
         clock = {"t": 0.0}
         real_popen = cdp.subprocess.Popen
 
@@ -739,15 +793,88 @@ class TestLaunchWaitExitZero:
         monkeypatch.setattr(cdp, "_fetch_json", fake_fetch)
         monkeypatch.setattr(cdp.time, "sleep", fake_sleep)
         monkeypatch.setattr(cdp.time, "time", lambda: clock["t"])
+        monkeypatch.setattr(cdp, "pids_holding_chromium_profile", lambda _p: [])
+        monkeypatch.setattr(cdp, "_pids_listening_on_local_port", lambda _p: [])
+        monkeypatch.setattr(
+            cdp,
+            "_kill_pids",
+            lambda pids, wait_sec=3.0: kill_calls.append(list(pids)) or [],
+        )
+        lock_calls: list[Path] = []
         monkeypatch.setattr(
             cdp,
             "release_chromium_profile_lock",
-            lambda p: lock_calls.append(Path(p)) or [],
+            lambda p, wait_sec=3.0: lock_calls.append(Path(p)) or [],
         )
 
         with pytest.raises(RuntimeError, match="did not start CDP"):
             launch_persistent_profile(profile, headless=False)
-        assert lock_calls, "exit 0 without CDP should release profile lock and retry"
+        # No pre-existing holders: extend wait + relaunch, never blanket-kill
+        # the profile (that closed the Connect window under the user).
+        assert lock_calls == []
+
+    def test_exit_zero_kills_only_pre_existing_holders(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        import auth.cdp_browser as cdp
+
+        exe = tmp_path / "chrome.exe"
+        exe.write_bytes(b"")
+        profile = tmp_path / "profile"
+        kill_calls: list[list[int]] = []
+        clock = {"t": 0.0}
+        real_popen = cdp.subprocess.Popen
+        holders = {"pids": [4242]}
+
+        class FakeProc:
+            stdout = io.BytesIO(b"")
+
+            def poll(self) -> int:
+                return 0
+
+            def kill(self) -> None:
+                return None
+
+            def communicate(self, input=None, timeout=None):  # noqa: A002
+                return (b"", b"")
+
+            def __enter__(self) -> FakeProc:
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                return None
+
+        def fake_fetch(url: str, timeout: float = 2) -> dict:
+            raise urllib.error.URLError("never")
+
+        def fake_sleep(_s: float) -> None:
+            clock["t"] += 40.0
+
+        monkeypatch.setattr(cdp, "find_chromium_executable", lambda: exe)
+        monkeypatch.setattr(cdp, "_free_port", lambda: 9222)
+        monkeypatch.setattr(
+            cdp.subprocess,
+            "Popen",
+            self._popen_only_fake(FakeProc, real_popen),
+        )
+        monkeypatch.setattr(cdp, "_fetch_json", fake_fetch)
+        monkeypatch.setattr(cdp.time, "sleep", fake_sleep)
+        monkeypatch.setattr(cdp.time, "time", lambda: clock["t"])
+        monkeypatch.setattr(
+            cdp,
+            "pids_holding_chromium_profile",
+            lambda _p: list(holders["pids"]),
+        )
+        monkeypatch.setattr(cdp, "_pids_listening_on_local_port", lambda _p: [])
+        monkeypatch.setattr(
+            cdp,
+            "_kill_pids",
+            lambda pids, wait_sec=3.0: kill_calls.append(list(pids)) or holders.update(pids=[]) or [],
+        )
+
+        with pytest.raises(RuntimeError, match="did not start CDP"):
+            launch_persistent_profile(profile, headless=False)
+        assert any(4242 in call for call in kill_calls)
 
     def test_nonzero_exit_still_raises_immediately(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/test_epic_library_connect_loop.py
+++ b/tests/test_epic_library_connect_loop.py
@@ -76,3 +76,35 @@ def test_epic_library_captures_redirect_on_non_first_tab(monkeypatch: pytest.Mon
 
     creds = runner._extract_epic_inline(primary, ctx, session=None)
     assert creds == {"EPIC_AUTH_CODE": "epic-lib-code-123"}
+
+
+def test_epic_library_inline_waits_on_cloudflare_managed_html(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from auth.epic_wishlist_session import EPIC_CF_CONNECT_HINT
+
+    clock = _FakeTime(step_s=6.0)
+    monkeypatch.setattr(runner, "time", clock)
+    monkeypatch.setattr(runner, "SUCCESS_WAIT_SEC", 20.0)
+    monkeypatch.setattr(runner, "POLL_SEC", 0.1)
+
+    cf_html = (
+        "<html><body><script>window._cf_chl_opt={cType: 'managed'};</script>"
+        "Enable JavaScript and cookies to continue</body></html>"
+    )
+    page = _FakePage("https://www.epicgames.com/id/login")
+    page.content = lambda: cf_html  # type: ignore[method-assign]
+    ctx = _FakeContext([page])
+    events: list[tuple[str, dict]] = []
+
+    class _Session:
+        def emit(self, event: str, data: dict) -> None:
+            events.append((event, data))
+
+    with pytest.raises(RuntimeError, match="Could not capture your Epic authorization code"):
+        runner._extract_epic_inline(page, ctx, session=_Session())  # type: ignore[arg-type]
+
+    assert any(
+        e == "waiting_for_user" and (d or {}).get("message") == EPIC_CF_CONNECT_HINT
+        for e, d in events
+    )

--- a/tests/test_epic_wishlist_connect_loop.py
+++ b/tests/test_epic_wishlist_connect_loop.py
@@ -70,6 +70,9 @@ class _FakePage:
     def wait_for_timeout(self, _ms: int) -> None:
         return None
 
+    def content(self) -> str:
+        return ""
+
 
 class _FakeLoginThenStorePage:
     """Simulates login -> store home -> post-login wishlist open."""
@@ -104,6 +107,9 @@ class _FakeLoginThenStorePage:
         path = urlparse(self.url or "").path.lower()
         if self._saw_login and self._polls == 1 and "wishlist" not in path:
             self.url = "https://store.epicgames.com/en-US/"
+
+    def content(self) -> str:
+        return ""
 
     def bring_to_front(self) -> None:
         return None
@@ -174,6 +180,9 @@ class _FakeSignedInRedirectPage:
 
     def wait_for_timeout(self, _ms: int) -> None:
         return None
+
+    def content(self) -> str:
+        return ""
 
     def bring_to_front(self) -> None:
         return None
@@ -249,3 +258,34 @@ def test_epic_wishlist_inline_post_login_goto_without_graphql_times_out(
         runner._extract_epic_wishlist_inline(page, context, session)  # type: ignore[attr-defined]
 
     assert page.goto_calls == 2
+
+
+def test_epic_wishlist_inline_waits_on_cloudflare_managed_html(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from auth.epic_wishlist_session import EPIC_CF_CONNECT_HINT
+
+    page = _FakePage(url="https://www.epicgames.com/id/login")
+    page.content = lambda: (  # type: ignore[method-assign]
+        "<html><body>window._cf_chl_opt={cType: 'managed'};"
+        "Enable JavaScript and cookies to continue</body></html>"
+    )
+    context = _FakeContext()
+    events: list[tuple[str, dict]] = []
+
+    class _Session:
+        def emit(self, event: str, data: dict) -> None:
+            events.append((event, data))
+
+    fake_time = _FakeTime(step_s=6.0)
+    monkeypatch.setattr(runner.time, "time", fake_time.time)
+    monkeypatch.setattr(runner, "SUCCESS_WAIT_SEC", 20.0)
+    monkeypatch.setattr(runner, "POLL_SEC", 0.1)
+
+    with pytest.raises(RuntimeError, match="Could not detect Epic wishlist sign-in"):
+        runner._extract_epic_wishlist_inline(page, context, _Session())  # type: ignore[arg-type]
+
+    assert any(
+        e == "waiting_for_user" and (d or {}).get("message") == EPIC_CF_CONNECT_HINT
+        for e, d in events
+    )

--- a/tests/test_epic_wishlist_session.py
+++ b/tests/test_epic_wishlist_session.py
@@ -80,6 +80,25 @@ def test_cloudflare_interstitial_real_challenge() -> None:
     assert storefront_auth_blocked(cf_html, wishlist_url)
 
 
+def test_cloudflare_interstitial_managed_challenge_html() -> None:
+    managed = (
+        "<html><body><script>window._cf_chl_opt={cType: 'managed'};</script>"
+        "Enable JavaScript and cookies to continue</body></html>"
+    )
+    login_url = "https://www.epicgames.com/id/login"
+    assert cloudflare_interstitial(managed, login_url)
+
+
+def test_cloudflare_interstitial_not_normal_epic_login_html() -> None:
+    login_html = (
+        "<html><head><title>Sign in to your Epic Games account</title></head>"
+        "<body><form><input name='email'/><button>Continue</button></form>"
+        "<script src='/cdn-cgi/challenge-platform/scripts/jsd/main.js'></script>"
+        "</body></html>"
+    )
+    assert not cloudflare_interstitial(login_html, "https://www.epicgames.com/id/login")
+
+
 def test_cloudflare_interstitial_not_store_home_js_bundle() -> None:
     snippet = (
         "<html><body><script>"

--- a/tests/test_nintendo_wishlist.py
+++ b/tests/test_nintendo_wishlist.py
@@ -130,3 +130,44 @@ def test_empty_authenticated_wishlist_counts_as_session() -> None:
     assert _wishlist_graphql_ok(payload)
     assert _wishlist_session_authenticated([payload])
     assert parse_wishlist_sources("", [payload]) == []
+
+
+def test_nintendo_wishlist_session_ready_rejects_guest_empty_graphql() -> None:
+    from auth.runner import _nintendo_wishlist_session_ready
+
+    guest_empty = {
+        "data": {
+            "customer": {
+                "wishList": {"items": [], "hasNextPage": False},
+            }
+        }
+    }
+    html = '<script>{"__typename":"GuestAuthorization"}</script>'
+    url = "https://www.nintendo.com/us/wish-list/"
+    assert not _nintendo_wishlist_session_ready(html, url, [guest_empty])
+    assert not _nintendo_wishlist_session_ready("", url, [guest_empty])
+
+
+def test_nintendo_wishlist_session_ready_accepts_authenticated_empty() -> None:
+    from auth.runner import _nintendo_wishlist_session_ready
+
+    authed_empty = {
+        "data": {
+            "customer": {
+                "id": "cust-1",
+                "wishList": {"items": [], "hasNextPage": False},
+            }
+        }
+    }
+    url = "https://www.nintendo.com/us/wish-list/"
+    assert _nintendo_wishlist_session_ready("", url, [authed_empty])
+
+
+def test_nintendo_wishlist_session_ready_rejects_signed_out_html() -> None:
+    from auth.runner import _nintendo_wishlist_session_ready
+
+    assert not _nintendo_wishlist_session_ready(
+        "<html>Sign in</html>",
+        "https://accounts.nintendo.com/login",
+        [],
+    )

--- a/tests/test_xbox_wishlist_connect.py
+++ b/tests/test_xbox_wishlist_connect.py
@@ -1,6 +1,11 @@
 """Xbox wishlist connect URL + SSR helpers."""
 from __future__ import annotations
 
+import time
+from pathlib import Path
+
+import pytest
+
 from auth import runner as auth_runner
 from auth.runner import _xbox_url_is_login, _xbox_url_on_wishlist
 
@@ -37,3 +42,59 @@ def test_xbox_has_msa_session_detects_wlssc_and_xb_tokens() -> None:
             ]
 
     assert auth_runner._xbox_has_msa_session(_Ctx2()) is True
+
+
+def test_xbox_capture_uses_bounded_close_on_hang(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Fetcher capture must not leave Chrome holding the profile after close hangs."""
+    from auth import xbox_wishlist_session as xws
+
+    profile = tmp_path / "xbox_wishlist"
+    profile.mkdir()
+    released: list[Path] = []
+
+    class HangCtx:
+        pages = []
+        _proc = type("P", (), {"poll": staticmethod(lambda: None)})()
+
+        def add_init_script(self, _s: str) -> None:
+            return None
+
+        def new_page(self):
+            class P:
+                def goto(self, *a, **k):
+                    raise RuntimeError("stop early")
+
+                def wait_for_timeout(self, _ms: int) -> None:
+                    return None
+
+                def content(self) -> str:
+                    return ""
+
+            return P()
+
+        def close(self) -> None:
+            time.sleep(5.0)
+
+    monkeypatch.setattr(xws, "profile_dir", lambda _p: profile)
+    monkeypatch.setattr(xws, "launch_persistent_profile", lambda *a, **k: HangCtx())
+    monkeypatch.setattr(
+        "auth.cdp_browser.pids_holding_chromium_profile",
+        lambda _p: [111] if not released else [],
+    )
+    monkeypatch.setattr(
+        "auth.cdp_browser.release_chromium_profile_lock",
+        lambda p, wait_sec=3.0: released.append(Path(p)) or [111],
+    )
+    # Force short join via close_browser_bounded used by the module.
+    real_bounded = xws.close_browser_bounded
+
+    def _bounded(ctx, *, profile=None, join_timeout: float = 10.0):
+        return real_bounded(ctx, profile=profile, join_timeout=0.05)
+
+    monkeypatch.setattr(xws, "close_browser_bounded", _bounded)
+
+    with pytest.raises(RuntimeError):
+        xws.capture_xbox_wishlist_preloaded_state(timeout_s=1)
+    assert released


### PR DESCRIPTION
## Summary
- Stop Xbox/Nintendo wishlist Connect flash-close: bounded Chrome close, launch retry kills only pre-existing profile holders, cancel API/UI for stuck sessions
- Nintendo wishlist Connect requires customer auth before ready (no empty guest GraphQL false-complete) + `connect-nintendo_wishlist.log`
- Epic/Epic WL Connect detects managed Cloudflare HTML, keeps polling with a clear wait hint, and launches without `--disable-extensions`

## Test plan
- [ ] pytest: cdp_browser, auth_manager_profile, xbox/nintendo wishlist, epic wishlist session + connect loops, battlenet connect_log
- [ ] Xbox wishlist Connect: window stays open through sign-in; Cancel works if stuck
- [ ] Nintendo wishlist Connect: guest empty list does not complete; signed-in empty may complete
- [ ] Epic + Epic WL Connect: CF challenge shows wait message and does not abort; sign-in after CF completes
- [ ] Do **not** tag `v0.8.41` in this PR
