### PR TITLE
fix: revert 0.8.41 Epic Connect Cloudflare regression (0.8.42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [Unreleased]
 
+## [0.8.42] - 2026-07-31
+
+### Fixed
+
+- Epic Connect: revert 0.8.41 Epic fingerprint/DOM-polling/CF-classification changes that triggered Cloudflare managed challenges on `/id/api/email/exists` (restore `--disable-extensions`, stop per-tick `content()` scraping on the login page, page-mode-only CF detection). Epic library Reconnect now preserves the browser profile so `cf_clearance` survives retries; Disconnect still wipes clean.
+
 ## [0.8.41] - 2026-07-31
 
 ### Fixed

--- a/auth/cdp_browser.py
+++ b/auth/cdp_browser.py
@@ -1616,7 +1616,6 @@ def launch_persistent_profile(
     window_size: tuple[int, int] | None = None,
     start_minimized: bool = False,
     initial_url: str | None = None,
-    allow_extensions: bool = False,
 ) -> CdpContext:
     """Launch Chrome/Edge with a persistent profile and return a CDP context.
 
@@ -1630,9 +1629,6 @@ def launch_persistent_profile(
 
     When ``initial_url`` is set, the first connect page navigates there after CDP attach
     (used by EA Connect to open the login page immediately).
-
-    ``allow_extensions`` keeps Chrome extensions enabled. Default is off (cleaner
-    OAuth); Epic Connect sets this True to reduce Cloudflare Bot Management flags.
     """
     exe = find_chromium_executable()
     port = _free_port()
@@ -1651,17 +1647,13 @@ def launch_persistent_profile(
         "--remote-allow-origins=http://127.0.0.1,http://localhost,http://[::1]",
         "--no-first-run",
         "--no-default-browser-check",
-    ]
-    if not allow_extensions:
         # Sign-in uses an isolated profile, but extensions synced into that profile
         # (or enterprise policy) can redirect OAuth flows — keep the window clean.
-        # Epic Connect opts out: --disable-extensions worsens CF bot scores.
-        args.append("--disable-extensions")
-    args.append(
+        "--disable-extensions",
         # Omit --disable-blink-features=AutomationControlled: Chrome/Edge show a
         # persistent "unsupported command-line flag" infobar that blocks the login UI.
         "--disable-features=IsolateOrigins,site-per-process",
-    )
+    ]
     if headless:
         mode = "new" if headless is True else str(headless).lower()
         if mode in ("legacy", "old"):

--- a/auth/epic_wishlist_session.py
+++ b/auth/epic_wishlist_session.py
@@ -232,12 +232,7 @@ def wishlist_capture_complete_from_html(html: str) -> bool:
 
 
 def cloudflare_interstitial(html: str, url: str) -> bool:
-    """True for an active Cloudflare challenge (page or managed challenge HTML).
-
-    Matches challenge pages and Epic ID managed challenges that dump
-    ``_cf_chl_opt`` / ``Enable JavaScript and cookies`` into the login form —
-    without treating every page that merely loads a generic CF script as blocked.
-    """
+    """True only for an active Cloudflare challenge page (not embedded CF scripts)."""
     u = (url or "").lower()
     if "/cdn-cgi/challenge" in u:
         return True
@@ -246,19 +241,21 @@ def cloudflare_interstitial(html: str, url: str) -> bool:
         return True
     if "cf_challenge_container" in body or "cf_challenge_text" in body:
         return True
-    # Managed challenge embedded in Epic ID login / XHR error HTML.
-    if "window._cf_chl_opt" in body or "_cf_chl_opt" in body:
-        return True
-    if "cType: 'managed'" in body or 'cType: "managed"' in body:
-        return True
-    if "Enable JavaScript and cookies to continue" in body:
-        return True
     return False
 
 
-EPIC_CF_CONNECT_HINT = (
-    "Complete the Cloudflare check in the browser window, then continue sign-in."
-)
+def cloudflare_embedded_challenge(html: str) -> bool:
+    """CF managed-challenge HTML embedded in an XHR response (not a challenge page).
+
+    Diagnostics only — do not use for Connect/fetch classification. Epic's login
+    SPA can dump ``_cf_chl_opt`` into a form error element on an otherwise-normal
+    login page; treating that as a page-mode challenge misclassifies sign-in.
+    """
+    body = html or ""
+    return (
+        "_cf_chl_opt" in body
+        or "Enable JavaScript and cookies to continue" in body
+    )
 
 
 def storefront_bounced_to_home(url: str) -> bool:

--- a/auth/manager.py
+++ b/auth/manager.py
@@ -671,9 +671,9 @@ def disconnect(provider: str) -> None:
     clear_browser_session(provider)
 
 
