### PR TITLE
fix: sticky failed pill dismiss + missed SSE finish (0.8.44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [Unreleased]
 
+## [0.8.44] - 2026-07-31
+
+### Fixed
+
+- Red fetcher status pill / failed chip click always clears sticky failed state (including already-connected and non-auth failures), so the UI cannot stay bricked on a red pill; dual-source reconnect (`amazon_web` / `gog_galaxy` / `itch_local`) now clears the matching library chip too.
+- Fetcher chips no longer spin forever after a missed SSE `done`: reconcile closes zombie EventSource streams when `/api/runs` history already finished, applies post-fetch reload, and stream-drop handling covers enrich lanes plus failed/cancelled outcomes.
+- Connections "Cancel sign-in" control has spacing above the button under the connect log.
+
 ## [0.8.43] - 2026-07-31
 
 ### Fixed

--- a/app.css
+++ b/app.css
@@ -11655,6 +11655,12 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
 .conn-log:not(.hidden) {
   color: var(--text-mute);
 }
+/* Cancel sign-in sits under .conn-log (not in the footer). Give it air above
+   the button without shifting footer Disconnect (also .conn-disconnect). */
+.conn-card [data-cancel-connect] {
+  margin-top: 10px;
+  margin-left: 0;
+}
 .conn-card-footer {
   display: flex;
   align-items: center;

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <!-- Must match pyproject.toml + package.json (see CHANGELOG release discipline). Read at runtime by js/error-boundary.js for bug-bundle metadata. -->
     <!-- Optional override for bug report endpoint during local testing: content="http://127.0.0.1:3000/api/report" -->
     <!-- <meta name="baklog-report-endpoint" content="https://baklog.app/api/report" /> -->
-    <meta name="baklog-version" content="0.8.43" />
+    <meta name="baklog-version" content="0.8.44" />
     <meta name="theme-color" content="#0f172a" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <script>

--- a/js/bind-events-fetcher.js
+++ b/js/bind-events-fetcher.js
@@ -6,6 +6,7 @@ import {
   toggleLegendTips,
   formatRefreshIntervalLabel,
   primaryFailureNavigateTarget,
+  dismissStickyFailedState,
 } from './fetcher-health.js';
 import { reconnectProvider } from './connections.js';
 
@@ -17,9 +18,14 @@ export function handleGlobalStatusClick(e) {
     fetcherRunner.openFetcherLog({ focusPanel: false });
     return;
   }
-  const navTarget = pill.classList.contains('fh-global-status-failed')
-    ? primaryFailureNavigateTarget()
-    : null;
+  const isFailed = pill.classList.contains('fh-global-status-failed');
+  // Capture navigate target before clearing sticky failed (map drives routing).
+  const navTarget = isFailed ? primaryFailureNavigateTarget() : null;
+  if (isFailed) {
+    // Always clear — otherwise a red pill with an already-connected provider
+    // (or a non-auth failure) stays red and bricks subsequent fetcher UI.
+    dismissStickyFailedState({ all: true });
+  }
   if (navTarget) {
     fetcherRunner.hideFetcherPopover();
     void reconnectProvider(navTarget.provider, { autoStart: false });
@@ -104,6 +110,10 @@ export function bindFetcherHealthEvents() {
     if (chip.dataset.fetcherConnect) {
       e.preventDefault();
       fetcherRunner.hideFetcherPopover();
+      dismissStickyFailedState({
+        fetcherKey: chip.dataset.fetcherKey,
+        provider: chip.dataset.fetcherConnect,
+      });
       reconnectProvider(chip.dataset.fetcherConnect, { autoStart: false });
       return;
     }

--- a/js/fetcher-health.js
+++ b/js/fetcher-health.js
@@ -80,6 +80,7 @@ export {
   primaryFailureNavigateTarget,
   connectProviderForFetcher,
   isFetcherDisconnected,
+  dismissStickyFailedState,
 } from './fetcher/reconnect.js';
 export {
   staleSweepRank,

--- a/js/fetcher/global-indicator.js
+++ b/js/fetcher/global-indicator.js
@@ -156,7 +156,7 @@ export function updateGlobalFetcherIndicator(runStateByKey, sourceFn) {
   if (!running.length && !queued.length) {
     // Failed takes precedence over done: a broken run is the most important
     // thing to surface. lastRunFailedByKey is sticky until that source's next
-    // success or the next run starts, mirroring the per-chip failed styling.
+    // success or the user dismisses via the red pill / connect chip.
     const failedKeys = [...lastRunFailedByKey.keys()];
     if (failedKeys.length > 0) {
       const labels = failedKeys.map(k => sourceFn(k)?.label || k);

--- a/js/fetcher/reconnect.js
+++ b/js/fetcher/reconnect.js
@@ -136,11 +136,20 @@ export function clearReconnectRequired(provider) {
   if (reconnectDismissed.delete(provider)) persistReconnectDismissed();
 }
 
-/** Fetcher chip keys whose mapped auth provider is `provider`. */
+/** Fetcher chip keys whose mapped auth provider is `provider`.
+ *  Dual-source groups (amazon_web/gog_galaxy/itch_local) are included even
+ *  when FETCHER_AUTH_PROVIDER points at the sibling key. */
 function fetcherKeysForProvider(provider) {
-  return Object.keys(FETCHER_AUTH_PROVIDER).filter(
-    k => FETCHER_AUTH_PROVIDER[k] === provider,
+  if (!provider) return [];
+  const keys = new Set(
+    Object.keys(FETCHER_AUTH_PROVIDER).filter(
+      k => FETCHER_AUTH_PROVIDER[k] === provider,
+    ),
   );
+  for (const [fetcherKey, group] of Object.entries(FETCHER_PROVIDER_GROUP)) {
+    if (group.includes(provider)) keys.add(fetcherKey);
+  }
+  return [...keys];
 }
 
 /** A provider just reconnected (was reconnect-required -> connected): clear
@@ -150,6 +159,27 @@ function clearFailedStateForReconnectedProvider(provider) {
     lastRunFailedByKey.delete(key);
     clearAuthCooldown(key);
   }
+}
+
+/**
+ * Dismiss sticky failed pill/chip state immediately.
+ * Red-pill / connect-chip clicks must clear every time — waiting for a
+ * reconnect transition leaves the UI stuck when the provider is already
+ * connected or the failure was non-auth.
+ */
+export function dismissStickyFailedState({
+  all = false,
+  provider = null,
+  fetcherKey = null,
+} = {}) {
+  if (all) {
+    lastRunFailedByKey.clear();
+  } else {
+    if (fetcherKey) lastRunFailedByKey.delete(fetcherKey);
+    if (provider) clearFailedStateForReconnectedProvider(provider);
+  }
+  try { _refreshGlobalIndicator(); } catch (_) { /* runner not ready */ }
+  try { _renderDashboard(); } catch (_) { /* not mounted */ }
 }
 
 /** User dismissed the inline reconnect chip affordance for this provider. */

--- a/js/fetcher/runner/index.js
+++ b/js/fetcher/runner/index.js
@@ -1079,14 +1079,36 @@ export const fetcherRunner = (() => {
       if (!state || state === 'failed') continue;
       if (inFlightKeys.has(key)) continue;
       const runId = runIdByKey.get(key);
-      if (runId && sourcesByRunId.has(runId)) continue;
       const hist = historyByKey.get(key);
+      if (runId && sourcesByRunId.has(runId)) {
+        // A CONNECTING/zombie EventSource used to block reconcile forever after
+        // a missed `done` (Free/claims and every other store). If the server
+        // already finished this key, drop the stream and apply history.
+        const serverFinished = hist && (
+          hist.status === 'done'
+          || hist.status === 'cancelled'
+          || hist.status === 'failed'
+        );
+        if (!serverFinished) continue;
+        const attached = sourcesByRunId.get(runId);
+        if (attached?.es) {
+          attached.es.onerror = null;
+          try { attached.es.close(); } catch (_) {}
+        }
+        sourcesByRunId.delete(runId);
+      }
       if (hist) {
         if (hist.status === 'done' && hist.exit_code === 0) {
+          lastRunFailedByKey.delete(key);
           markChipState(key, null);
+          if (hist.id && hist.id !== _lastAppliedDoneRunId) {
+            _lastAppliedDoneRunId = hist.id;
+            void refreshAfterFetch(key);
+          }
         } else if (hist.status === 'cancelled') {
           markChipState(key, null);
         } else {
+          lastRunFailedByKey.set(key, Date.now());
           markChipState(key, 'failed');
         }
         if (hist.id) clearLastSeq(hist.id);
@@ -1657,8 +1679,10 @@ export const fetcherRunner = (() => {
       try {
         const snap = await fetchRunsSnapshot();
         if (!snap) throw new Error('no snapshot');
-        const stillActive = snap.active?.id === runId;
-        const inQueue = (snap.queue || []).some(r => r.id === runId);
+        const stillActive = snap.active?.id === runId
+          || snap.enrich_active?.id === runId;
+        const inQueue = (snap.queue || []).some(r => r.id === runId)
+          || (snap.enrich_queue || []).some(r => r.id === runId);
         const finished = (snap.history || []).find(r => r.id === runId);
         if (stillActive || inQueue) {
           const queuedOnly = inQueue && !stillActive;
@@ -1666,19 +1690,37 @@ export const fetcherRunner = (() => {
           return;
         }
         if (finished) {
+          const cancelled = finished.status === 'cancelled';
           const ok = finished.status === 'done' && finished.exit_code === 0;
           logEvent('info', `[${src.label}: stream dropped after exit ${finished.exit_code}]`);
-          if (liveRunId === runId) setStatus(ok ? 'done' : 'failed');
-          if (ok) fetchSuccessLabels.add(src.label || key);
-          if (ok) markChipState(key, null);
-          if (ok && finished.id !== _lastAppliedDoneRunId) {
-            _lastAppliedDoneRunId = finished.id;
-            await refreshAfterFetch(key);
+          if (liveRunId === runId) {
+            setStatus(cancelled ? 'failed' : ok ? 'done' : 'failed');
+            updateCancelButton();
           }
-          if (!ok && finished.status === 'done') {
+          if (ok) {
+            lastRunFailedByKey.delete(key);
+            fetchSuccessLabels.add(src.label || key);
+            markChipState(key, null);
+            if (finished.id !== _lastAppliedDoneRunId) {
+              _lastAppliedDoneRunId = finished.id;
+              await refreshAfterFetch(key);
+            }
+            clearAuthCooldown(key);
+          } else if (cancelled) {
+            markChipState(key, null);
+          } else {
+            lastRunFailedByKey.set(key, Date.now());
+            markChipState(key, 'failed');
             handleFetcherAuthOutcome(key, finished, '');
+            setTimeout(() => {
+              if (runStateByKey.get(key) === 'failed') {
+                runStateByKey.delete(key);
+                renderDashboardFetcherHealth();
+              }
+            }, 10000);
           }
           if (liveRunId === runId) liveRunId = null;
+          revertFetcherLayoutIfIdle();
           return;
         }
       } catch (_) {}
@@ -1920,6 +1962,16 @@ export const fetcherRunner = (() => {
     recordLineSeqForTest: recordLineSeq,
     getLastSeqForTest: getLastSeq,
     reconcileRunStateFromSnapshot,
+    attachStreamForTest(runId, key, es) {
+      sourcesByRunId.set(runId, {
+        es: es || { readyState: 0, close() {}, onerror: null },
+        key,
+        src: { key, label: key },
+      });
+    },
+    hasStreamForTest(runId) {
+      return sourcesByRunId.has(runId);
+    },
     isCancelInFlightForTest: () => cancelInFlight,
     getInFlightCountForTest: () => runStateByKey.size,
     getCancelEpoch,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog",
-  "version": "0.8.43",
+  "version": "0.8.44",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["auth*", "clients*", "fetchers*", "enrichers*", "shared*"]
 
 [project]
 name = "steam-backlog"
-version = "0.8.43"
+version = "0.8.44"
 description = "Local multi-store game library dashboard and fetchers"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/fetcher-health.test.js
+++ b/tests/fetcher-health.test.js
@@ -42,6 +42,7 @@ import {
   isFetcherAuthHealthy,
   coverableRows,
   primaryFailureNavigateTarget,
+  dismissStickyFailedState,
 } from '../js/fetcher-health.js';
 import { state } from '../js/state.js';
 
@@ -714,6 +715,12 @@ describe('reconnect-required state', () => {
     }));
     expect(fetcherRunner.isRunFailedForTest('wishlistXbox')).toBe(true);
   });
+
+  it('dismissStickyFailedState clears sticky failed for dual-source amazon_web', () => {
+    fetcherRunner.markRunFailedForTest('amazon');
+    dismissStickyFailedState({ provider: 'amazon_web' });
+    expect(fetcherRunner.isRunFailedForTest('amazon')).toBe(false);
+  });
 });
 
 describe('syncLogPanelChrome', () => {
@@ -863,6 +870,31 @@ describe('reconcileRunStateFromSnapshot', () => {
       ],
     });
     expect(fetcherRunner.stateFor('hltb')).toBeNull();
+  });
+
+  it('clears zombie EventSource when history shows finished (missed done)', () => {
+    fetcherRunner.markChipStateForTest('claims', 'running', '732655ccd4fc');
+    fetcherRunner.attachStreamForTest('732655ccd4fc', 'claims', {
+      readyState: 0, // EventSource.CONNECTING
+      close() {},
+      onerror: null,
+    });
+    expect(fetcherRunner.hasStreamForTest('732655ccd4fc')).toBe(true);
+    fetcherRunner.reconcileRunStateFromSnapshot({
+      active: null,
+      queue: [],
+      history: [
+        {
+          id: '732655ccd4fc',
+          key: 'claims',
+          status: 'done',
+          exit_code: 0,
+          ended_at: Date.now() / 1000,
+        },
+      ],
+    });
+    expect(fetcherRunner.stateFor('claims')).toBeNull();
+    expect(fetcherRunner.hasStreamForTest('732655ccd4fc')).toBe(false);
   });
 
   it('tracks enrich lane runs in inFlightKeys', () => {
@@ -1391,7 +1423,23 @@ describe('global failure nav', () => {
     handleGlobalStatusClick({ shiftKey: false });
 
     expect(reconnectProvider).toHaveBeenCalledWith('xbox_wishlist', { autoStart: false });
+    expect(fetcherRunner.isRunFailedForTest('wishlistXbox')).toBe(false);
     clearReconnectRequired('xbox_wishlist');
+  });
+
+  it('pill click clears sticky failed even when already connected', () => {
+    processAuthStatusTransitions([{ key: 'xbox_wishlist', status: 'connected' }]);
+    connMock.statuses.xbox_wishlist = 'connected';
+    fetcherRunner.markRunFailedForTest('wishlistXbox');
+    fetcherRunner.refreshGlobalIndicator();
+    const pill = document.getElementById('fetcherGlobalStatus');
+    expect(pill?.classList.contains('fh-global-status-failed')).toBe(true);
+
+    handleGlobalStatusClick({ shiftKey: false });
+
+    expect(fetcherRunner.isRunFailedForTest('wishlistXbox')).toBe(false);
+    fetcherRunner.refreshGlobalIndicator();
+    expect(pill?.classList.contains('fh-global-status-failed')).toBe(false);
   });
 
   it('shift+click pill opens log even when auth failure would route to Connections', async () => {
@@ -1428,6 +1476,7 @@ describe('global failure nav', () => {
 
     expect(reconnectProvider).not.toHaveBeenCalled();
     expect(openSpy).toHaveBeenCalledWith({ focusPanel: false });
+    expect(fetcherRunner.isRunFailedForTest('hltb')).toBe(false);
     openSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- Red fetcher pill / failed chip click always clears sticky failed state (including already-connected and dual-source `amazon_web` / `gog_galaxy` / `itch_local`), so the UI cannot stay bricked on a red pill.
- Reconcile closes zombie EventSource streams when `/api/runs` history already finished (missed SSE `done`), applies post-fetch reload, and stream-drop handling covers enrich lanes plus failed/cancelled — fixes Free/claims and all other stores spinning after server success.
- Connections Cancel sign-in gets spacing above the button under the connect log.

## Test plan
- [x] `vitest` `tests/fetcher-health.test.js` + `tests/fetcher-retry-failed-button.test.js` (130 tests)
- [ ] Confirm repeat-connected auth poll still does **not** auto-clear sticky failed
- [ ] Confirm Shift+click red pill opens log without dismissing
- [ ] Fail a fetcher, click red pill → failed styling clears; navigate to Connections still works
- [ ] Start Connect on a store → Cancel sign-in has visible gap under the log
- [ ] Trigger a fast fetcher (e.g. Free); if SSE drops, chip clears within in-flight poll once history shows done