### PR TITLE
fix: Epic Connect Cloudflare challenge background tab (0.8.43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [Unreleased]
 
+## [0.8.43] - 2026-07-31
+
+### Fixed
+
+- Epic Connect Cloudflare managed challenge on `/id/api/email/exists`: passively sniff the XHR body for `__cf_chl_tk`, open that URL in a background tab so CF's orchestrator can run (Epic was dumping challenge HTML into the form error as text, so the script never executed). Skip heavy STEALTH_INIT for Epic to reduce Bot Management noise; keep the system-browser OAuth escape hatch in the wait hint.
+
 ## [0.8.42] - 2026-07-31
 
 ### Fixed

--- a/auth/cdp_browser.py
+++ b/auth/cdp_browser.py
@@ -1081,6 +1081,7 @@ class CdpContext:
         self._init_scripts: list[str] = []
         self._page_handlers: list[Callable[[CdpPage], None]] = []
         self._ubisoft_native_popup_targets: set[str] = set()
+        self._background_targets: set[str] = set()
         self._ws_dead = False
         self.request = CdpHttpClient(self)
 
@@ -1195,9 +1196,16 @@ class CdpContext:
             )
         return out
 
-    def new_page(self) -> CdpPage:
-        result = self._send("Target.createTarget", {"url": "about:blank"})
+    def new_page(self, *, background: bool = False) -> CdpPage:
+        params: dict[str, Any] = {"url": "about:blank"}
+        if background:
+            # Create without activating — keeps Epic login form focused while a
+            # Cloudflare challenge tab loads in the background.
+            params["background"] = True
+        result = self._send("Target.createTarget", params)
         target_id = result.get("targetId", "")
+        if background and target_id:
+            self._background_targets.add(target_id)
         page = self._attach_page(target_id)
         if page not in self.pages:
             self.pages.append(page)
@@ -1237,6 +1245,11 @@ class CdpContext:
                 time.sleep(0.25)
             url = (page.url or "").strip()
             others = [p for p in self.pages if p is not page and not p.is_closed]
+
+            # Programmatic background tabs (Epic CF challenge) must stay quiet —
+            # never steal focus from the login form via bring_to_front.
+            if getattr(page, "_target_id", "") in self._background_targets:
+                return
 
             if _should_preserve_popup(url):
                 # Blank OAuth popups must stay open but should not steal focus

--- a/auth/connect_extractors.py
+++ b/auth/connect_extractors.py
@@ -626,6 +626,55 @@ def build_epic_wishlist_graphql_sniffer() -> DeferredGraphqlResponseSniffer:
     )
 
 
+class EpicEmailExistsCfSniffer:
+    """Stash ``/id/api/email/exists`` responses; drain CF challenge URLs off-thread.
+
+    Cloudflare often returns non-200 HTML for the email-exists XHR. Epic dumps that
+    body into the login form error so the challenge script never runs — Connect
+    must open the ``__cf_chl_tk`` URL as a top-level document instead.
+    """
+
+    def __init__(self) -> None:
+        self._pending: list[Any] = []
+        self._seen_tokens: set[str] = set()
+        self._lock = threading.Lock()
+
+    def attach(self, page: Any) -> None:
+        def on_response(response: Any) -> None:
+            try:
+                url = (getattr(response, "url", None) or "").lower()
+                if "/id/api/email/exists" not in url:
+                    return
+                self._pending.append(response)
+            except Exception:  # noqa: BLE001
+                pass
+
+        page.on("response", on_response)
+
+    def drain_challenge_url(self) -> str | None:
+        from urllib.parse import parse_qs, urlparse
+
+        from auth.epic_wishlist_session import extract_epic_cf_challenge_url
+
+        while self._pending:
+            resp = self._pending.pop(0)
+            try:
+                body = resp.text()
+            except Exception:  # noqa: BLE001
+                continue
+            url = extract_epic_cf_challenge_url(body or "")
+            if not url:
+                continue
+            qs = parse_qs(urlparse(url).query)
+            token = (qs.get("__cf_chl_tk") or [None])[0] or url
+            with self._lock:
+                if token in self._seen_tokens:
+                    continue
+                self._seen_tokens.add(token)
+            return url
+        return None
+
+
 UBISOFT_API_HOST = "public-ubiservices.ubi.com"
 
 