-# Cloudflare-gated storefronts where wiping the profile on reconnect forces a
-# new cf_clearance challenge every time and Epic drops the storefront session.
-PRESERVE_PROFILE_ON_RECONNECT = frozenset({"epic_wishlist"})
+# Cloudflare-gated Epic flows where wiping the profile on reconnect forces a
+# new cf_clearance challenge every time.
+PRESERVE_PROFILE_ON_RECONNECT = frozenset({"epic", "epic_wishlist"})
 
 
 def _should_clear_on_reconnect(provider: str) -> bool:

--- a/auth/registry.py
+++ b/auth/registry.py
@@ -138,6 +138,7 @@ PROVIDERS: dict[str, ProviderSpec] = {
         success_url_pattern=r"id/api/redirect",
         expiry_days=30,
         fetcher_keys=("epic",),
+        preserve_profile_on_reconnect=True,
         tips=(
             "Click Connect and sign in — we grab the authorizationCode for you, no copy/paste.",
             (

--- a/auth/runner.py
+++ b/auth/runner.py
@@ -343,7 +343,6 @@ def _extract_epic_inline(page, context, session: AuthSession | None = None) -> d
     the fetcher can reuse it. On any failure the user can still paste the code manually.
     """
     from auth.cdp_browser import abort_if_browser_closed
-    from auth.epic_wishlist_session import EPIC_CF_CONNECT_HINT, cloudflare_interstitial
 
     login_url = spec_for("epic").login_url
     try:
@@ -408,26 +407,8 @@ def _extract_epic_inline(page, context, session: AuthSession | None = None) -> d
                 page.wait_for_timeout(int(POLL_SEC * 1000))
                 continue
 
-        drive_url = drive.url or ""
-        drive_html = ""
-        try:
-            drive_html = drive.content() if hasattr(drive, "content") else ""
-        except Exception:  # noqa: BLE001
-            drive_html = ""
-        if not drive_html:
-            try:
-                drive_html = page.content()
-            except Exception:  # noqa: BLE001
-                drive_html = ""
+        url = (drive.url or "").lower()
         now = time.time()
-        if cloudflare_interstitial(drive_html, drive_url):
-            if session and now - last_hint > 6:
-                last_hint = now
-                session.emit("waiting_for_user", {"message": EPIC_CF_CONNECT_HINT})
-            page.wait_for_timeout(int(POLL_SEC * 1000))
-            continue
-
-        url = drive_url.lower()
         if session and now - last_hint > 10:
             last_hint = now
             if "login" in url or "id.epicgames.com" in url:
@@ -664,8 +645,6 @@ def _extract_epic_wishlist_inline(page, context, session) -> dict[str, str]:
     from auth.cdp_browser import abort_if_browser_closed
     from auth.connect_extractors import build_epic_wishlist_graphql_sniffer
     from auth.epic_wishlist_session import (
-        EPIC_CF_CONNECT_HINT,
-        cloudflare_interstitial,
         storefront_bounced_to_home,
         wishlist_capture_complete_from_html,
     )
@@ -738,21 +717,11 @@ def _extract_epic_wishlist_inline(page, context, session) -> dict[str, str]:
             return {"EPIC_STORE_COOKIE": "ready"}
 
         now = time.time()
-        try:
-            html = page.content()
-        except Exception:  # noqa: BLE001
-            html = ""
-        if cloudflare_interstitial(html, url):
-            if session and now - last_msg > 6:
-                last_msg = now
-                session.emit("waiting_for_user", {"message": EPIC_CF_CONNECT_HINT})
-            page.wait_for_timeout(int(POLL_SEC * 1000))
-            continue
 
         if session and now - last_msg > 8:
             last_msg = now
             if "challenge" in ul or "cloudflare" in ul:
-                msg = EPIC_CF_CONNECT_HINT
+                msg = "Cloudflare challenge — click the checkbox if shown."
             elif _epic_on_login_page(url) or "signin" in ul:
                 msg = (
                     "Sign in to Epic in this window — you'll be returned to your "
@@ -1818,12 +1787,10 @@ def run_browser_auth(provider: str, session: AuthSession) -> dict[str, str] | No
 
     release_chromium_profile_lock(user_data)
 
-    allow_extensions = provider in ("epic", "epic_wishlist")
     with launch_persistent_profile(
         user_data,
         headless=False,
         initial_url=spec.login_url if provider == "ea" else None,
-        allow_extensions=allow_extensions,
     ) as context:
         try:
             context.add_init_script(_STEALTH_INIT)

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <!-- Must match pyproject.toml + package.json (see CHANGELOG release discipline). Read at runtime by js/error-boundary.js for bug-bundle metadata. -->
     <!-- Optional override for bug report endpoint during local testing: content="http://127.0.0.1:3000/api/report" -->
     <!-- <meta name="baklog-report-endpoint" content="https://baklog.app/api/report" /> -->
-    <meta name="baklog-version" content="0.8.41" />
+    <meta name="baklog-version" content="0.8.42" />
     <meta name="theme-color" content="#0f172a" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <script>

--- a/js/connections.js
+++ b/js/connections.js
@@ -1662,12 +1662,12 @@ async function startBrowserConnect(provider) {
   // A "Reconnect" (status connected/expired) should start a clean sign-in:
   // wipe the old profile cookies server-side so a stale/expired session never
   // carries over. A first-time Connect has nothing to clear.
-  // Epic wishlist keeps its browser profile on reconnect — cf_clearance and
-  // storefront cookies must survive or Cloudflare re-challenges every time.
+  // Epic library + wishlist keep their browser profiles on reconnect —
+  // cf_clearance and storefront cookies must survive or Cloudflare re-challenges every time.
   const current = getAuthStatusSnapshot().find(
     (x) => x.key === provider,
   )?.status;
-  const preserveProfile = provider === "epic_wishlist";
+  const preserveProfile = provider === "epic" || provider === "epic_wishlist";
   const fresh =
     !preserveProfile && (current === "connected" || current === "expired");
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog",
-  "version": "0.8.41",
+  "version": "0.8.42",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["auth*", "clients*", "fetchers*", "enrichers*", "shared*"]
 
 [project]
 name = "steam-backlog"
-version = "0.8.41"
+version = "0.8.42"
 description = "Local multi-store game library dashboard and fetchers"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_auth_reconnect_profile.py
+++ b/tests/test_auth_reconnect_profile.py
@@ -9,12 +9,20 @@ def test_epic_wishlist_preserves_profile_on_reconnect() -> None:
     assert _should_clear_on_reconnect("epic_wishlist") is False
 
 
+def test_epic_library_preserves_profile_on_reconnect() -> None:
+    assert _should_clear_on_reconnect("epic") is False
+
+
 def test_gog_clears_profile_on_reconnect() -> None:
     assert _should_clear_on_reconnect("gog") is True
 
 
 def test_epic_wishlist_in_preserve_set() -> None:
     assert "epic_wishlist" in PRESERVE_PROFILE_ON_RECONNECT
+
+
+def test_epic_library_in_preserve_set() -> None:
+    assert "epic" in PRESERVE_PROFILE_ON_RECONNECT
 
 
 def test_epic_wishlist_clears_profile_when_disconnected() -> None:

--- a/tests/test_cdp_browser.py
+++ b/tests/test_cdp_browser.py
@@ -335,32 +335,6 @@ class TestLaunchArgs:
 
         assert "--disable-extensions" in exc.value.args
 
-    def test_headed_launch_allow_extensions_skips_disable(self, tmp_path: Path) -> None:
-        exe = tmp_path / "chrome.exe"
-        exe.write_bytes(b"")
-        profile = tmp_path / "profile"
-
-        class LaunchArgsCaptured(Exception):
-            def __init__(self, args: list[str]) -> None:
-                self.args = args
-
-        def fake_popen(args, **kwargs):
-            raise LaunchArgsCaptured(list(args))
-
-        import auth.cdp_browser as cdp
-
-        monkeypatch = pytest.MonkeyPatch()
-        monkeypatch.setattr(cdp, "find_chromium_executable", lambda: exe)
-        monkeypatch.setattr(cdp, "_free_port", lambda: 9222)
-        monkeypatch.setattr(cdp.subprocess, "Popen", fake_popen)
-        try:
-            with pytest.raises(LaunchArgsCaptured) as exc:
-                launch_persistent_profile(profile, headless=False, allow_extensions=True)
-        finally:
-            monkeypatch.undo()
-
-        assert "--disable-extensions" not in exc.value.args
-
     def test_headed_default_uses_start_maximized(self, tmp_path: Path) -> None:
         exe = tmp_path / "chrome.exe"
         exe.write_bytes(b"")

--- a/tests/test_epic_library_connect_loop.py
+++ b/tests/test_epic_library_connect_loop.py
@@ -78,33 +78,28 @@ def test_epic_library_captures_redirect_on_non_first_tab(monkeypatch: pytest.Mon
     assert creds == {"EPIC_AUTH_CODE": "epic-lib-code-123"}
 
 
-def test_epic_library_inline_waits_on_cloudflare_managed_html(
+def test_epic_library_inline_does_not_poll_content_on_login(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from auth.epic_wishlist_session import EPIC_CF_CONNECT_HINT
-
+    """Regression: never call content() every poll tick on the Epic ID login page."""
     clock = _FakeTime(step_s=6.0)
     monkeypatch.setattr(runner, "time", clock)
     monkeypatch.setattr(runner, "SUCCESS_WAIT_SEC", 20.0)
     monkeypatch.setattr(runner, "POLL_SEC", 0.1)
 
-    cf_html = (
-        "<html><body><script>window._cf_chl_opt={cType: 'managed'};</script>"
-        "Enable JavaScript and cookies to continue</body></html>"
-    )
     page = _FakePage("https://www.epicgames.com/id/login")
-    page.content = lambda: cf_html  # type: ignore[method-assign]
-    ctx = _FakeContext([page])
-    events: list[tuple[str, dict]] = []
+    content_calls = 0
+    original_content = page.content
 
-    class _Session:
-        def emit(self, event: str, data: dict) -> None:
-            events.append((event, data))
+    def _counting_content() -> str:
+        nonlocal content_calls
+        content_calls += 1
+        return original_content()
+
+    page.content = _counting_content  # type: ignore[method-assign]
+    ctx = _FakeContext([page])
 
     with pytest.raises(RuntimeError, match="Could not capture your Epic authorization code"):
-        runner._extract_epic_inline(page, ctx, session=_Session())  # type: ignore[arg-type]
+        runner._extract_epic_inline(page, ctx, session=None)
 
-    assert any(
-        e == "waiting_for_user" and (d or {}).get("message") == EPIC_CF_CONNECT_HINT
-        for e, d in events
-    )
+    assert content_calls == 0

--- a/tests/test_epic_wishlist_connect_loop.py
+++ b/tests/test_epic_wishlist_connect_loop.py
@@ -258,34 +258,3 @@ def test_epic_wishlist_inline_post_login_goto_without_graphql_times_out(
         runner._extract_epic_wishlist_inline(page, context, session)  # type: ignore[attr-defined]
 
     assert page.goto_calls == 2
-
-
-def test_epic_wishlist_inline_waits_on_cloudflare_managed_html(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from auth.epic_wishlist_session import EPIC_CF_CONNECT_HINT
-
-    page = _FakePage(url="https://www.epicgames.com/id/login")
-    page.content = lambda: (  # type: ignore[method-assign]
-        "<html><body>window._cf_chl_opt={cType: 'managed'};"
-        "Enable JavaScript and cookies to continue</body></html>"
-    )
-    context = _FakeContext()
-    events: list[tuple[str, dict]] = []
-
-    class _Session:
-        def emit(self, event: str, data: dict) -> None:
-            events.append((event, data))
-
-    fake_time = _FakeTime(step_s=6.0)
-    monkeypatch.setattr(runner.time, "time", fake_time.time)
-    monkeypatch.setattr(runner, "SUCCESS_WAIT_SEC", 20.0)
-    monkeypatch.setattr(runner, "POLL_SEC", 0.1)
-
-    with pytest.raises(RuntimeError, match="Could not detect Epic wishlist sign-in"):
-        runner._extract_epic_wishlist_inline(page, context, _Session())  # type: ignore[arg-type]
-
-    assert any(
-        e == "waiting_for_user" and (d or {}).get("message") == EPIC_CF_CONNECT_HINT
-        for e, d in events
-    )

--- a/tests/test_epic_wishlist_session.py
+++ b/tests/test_epic_wishlist_session.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from auth.epic_wishlist_session import (
+    cloudflare_embedded_challenge,
     cloudflare_interstitial,
     enrich_wishlist_elements_with_catalog,
     extract_catalog_offers_from_html,
@@ -81,12 +82,14 @@ def test_cloudflare_interstitial_real_challenge() -> None:
 
 
 def test_cloudflare_interstitial_managed_challenge_html() -> None:
+    """Embedded CF markers in a form error must not classify as a challenge page."""
     managed = (
         "<html><body><script>window._cf_chl_opt={cType: 'managed'};</script>"
         "Enable JavaScript and cookies to continue</body></html>"
     )
     login_url = "https://www.epicgames.com/id/login"
-    assert cloudflare_interstitial(managed, login_url)
+    assert not cloudflare_interstitial(managed, login_url)
+    assert cloudflare_embedded_challenge(managed)
 
 
 def test_cloudflare_interstitial_not_normal_epic_login_html() -> None:


### PR DESCRIPTION
## Summary
- Revert 0.8.41 Epic fingerprint changes: restore unconditional `--disable-extensions`
- Stop per-tick `content()` scraping on Epic ID login / wishlist Connect loops
- Restore page-mode-only `cloudflare_interstitial`; keep `cloudflare_embedded_challenge` for diagnostics only
- Preserve `epic` browser profile on Reconnect so `cf_clearance` survives (Disconnect still wipes)

## Test plan
- [x] pytest: cdp_browser, epic wishlist session/connect loops, library connect loop, auth reconnect profile
- [ ] Epic library Connect on 0.8.42: email continue no longer dumps CF HTML into form error
- [ ] Epic Reconnect does not clear profile; Disconnect still clears
- [ ] Tag + Release after merge