### PR TITLE
fix: Reviews/Tags speed, order, and auto-enrich opt-in (0.8.45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,19 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [Unreleased]
 
+## [0.8.45] - 2026-08-01
+
+### Fixed
+
+- Reviews and Co-op tags no longer hit the global 30-minute kill on large libraries (`maxRunSeconds: 0`, same as HLTB).
+- Reviews/Tags flush catalog JSON mid-store so cancel or timeout keeps progress already written.
+- Auto-enrich runs Reviews before Tags (Tags needs the appid map); empty-map Tags skips with exit 0 instead of sticky failed.
+- Auto-enrich is true opt-in: missing/`undefined` pref no longer enables the checkbox or queues enrichers.
+
+### Changed
+
+- Reviews storesearch delay 1.0s → 0.4s; appreviews throttle 1.5s → 0.75s (appdetails for Tags/Covers stays at 1.5s).
+
 ## [0.8.44] - 2026-07-31
 
 ### Fixed

--- a/clients/steam_client.py
+++ b/clients/steam_client.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import requests
 
 STORE_DELAY_SEC = 1.5
+# Lighter throttle for appreviews only (storesearch uses SEARCH_DELAY_SEC).
+REVIEW_DELAY_SEC = 0.75
 _STORE_RETRY_BACKOFF = (2, 5, 10)
 _RETRYABLE_HTTP = frozenset({429, 500, 502, 503, 504})
 
@@ -74,10 +76,11 @@ class SteamClient:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
 
-    def _throttle_store(self) -> None:
+    def _throttle_store(self, delay: float | None = None) -> None:
+        min_gap = STORE_DELAY_SEC if delay is None else delay
         elapsed = time.time() - self._last_store_call
-        if elapsed < STORE_DELAY_SEC:
-            time.sleep(STORE_DELAY_SEC - elapsed)
+        if elapsed < min_gap:
+            time.sleep(min_gap - elapsed)
         self._last_store_call = time.time()
 
     def get_owned_games(self) -> list[dict]:
@@ -143,7 +146,7 @@ class SteamClient:
             if cached is not None:
                 return cached
 
-        self._throttle_store()
+        self._throttle_store(REVIEW_DELAY_SEC)
         url = f"https://store.steampowered.com/appreviews/{appid}"
         params = {
             "json": 1,

--- a/enrichers/enrich_steam_reviews.py
+++ b/enrichers/enrich_steam_reviews.py
@@ -32,7 +32,7 @@ sys.stdout.reconfigure(encoding="utf-8", errors="replace", line_buffering=True)
 
 def mapping_file() -> Path:
     return cache_json_path("steam_review_map.json")
-SEARCH_DELAY_SEC = 1.0
+SEARCH_DELAY_SEC = 0.4
 SEARCH_URL = "https://store.steampowered.com/api/storesearch/"
 HEADERS = {"User-Agent": "Mozilla/5.0 backlog/1.0"}
 
@@ -231,6 +231,9 @@ def main() -> int:
                     f"({g['name']} -> {reviews['percent_positive']}%)",
                     flush=True,
                 )
+                data["game_count"] = len(games)
+                write_catalog_text(rel, json.dumps(data, indent=2, ensure_ascii=False))
+                save_mapping(mapping)
 
         data["game_count"] = len(games)
         write_catalog_text(rel, json.dumps(data, indent=2, ensure_ascii=False))

--- a/enrichers/enrich_steam_tags.py
+++ b/enrichers/enrich_steam_tags.py
@@ -130,11 +130,11 @@ def main(argv: list[str] | None = None) -> int:
 
     mapping = load_mapping()
     if not mapping:
-        stats.error(
-            "cache/steam_review_map.json is missing or empty. "
-            "Run enrich_steam_reviews.py first to build the appid map."
+        stats.warn(
+            "cache/steam_review_map.json is missing or empty — "
+            "skipping (run Reviews first to build the appid map)."
         )
-        return stats.finish("enrich_steam_tags", t0, exit_code=1)
+        return stats.finish("enrich_steam_tags", t0, exit_code=0)
 
     steam = SteamClient(api_key=api_key, steam_id=steam_id)
     hb = HeartbeatTimer(45.0)
@@ -199,6 +199,9 @@ def main(argv: list[str] | None = None) -> int:
                     f"(last: {g.get('name')})",
                     flush=True,
                 )
+                if not args.dry_run:
+                    data["game_count"] = len(games)
+                    write_catalog_text(rel, json.dumps(data, indent=2, ensure_ascii=False))
 
         if not args.dry_run and rows_updated:
             data["game_count"] = len(games)

--- a/fetchers/manifest.json
+++ b/fetchers/manifest.json
@@ -407,6 +407,7 @@
       ],
       "metaKey": "steamReviews",
       "color": "#ea580c",