--- a/auth/epic_wishlist_session.py
+++ b/auth/epic_wishlist_session.py
@@ -258,6 +258,34 @@ def cloudflare_embedded_challenge(html: str) -> bool:
     )
 
 
+_CUPMDTK_RE = re.compile(r"""cUPMDTk\s*:\s*["']([^"']+)["']""")
+_CF_CHL_TK_RE = re.compile(r"__cf_chl_tk=([A-Za-z0-9_.\-]+)")
+_EPIC_CF_ORIGIN = "https://www.epicgames.com"
+
+
+def extract_epic_cf_challenge_url(html: str) -> str | None:
+    """Build a top-level CF challenge URL from managed-challenge HTML/XHR body.
+
+    Epic dumps challenge HTML into the login form error; the orchestrator never
+    runs there. Opening ``cUPMDTk`` / ``__cf_chl_tk`` as a document lets CF set
+    ``cf_clearance`` for ``www.epicgames.com``.
+    """
+    body = html or ""
+    if not cloudflare_embedded_challenge(body):
+        return None
+    m = _CUPMDTK_RE.search(body)
+    if m:
+        path = (m.group(1) or "").strip()
+        if path.startswith("/"):
+            return f"{_EPIC_CF_ORIGIN}{path}"
+        if path.startswith("http://") or path.startswith("https://"):
+            return path
+    tk = _CF_CHL_TK_RE.search(body)
+    if tk:
+        return f"{_EPIC_CF_ORIGIN}/id/api/email/exists?__cf_chl_tk={tk.group(1)}"
+    return None
+
+
 def storefront_bounced_to_home(url: str) -> bool:
     """True when the storefront URL is not the wishlist after a wishlist navigation."""
     parsed = urlparse(url or "")

--- a/auth/runner.py
+++ b/auth/runner.py
@@ -332,6 +332,46 @@ EPIC_CORRECTIVE_ACTION_ERROR = (
     "accept the privacy policy / complete the prompt, then refresh the page and "
     "click Connect again."
 )
+EPIC_CF_CHALLENGE_HINT = (
+    "Cloudflare opened a check in a background tab — complete it there, then "
+    "continue signing in on this page. Or use Sign in with your browser instead."
+)
+EPIC_CF_CHALLENGE_COOLDOWN_SEC = 30.0
+
+
+def _close_epic_cf_challenge_tabs(pages: list) -> None:
+    for pg in list(pages):
+        try:
+            pg.close()
+        except Exception:  # noqa: BLE001
+            pass
+    pages.clear()
+
+
+def _maybe_open_epic_cf_challenge(
+    context,
+    sniffer,
+    session: AuthSession | None,
+    *,
+    opened_until: list[float],
+    challenge_pages: list,
+) -> None:
+    """Open a background tab for a sniffed CF challenge URL (once per cooldown)."""
+    now = time.time()
+    if opened_until and opened_until[0] > now:
+        return
+    challenge_url = sniffer.drain_challenge_url()
+    if not challenge_url:
+        return
+    try:
+        bg = context.new_page(background=True)
+        challenge_pages.append(bg)
+        bg.goto(challenge_url, wait_until="domcontentloaded", timeout=25_000)
+    except Exception:  # noqa: BLE001
+        pass
+    opened_until[:] = [now + EPIC_CF_CHALLENGE_COOLDOWN_SEC]
+    if session:
+        session.emit("waiting_for_user", {"message": EPIC_CF_CHALLENGE_HINT})
 
 
 def _extract_epic_inline(page, context, session: AuthSession | None = None) -> dict[str, str]:
@@ -343,8 +383,13 @@ def _extract_epic_inline(page, context, session: AuthSession | None = None) -> d
     the fetcher can reuse it. On any failure the user can still paste the code manually.
     """
     from auth.cdp_browser import abort_if_browser_closed
+    from auth.connect_extractors import EpicEmailExistsCfSniffer
 
     login_url = spec_for("epic").login_url
+    cf_sniffer = EpicEmailExistsCfSniffer()
+    cf_sniffer.attach(page)
+    cf_opened_until: list[float] = [0.0]
+    cf_pages: list = []
     try:
         page.goto(login_url, wait_until="domcontentloaded", timeout=25_000)
     except Exception:
@@ -352,77 +397,89 @@ def _extract_epic_inline(page, context, session: AuthSession | None = None) -> d
 
     deadline = time.time() + SUCCESS_WAIT_SEC
     last_hint = 0.0
-    while time.time() < deadline:
-        abort_if_browser_closed(context)
-        drive = _drive_connect_page(page, context)
+    try:
+        while time.time() < deadline:
+            abort_if_browser_closed(context)
+            _maybe_open_epic_cf_challenge(
+                context,
+                cf_sniffer,
+                session,
+                opened_until=cf_opened_until,
+                challenge_pages=cf_pages,
+            )
+            drive = _drive_connect_page(page, context)
 
-        redirect_page = None
-        for pg in _connect_pages(page, context):
-            if EPIC_REDIRECT_MARKER in (pg.url or "").lower():
-                redirect_page = pg
-                break
-        if redirect_page is not None:
-            main = redirect_page
-            url = (main.url or "").lower()
-            body = ""
-            try:
-                body = main.evaluate("() => document.body ? document.body.innerText : ''") or ""
-            except Exception:
+            redirect_page = None
+            for pg in _connect_pages(page, context):
+                if EPIC_REDIRECT_MARKER in (pg.url or "").lower():
+                    redirect_page = pg
+                    break
+            if redirect_page is not None:
+                main = redirect_page
+                url = (main.url or "").lower()
                 body = ""
-            code = _epic_code_from_text(body)
-            html = ""
-            if not code:
                 try:
-                    html = main.content()
+                    body = main.evaluate("() => document.body ? document.body.innerText : ''") or ""
                 except Exception:
-                    html = ""
-                code = _epic_code_from_text(html)
-            if code:
-                from clients.epic_client import (
-                    EpicAuthError,
-                    EpicClient,
-                    EpicCorrectiveActionError,
-                    default_epic_cache_dir,
-                )
+                    body = ""
+                code = _epic_code_from_text(body)
+                html = ""
+                if not code:
+                    try:
+                        html = main.content()
+                    except Exception:
+                        html = ""
+                    code = _epic_code_from_text(html)
+                if code:
+                    from clients.epic_client import (
+                        EpicAuthError,
+                        EpicClient,
+                        EpicCorrectiveActionError,
+                        default_epic_cache_dir,
+                    )
 
-                try:
-                    EpicClient(auth_code=code, cache_dir=default_epic_cache_dir()).login()
-                except EpicCorrectiveActionError as exc:
-                    raise RuntimeError(EPIC_CORRECTIVE_ACTION_ERROR) from exc
-                except EpicAuthError as exc:
-                    raise RuntimeError(
-                        f"Epic rejected the captured code ({exc}). Refresh the Epic page so a new "
-                        "code appears, or paste the authorizationCode into the fallback field below."
-                    ) from exc
-                return {"EPIC_AUTH_CODE": code}
+                    try:
+                        EpicClient(auth_code=code, cache_dir=default_epic_cache_dir()).login()
+                    except EpicCorrectiveActionError as exc:
+                        raise RuntimeError(EPIC_CORRECTIVE_ACTION_ERROR) from exc
+                    except EpicAuthError as exc:
+                        raise RuntimeError(
+                            f"Epic rejected the captured code ({exc}). Refresh the Epic page so a new "
+                            "code appears, or paste the authorizationCode into the fallback field below."
+                        ) from exc
+                    return {"EPIC_AUTH_CODE": code}
 
-            # No code yet: if Epic is showing its corrective-action gate (e.g.
-            # privacy-policy acceptance), guide the user to complete it and keep
-            # polling instead of silently timing out.
-            if _epic_error_from_text(body) or _epic_error_from_text(html):
-                now = time.time()
-                if session and now - last_hint > 8:
-                    last_hint = now
-                    session.emit("waiting_for_user", {"message": EPIC_CORRECTIVE_ACTION_HINT})
-                page.wait_for_timeout(int(POLL_SEC * 1000))
-                continue
+                # No code yet: if Epic is showing its corrective-action gate (e.g.
+                # privacy-policy acceptance), guide the user to complete it and keep
+                # polling instead of silently timing out.
+                if _epic_error_from_text(body) or _epic_error_from_text(html):
+                    now = time.time()
+                    if session and now - last_hint > 8:
+                        last_hint = now
+                        session.emit("waiting_for_user", {"message": EPIC_CORRECTIVE_ACTION_HINT})
+                    page.wait_for_timeout(int(POLL_SEC * 1000))
+                    continue
 
-        url = (drive.url or "").lower()
-        now = time.time()
-        if session and now - last_hint > 10:
-            last_hint = now
-            if "login" in url or "id.epicgames.com" in url:
-                msg = "Sign in to your Epic account in the browser window."
-            else:
-                msg = "Capturing your Epic authorization code — keep the window open."
-            session.emit("waiting_for_user", {"message": msg})
+            url = (drive.url or "").lower()
+            now = time.time()
+            if session and now - last_hint > 10:
+                last_hint = now
+                if cf_pages and cf_opened_until and cf_opened_until[0] > now:
+                    msg = EPIC_CF_CHALLENGE_HINT
+                elif "login" in url or "id.epicgames.com" in url:
+                    msg = "Sign in to your Epic account in the browser window."
+                else:
+                    msg = "Capturing your Epic authorization code — keep the window open."
+                session.emit("waiting_for_user", {"message": msg})
 
-        page.wait_for_timeout(int(POLL_SEC * 1000))
+            page.wait_for_timeout(int(POLL_SEC * 1000))
 
-    raise RuntimeError(
-        "Could not capture your Epic authorization code in time. If the Epic page shows an "
-        "authorizationCode, paste it into the fallback field below and click Save key."
-    )
+        raise RuntimeError(
+            "Could not capture your Epic authorization code in time. If the Epic page shows an "
+            "authorizationCode, paste it into the fallback field below and click Save key."
+        )
+    finally:
+        _close_epic_cf_challenge_tabs(cf_pages)
 
 
 def pick_gog_al_from_cookies(cookies: list[dict]) -> str:
@@ -643,16 +700,22 @@ def _extract_epic_wishlist_inline(page, context, session) -> dict[str, str]:
     either a GraphQL response or Epic's dehydrated React Query HTML state.
     """
     from auth.cdp_browser import abort_if_browser_closed
-    from auth.connect_extractors import build_epic_wishlist_graphql_sniffer
+    from auth.connect_extractors import (
+        EpicEmailExistsCfSniffer,
+        build_epic_wishlist_graphql_sniffer,
+    )
     from auth.epic_wishlist_session import (
         storefront_bounced_to_home,
         wishlist_capture_complete_from_html,
     )
 
     sniffer = build_epic_wishlist_graphql_sniffer()
+    cf_sniffer = EpicEmailExistsCfSniffer()
     wishlist_loaded = False
     saw_id_login = False
     did_post_login_nav = False
+    cf_opened_until: list[float] = [0.0]
+    cf_pages: list = []
 
     try:
         _debug_path = profile_dir("epic_wishlist").parent / "epic_wishlist_connect_debug.json"
@@ -672,6 +735,7 @@ def _extract_epic_wishlist_inline(page, context, session) -> dict[str, str]:
             pass
 
     sniffer.attach(page)
+    cf_sniffer.attach(page)
     try:
         page.goto(epic_store_login_url(), wait_until="domcontentloaded", timeout=25_000)
     except Exception:  # noqa: BLE001
@@ -679,73 +743,85 @@ def _extract_epic_wishlist_inline(page, context, session) -> dict[str, str]:
 
     deadline = time.time() + SUCCESS_WAIT_SEC
     last_msg = 0.0
-    while time.time() < deadline:
-        abort_if_browser_closed(context)
-        if not wishlist_loaded and sniffer.drain():
-            wishlist_loaded = True
-            _write_debug()
-        url = page.url or ""
-        ul = url.lower()
-        on_wishlist = _epic_on_wishlist(url)
-        if not wishlist_loaded and on_wishlist:
-            try:
-                if wishlist_capture_complete_from_html(page.content()):
-                    wishlist_loaded = True
-            except Exception:  # noqa: BLE001
-                pass
-        if _epic_on_login_page(url):
-            saw_id_login = True
-        if (
-            not wishlist_loaded
-            and not did_post_login_nav
-            and saw_id_login
-            and storefront_bounced_to_home(url)
-        ):
-            did_post_login_nav = True
-            try:
-                page.goto(EPIC_WISHLIST_URL, wait_until="domcontentloaded", timeout=25_000)
-            except Exception:  # noqa: BLE001
-                pass
+    try:
+        while time.time() < deadline:
+            abort_if_browser_closed(context)
+            _maybe_open_epic_cf_challenge(
+                context,
+                cf_sniffer,
+                session,
+                opened_until=cf_opened_until,
+                challenge_pages=cf_pages,
+            )
             if not wishlist_loaded and sniffer.drain():
                 wishlist_loaded = True
                 _write_debug()