+      "maxRunSeconds": 0,
       "requires": [
         {
           "env": "STEAM_API_KEY",
@@ -439,6 +440,7 @@
       ],
       "metaKey": "steamTags",
       "color": "#ea580c",
+      "maxRunSeconds": 0,
       "requires": [
         {
           "env": "STEAM_API_KEY",

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <!-- Must match pyproject.toml + package.json (see CHANGELOG release discipline). Read at runtime by js/error-boundary.js for bug-bundle metadata. -->
     <!-- Optional override for bug report endpoint during local testing: content="http://127.0.0.1:3000/api/report" -->
     <!-- <meta name="baklog-report-endpoint" content="https://baklog.app/api/report" /> -->
-    <meta name="baklog-version" content="0.8.44" />
+    <meta name="baklog-version" content="0.8.45" />
     <meta name="theme-color" content="#0f172a" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <script>

--- a/js/fetcher-auto-refresh.js
+++ b/js/fetcher-auto-refresh.js
@@ -56,7 +56,7 @@ export function autoStaleLastRunKey() {
   return profileScopedStorageKey(LS_AUTO_STALE_LAST_RUN);
 }
 
-const ENRICH_ORDER = ['steamTags', 'steamCovers', 'steamReviews', 'protondb', 'hltb'];
+const ENRICH_ORDER = ['steamReviews', 'steamTags', 'steamCovers', 'protondb', 'hltb'];
 
 let autoEnrichCooldownUntil = 0;
 const AUTO_ENRICH_COOLDOWN_MS = 3000;
@@ -206,7 +206,7 @@ export function maybeAutoFetchStale24h(deps = {}) {
 }
 
 export async function maybeAutoEnrichNewAdditions(newCount, deps = {}) {
-  if (state.prefs.autoEnrichOnAdd === false) return false;
+  if (!state.prefs.autoEnrichOnAdd) return false;
   if (!newCount || newCount <= 0) return false;
   const now = deps.now ?? Date.now();
   if (now < autoEnrichCooldownUntil) return false;

--- a/js/fetcher/render/dashboard.js
+++ b/js/fetcher/render/dashboard.js
@@ -316,7 +316,7 @@ export function renderDashboardFetcherHealth() {
             </div>`;
         } else if (group === 'enrich') {
           groupToggle = `<label class="fh-toggle" title="After a library fetch adds new games, queue HLTB, Reviews, Covers, and Co-op tags">
-              <input id="autoEnrichOnAddToggle" type="checkbox" class="rounded" ${state.prefs.autoEnrichOnAdd !== false ? 'checked' : ''} />
+              <input id="autoEnrichOnAddToggle" type="checkbox" class="rounded" ${state.prefs.autoEnrichOnAdd === true ? 'checked' : ''} />
               Auto-enrich new games
             </label>`;
         }

--- a/js/fetcher/source-meta.js
+++ b/js/fetcher/source-meta.js
@@ -29,7 +29,7 @@ export const COUNT_PILL_TITLES = {
 // Fixed order within the Enrichment group: keep the three Steam-derived
 // enrichers (orange edge) adjacent, then HLTB. Overrides the status/label
 // sort so they always render next to each other.
-export const ENRICH_ORDER = ['steamTags', 'steamCovers', 'steamReviews', 'protondb', 'hltb'];
+export const ENRICH_ORDER = ['steamReviews', 'steamTags', 'steamCovers', 'protondb', 'hltb'];
 
 export const COUNT_FNS = {
   itad: m => Object.keys(m?.by_key || {}).length,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog",
-  "version": "0.8.44",
+  "version": "0.8.45",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["auth*", "clients*", "fetchers*", "enrichers*", "shared*"]
 
 [project]
 name = "steam-backlog"
-version = "0.8.44"
+version = "0.8.45"
 description = "Local multi-store game library dashboard and fetchers"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/auto-enrich.test.js
+++ b/tests/auto-enrich.test.js
@@ -32,6 +32,19 @@ describe('maybeAutoEnrichNewAdditions', () => {
     expect(runFn).not.toHaveBeenCalled();
   });
 
+  it('does nothing when pref is undefined (opt-in)', async () => {
+    delete state.prefs.autoEnrichOnAdd;
+    const runFn = vi.fn();
+    const ok = await maybeAutoEnrichNewAdditions(5, {
+      isApiAvailable: () => true,
+      runFn,
+      loadFetcherSources: async () => {},
+      sources: enrichSources,
+    });
+    expect(ok).toBe(false);
+    expect(runFn).not.toHaveBeenCalled();
+  });
+
   it('does nothing when newCount is zero', async () => {
     const runFn = vi.fn();
     const ok = await maybeAutoEnrichNewAdditions(0, {
@@ -61,9 +74,9 @@ describe('maybeAutoEnrichNewAdditions', () => {
     });
     expect(ok).toBe(true);
     expect(runFn.mock.calls.map(c => c[0])).toEqual([
+      'steamReviews',
       'steamTags',
       'steamCovers',
-      'steamReviews',
       'hltb',
     ]);
     expect(runFn.mock.calls.every(c => c[1]?.auto === true)).toBe(true);
@@ -101,7 +114,7 @@ describe('maybeAutoEnrichNewAdditions', () => {
       authCooldownRemainingMs: () => 0,
       isFetcherDisconnected: () => false,
     });
-    expect(runFn.mock.calls.map(c => c[0])).toEqual(['steamTags', 'steamCovers', 'steamReviews']);
+    expect(runFn.mock.calls.map(c => c[0])).toEqual(['steamReviews', 'steamTags', 'steamCovers']);
   });
 
   it('stops queuing remaining enrichers after cancel epoch bumps mid-batch', async () => {
@@ -125,7 +138,7 @@ describe('maybeAutoEnrichNewAdditions', () => {
       isFetcherDisconnected: () => false,
       appendLine,
     });
-    expect(runFn.mock.calls.map(c => c[0])).toEqual(['steamTags', 'steamCovers']);
+    expect(runFn.mock.calls.map(c => c[0])).toEqual(['steamReviews', 'steamTags', 'steamCovers']);
     expect(appendLine).toHaveBeenCalledWith('[auto-enrich aborted: cancelled]', 'meta');
   });
 

--- a/tests/queue-wait-timeout.test.js
+++ b/tests/queue-wait-timeout.test.js
@@ -1,6 +1,6 @@
 /**
  * Regression repro for "queue wait timeout" aborting the enrich chain so
- * steamReviews (3rd in ENRICH_ORDER) silently never runs.
+ * later enrichers in ENRICH_ORDER silently never run.
  *
  * Beta report: wishlist view, lib:259, persisted unhandledrejection
  * "queue wait timeout" + "steam review enrichment didn't work".
@@ -10,7 +10,7 @@
  * slow preceding enricher like Covers over hundreds of rows) keeps the single
  * server slot busy past the cap, so the next waitForQueueSlot rejects
  * "queue wait timeout" even though the run is alive and making progress. In the
- * enrich chain that rejection breaks the loop before steamReviews runs.
+ * enrich chain that rejection breaks the loop before remaining enrichers run.
  *
  * Fix: the cap is a NO-PROGRESS timeout. While the active run keeps advancing
  * (new run id or growing line_count, surfaced via applyServerSnapshotInFlight),
@@ -124,7 +124,7 @@ describe('enrich chain reaction to a queue wait timeout', () => {
     expect(runFn.mock.calls.map((c) => c[0])).toContain('steamReviews');
   });
 
-  it('aborts steamReviews/protondb/hltb when the slot wait times out after Covers', async () => {
+  it('aborts remaining enrichers when the slot wait times out after Tags', async () => {
     const runFn = vi.fn().mockResolvedValue(undefined);
     let slotCalls = 0;
     const waitForQueueSlot = vi.fn().mockImplementation(() => {
@@ -150,7 +150,8 @@ describe('enrich chain reaction to a queue wait timeout', () => {
     });
 
     const ran = runFn.mock.calls.map((c) => c[0]);
-    expect(ran).toEqual(['steamTags', 'steamCovers']);
-    expect(ran).not.toContain('steamReviews');
+    // ENRICH_ORDER: Reviews → Tags → Covers…; 3rd wait fails before Covers.
+    expect(ran).toEqual(['steamReviews', 'steamTags']);
+    expect(ran).not.toContain('steamCovers');
   });
 });

--- a/tests/test_enrich_steam_tags.py
+++ b/tests/test_enrich_steam_tags.py
@@ -189,4 +189,4 @@ def test_enricher_bails_without_mapping(
     import enrichers.enrich_steam_tags as enrich_steam_tags
 
     exit_code = enrich_steam_tags.main([])
-    assert exit_code == 1
+    assert exit_code == 0


### PR DESCRIPTION
## Summary
- Uncap Reviews and Co-op tags runtime (`maxRunSeconds: 0`, like HLTB) so large libraries are not force-killed at 30 minutes.
- Lightly trim Reviews delays (storesearch 0.4s, appreviews 0.75s); leave appdetails at 1.5s for Tags/Covers.
- Mid-store catalog flush for Reviews (every 25) and Tags (every 50) so cancel/timeout keeps progress.
- Auto-enrich order is Reviews → Tags → Covers → …; empty-map Tags skips with exit 0.
- Auto-enrich is true opt-in (`undefined` no longer enables checkbox or queues).

## Test plan
- [x] vitest `auto-enrich` + `queue-wait-timeout`
- [x] pytest `test_enrich_steam_tags` + `test_enrich_steam_reviews`
- [ ] Run Reviews on a large library — should pass 30 minutes if still working
- [ ] Cancel Tags mid-store — prior flushed batches remain in catalog JSON
- [ ] Confirm Auto-enrich new games stays unchecked with default prefs