-        if wishlist_loaded:
-            try:
-                page.wait_for_timeout(800)
-            except Exception:  # noqa: BLE001
-                pass
-            return {"EPIC_STORE_COOKIE": "ready"}
+            url = page.url or ""
+            ul = url.lower()
+            on_wishlist = _epic_on_wishlist(url)
+            if not wishlist_loaded and on_wishlist:
+                try:
+                    if wishlist_capture_complete_from_html(page.content()):
+                        wishlist_loaded = True
+                except Exception:  # noqa: BLE001
+                    pass
+            if _epic_on_login_page(url):
+                saw_id_login = True
+            if (
+                not wishlist_loaded
+                and not did_post_login_nav
+                and saw_id_login
+                and storefront_bounced_to_home(url)
+            ):
+                did_post_login_nav = True
+                try:
+                    page.goto(EPIC_WISHLIST_URL, wait_until="domcontentloaded", timeout=25_000)
+                except Exception:  # noqa: BLE001
+                    pass
+                if not wishlist_loaded and sniffer.drain():
+                    wishlist_loaded = True
+                    _write_debug()
+            if wishlist_loaded:
+                try:
+                    page.wait_for_timeout(800)
+                except Exception:  # noqa: BLE001
+                    pass
+                return {"EPIC_STORE_COOKIE": "ready"}
 
-        now = time.time()
+            now = time.time()
 
-        if session and now - last_msg > 8:
-            last_msg = now
-            if "challenge" in ul or "cloudflare" in ul:
-                msg = "Cloudflare challenge — click the checkbox if shown."
-            elif _epic_on_login_page(url) or "signin" in ul:
-                msg = (
-                    "Sign in to Epic in this window — you'll be returned to your "
-                    "wishlist automatically. Clear any Cloudflare check if shown."
-                )
-            elif on_wishlist:
-                msg = "On the wishlist page? Give it a moment to load."
-            elif "store.epicgames.com" in ul:
-                msg = (
-                    "Signed in? Opening your wishlist — give it a moment to load."
-                )
-            else:
-                msg = (
-                    "Sign in to Epic in this window — you'll be returned to your "
-                    "wishlist automatically."
-                )
-            session.emit("waiting_for_user", {"message": msg})
+            if session and now - last_msg > 8:
+                last_msg = now
+                if cf_pages and cf_opened_until and cf_opened_until[0] > now:
+                    msg = EPIC_CF_CHALLENGE_HINT
+                elif "challenge" in ul or "cloudflare" in ul:
+                    msg = "Cloudflare challenge — click the checkbox if shown."
+                elif _epic_on_login_page(url) or "signin" in ul:
+                    msg = (
+                        "Sign in to Epic in this window — you'll be returned to your "
+                        "wishlist automatically. Clear any Cloudflare check if shown."
+                    )
+                elif on_wishlist:
+                    msg = "On the wishlist page? Give it a moment to load."
+                elif "store.epicgames.com" in ul:
+                    msg = (
+                        "Signed in? Opening your wishlist — give it a moment to load."
+                    )
+                else:
+                    msg = (
+                        "Sign in to Epic in this window — you'll be returned to your "
+                        "wishlist automatically."
+                    )
+                session.emit("waiting_for_user", {"message": msg})
 
-        page.wait_for_timeout(int(POLL_SEC * 1000))
+            page.wait_for_timeout(int(POLL_SEC * 1000))
 
-    raise RuntimeError(
-        "Could not detect Epic wishlist sign-in — sign in at store.epicgames.com/wishlist, "
-        "clear any Cloudflare challenge, and let your wishlist finish loading."
-    )
+        raise RuntimeError(
+            "Could not detect Epic wishlist sign-in — sign in at store.epicgames.com/wishlist, "
+            "clear any Cloudflare challenge, and let your wishlist finish loading."
+        )
+    finally:
+        _close_epic_cf_challenge_tabs(cf_pages)
 
 
 XBOX_WISHLIST_URL = "https://www.xbox.com/en-us/wishlist"
@@ -1793,7 +1869,11 @@ def run_browser_auth(provider: str, session: AuthSession) -> dict[str, str] | No
         initial_url=spec.login_url if provider == "ea" else None,
     ) as context:
         try:
-            context.add_init_script(_STEALTH_INIT)
+            # Epic: skip heavy STEALTH_INIT — fake plugins/permissions/hardware
+            # worsen Cloudflare Bot Management scores. Launch already applies the
+            # light webdriver mask (_AUTOMATION_MASK_SCRIPT).
+            if provider not in ("epic", "epic_wishlist"):
+                context.add_init_script(_STEALTH_INIT)
             # Paint a persistent, click-through banner inside the popup so users see
             # the same guidance there (not just on the dashboard). Keep it in sync
             # with the live waiting_for_user / signed_in messages.

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <!-- Must match pyproject.toml + package.json (see CHANGELOG release discipline). Read at runtime by js/error-boundary.js for bug-bundle metadata. -->
     <!-- Optional override for bug report endpoint during local testing: content="http://127.0.0.1:3000/api/report" -->
     <!-- <meta name="baklog-report-endpoint" content="https://baklog.app/api/report" /> -->
-    <meta name="baklog-version" content="0.8.42" />
+    <meta name="baklog-version" content="0.8.43" />
     <meta name="theme-color" content="#0f172a" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog",
-  "version": "0.8.42",
+  "version": "0.8.43",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["auth*", "clients*", "fetchers*", "enrichers*", "shared*"]
 
 [project]
 name = "steam-backlog"
-version = "0.8.42"
+version = "0.8.43"
 description = "Local multi-store game library dashboard and fetchers"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_cdp_browser.py
+++ b/tests/test_cdp_browser.py
@@ -92,6 +92,34 @@ class TestShouldPreservePopup:
         )
 
 
+class TestNewPageBackground:
+    def test_new_page_background_passes_create_target_flag(self) -> None:
+        ctx = _bare_context()
+        ctx.pages = []
+        ctx._pages_by_session = {}
+        ctx._pages_by_target = {}
+        ctx._background_targets = set()
+        ctx._init_scripts = []
+        ctx._apply_init_script = lambda page, source: None  # type: ignore[method-assign]
+        sent: list[tuple[str, dict | None]] = []
+
+        def fake_send(method, params=None, *, session_id=None, timeout=60):
+            sent.append((method, params))
+            if method == "Target.createTarget":
+                return {"targetId": "bg-target-1"}
+            if method == "Target.attachToTarget":
+                return {"sessionId": "sess-bg-1"}
+            return {}
+
+        ctx._send = fake_send  # type: ignore[method-assign]
+        page = ctx.new_page(background=True)
+        create = next(p for m, p in sent if m == "Target.createTarget")
+        assert create is not None
+        assert create.get("background") is True
+        assert "bg-target-1" in ctx._background_targets
+        assert page._target_id == "bg-target-1"
+
+
 class TestRegisterPageDebugger:
     def test_register_page_skips_debugger_for_storefront_auth(self) -> None:
         ctx = _bare_context()

--- a/tests/test_epic_email_exists_cf_sniffer.py
+++ b/tests/test_epic_email_exists_cf_sniffer.py
@@ -1,0 +1,77 @@
+"""Tests for Epic /id/api/email/exists Cloudflare challenge sniffer."""
+
+from __future__ import annotations
+
+from auth.connect_extractors import EpicEmailExistsCfSniffer
+
+
+class _FakeResponse:
+    def __init__(self, url: str, body: str, status: int = 403) -> None:
+        self.url = url
+        self.status = status
+        self._body = body
+
+    def text(self) -> str:
+        return self._body
+
+
+class _FakePage:
+    def __init__(self) -> None:
+        self._handlers: list = []
+
+    def on(self, event: str, callback) -> None:
+        if event == "response":
+            self._handlers.append(callback)
+
+    def emit(self, response: _FakeResponse) -> None:
+        for cb in self._handlers:
+            cb(response)
+
+
+def test_sniffer_drains_challenge_url_from_non_200_html() -> None:
+    token = "tok-abc-123"
+    body = (
+        "Enable JavaScript and cookies to continue"
+        f'window._cf_chl_opt={{cUPMDTk:"/id/api/email/exists?__cf_chl_tk={token}"}}'
+    )
+    page = _FakePage()
+    sniffer = EpicEmailExistsCfSniffer()
+    sniffer.attach(page)
+    page.emit(
+        _FakeResponse(
+            "https://www.epicgames.com/id/api/email/exists",
+            body,
+            status=403,
+        )
+    )
+    url = sniffer.drain_challenge_url()
+    assert url == f"https://www.epicgames.com/id/api/email/exists?__cf_chl_tk={token}"
+    assert sniffer.drain_challenge_url() is None
+
+
+def test_sniffer_ignores_normal_json_exists_response() -> None:
+    page = _FakePage()
+    sniffer = EpicEmailExistsCfSniffer()
+    sniffer.attach(page)
+    page.emit(
+        _FakeResponse(
+            "https://www.epicgames.com/id/api/email/exists",
+            '{"exists":false}',
+            status=200,
+        )
+    )
+    assert sniffer.drain_challenge_url() is None
+
+
+def test_sniffer_ignores_unrelated_urls() -> None:
+    page = _FakePage()
+    sniffer = EpicEmailExistsCfSniffer()
+    sniffer.attach(page)
+    page.emit(
+        _FakeResponse(
+            "https://www.epicgames.com/id/api/redirect",
+            "Enable JavaScript and cookies to continue _cf_chl_opt",
+            status=403,
+        )
+    )
+    assert sniffer.drain_challenge_url() is None

--- a/tests/test_epic_library_connect_loop.py
+++ b/tests/test_epic_library_connect_loop.py
@@ -24,10 +24,15 @@ class _FakePage:
         self.url = url
         self.is_closed = False
         self.goto_calls = 0
+        self._listeners: dict[str, list] = {}
+        self.closed = False
+
+    def on(self, event: str, callback) -> None:
+        self._listeners.setdefault(event, []).append(callback)
 
     def goto(self, _url: str, *, wait_until: str | None = None, timeout: int | None = None) -> None:
         self.goto_calls += 1
-        if "id/login" in _url:
+        if "id/login" in _url or "__cf_chl_tk" in _url:
             self.url = _url
 
     def evaluate(self, _fn: str) -> str:
@@ -41,12 +46,19 @@ class _FakePage:
     def wait_for_timeout(self, _ms: int) -> None:
         return None
 
+    def close(self) -> None:
+        self.closed = True
+        self.is_closed = True
+
 
 class _FakeContext:
     def __init__(self, pages: list[_FakePage]) -> None:
         self.pages = pages
+        self.background_new_pages = 0
 
-    def new_page(self) -> _FakePage:
+    def new_page(self, *, background: bool = False) -> _FakePage:
+        if background:
+            self.background_new_pages += 1
         page = _FakePage()
         self.pages.append(page)
         return page
@@ -103,3 +115,53 @@ def test_epic_library_inline_does_not_poll_content_on_login(
         runner._extract_epic_inline(page, ctx, session=None)
 
     assert content_calls == 0
+
+
+def test_epic_library_opens_background_cf_challenge_tab(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeTime(step_s=6.0)
+    monkeypatch.setattr(runner, "time", clock)
+    monkeypatch.setattr(runner, "SUCCESS_WAIT_SEC", 20.0)
+    monkeypatch.setattr(runner, "POLL_SEC", 0.1)
+
+    token = "cf-tok-xyz"
+    challenge_url = f"https://www.epicgames.com/id/api/email/exists?__cf_chl_tk={token}"
+
+    page = _FakePage("https://www.epicgames.com/id/login")
+    ctx = _FakeContext([page])
+    events: list[tuple[str, dict]] = []
+
+    class _Session:
+        def emit(self, event: str, data: dict) -> None:
+            events.append((event, data))
+
+    class _FakeCfSniffer:
+        def __init__(self) -> None:
+            self._once = True
+
+        def attach(self, _page) -> None:
+            return None
+
+        def drain_challenge_url(self) -> str | None:
+            if self._once:
+                self._once = False
+                return challenge_url
+            return None
+
+    monkeypatch.setattr(
+        "auth.connect_extractors.EpicEmailExistsCfSniffer",
+        _FakeCfSniffer,
+    )
+
+    with pytest.raises(RuntimeError, match="Could not capture your Epic authorization code"):
+        runner._extract_epic_inline(page, ctx, session=_Session())  # type: ignore[arg-type]
+
+    assert ctx.background_new_pages == 1
+    assert any(
+        e == "waiting_for_user"
+        and runner.EPIC_CF_CHALLENGE_HINT in ((d or {}).get("message") or "")
+        for e, d in events
+    )
+    # Login page must not be content()-polled while waiting.
+    assert page.content() == ""

--- a/tests/test_epic_wishlist_connect_loop.py
+++ b/tests/test_epic_wishlist_connect_loop.py
@@ -118,6 +118,7 @@ class _FakeLoginThenStorePage:
 class _FakeContext:
     def __init__(self, *, signed_in: bool = False) -> None:
         self._signed_in = signed_in
+        self.pages: list = []
 
     def cookies(self) -> list[dict]:
         if not self._signed_in:
@@ -129,6 +130,11 @@ class _FakeContext:
                 "domain": ".epicgames.com",
             }
         ]
+
+    def new_page(self, *, background: bool = False):
+        page = _FakePage()
+        self.pages.append(page)
+        return page
 
 
 class _FakeSession:
@@ -232,9 +238,11 @@ def test_epic_wishlist_inline_post_login_goto_without_graphql_times_out(
     session = _FakeSession()
     page.url = "https://www.epicgames.com/id/login"
 
-    fake_time = _FakeTime(step_s=6.0)
+    # FakeTime advances on every time.time() call; keep steps small enough that
+    # post-login wishlist navigation still runs before the deadline.
+    fake_time = _FakeTime(step_s=2.0)
     monkeypatch.setattr(runner.time, "time", fake_time.time)
-    monkeypatch.setattr(runner, "SUCCESS_WAIT_SEC", 20.0)
+    monkeypatch.setattr(runner, "SUCCESS_WAIT_SEC", 40.0)
     monkeypatch.setattr(runner, "POLL_SEC", 0.1)
 
     def _goto(url: str, *, wait_until: str | None = None, timeout: int | None = None) -> None:

--- a/tests/test_epic_wishlist_session.py
+++ b/tests/test_epic_wishlist_session.py
@@ -9,6 +9,7 @@ from auth.epic_wishlist_session import (
     cloudflare_interstitial,
     enrich_wishlist_elements_with_catalog,
     extract_catalog_offers_from_html,
+    extract_epic_cf_challenge_url,
     extract_wishlist_payloads_from_html,
     is_epic_graphql_url,
     storefront_auth_blocked,
@@ -90,6 +91,23 @@ def test_cloudflare_interstitial_managed_challenge_html() -> None:
     login_url = "https://www.epicgames.com/id/login"
     assert not cloudflare_interstitial(managed, login_url)
     assert cloudflare_embedded_challenge(managed)
+
+
+def test_extract_epic_cf_challenge_url_from_form_error_payload() -> None:
+    token = "VQWokJZi5HM99Z2C2PZC_DfijqpJciNvxx_RvlerJgE-1785556737-1.0.1.1-abc"
+    managed = (
+        "Enable JavaScript and cookies to continue"
+        f"(function(){{window._cf_chl_opt = {{cType: 'managed',"
+        f'cUPMDTk:"/id/api/email/exists?__cf_chl_tk={token}",'
+        f'fa:"/id/api/email/exists?__cf_chl_f_tk={token}"}};}})();'
+    )
+    url = extract_epic_cf_challenge_url(managed)
+    assert url == f"https://www.epicgames.com/id/api/email/exists?__cf_chl_tk={token}"
+    assert not cloudflare_interstitial(managed, "https://www.epicgames.com/id/login")
+
+
+def test_extract_epic_cf_challenge_url_ignores_normal_json() -> None:
+    assert extract_epic_cf_challenge_url('{"exists":true}') is None
 
 
 def test_cloudflare_interstitial_not_normal_epic_login_html() -> None:


### PR DESCRIPTION
## Summary
- Passively sniff `/id/api/email/exists` XHR for managed CF HTML and open `__cf_chl_tk` in a background tab so the challenge can actually run
- Skip heavy `STEALTH_INIT` for Epic/Epic wishlist (keep light webdriver mask)
- Wait hint points at system-browser OAuth escape hatch when CF fires

## Test plan
- [x] pytest: epic wishlist session, email-exists sniffer, library/wishlist connect loops, CDP background new_page
- [ ] Epic library Connect: entering email opens background CF tab or proceeds; form error no longer the only path
- [ ] After CF clearance, continue sign-in / Reconnect preserves profile