### PR TITLE
fix: sticky Cancel after finished enrichers (0.8.45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 - Reviews/Tags flush catalog JSON mid-store so cancel or timeout keeps progress already written.
 - Auto-enrich runs Reviews before Tags (Tags needs the appid map); empty-map Tags skips with exit 0 instead of sticky failed.
 - Auto-enrich is true opt-in: missing/`undefined` pref no longer enables the checkbox or queues enrichers.
+- Fetcher Cancel no longer sticks after short enrichers finish: ignore non-cancellable chip states, force-refresh idle `/api/runs` snaps, and reattach enrich-lane runs in `syncFromServer`.
 
 ### Changed
 

--- a/js/fetcher/runner/index.js
+++ b/js/fetcher/runner/index.js
@@ -252,14 +252,21 @@ export const fetcherRunner = (() => {
 
   function ensureInFlightPolling() {
     if (inFlightPollTimer || !isApiAvailable()) return;
-    if (runStateByKey.size === 0 && sourcesByRunId.size === 0) return;
+    if (runStateByKey.size === 0 && sourcesByRunId.size === 0 && !lastServerInFlight) return;
     inFlightPollTimer = setInterval(() => {
       syncFromServer().catch(() => {});
-      if (runStateByKey.size === 0 && sourcesByRunId.size === 0) {
+      if (runStateByKey.size === 0 && sourcesByRunId.size === 0 && !lastServerInFlight) {
         clearInterval(inFlightPollTimer);
         inFlightPollTimer = null;
       }
     }, IN_FLIGHT_POLL_MS);
+  }
+
+  function clearServerInFlightLatch() {
+    lastServerInFlight = false;
+    lastFetcherLaneInFlight = false;
+    lastEnrichLaneInFlight = false;
+    lastInFlightSig = '';
   }
 
   function stopInFlightPolling() {
@@ -717,8 +724,17 @@ export const fetcherRunner = (() => {
   // cap of 1 (no queuing); we mirror that here so the UI can disable other
   // chips before the user wastes a click on a 409.
   const MAX_IN_FLIGHT = 1;
+  /** Chip states that mean something is still cancellable / occupying a lane. */
+  const CANCELLABLE_CHIP_STATES = new Set(['running', 'queued']);
   function inFlightCount() {
     return runStateByKey.size;
+  }
+  function cancellableCount() {
+    let n = 0;
+    for (const st of runStateByKey.values()) {
+      if (CANCELLABLE_CHIP_STATES.has(st)) n += 1;
+    }
+    return n;
   }
   function isEnrichKey(key) {
     return source(key)?.group === 'enrich';
@@ -727,13 +743,14 @@ export const fetcherRunner = (() => {
     const enrich = isEnrichKey(key);
     const laneBusy = enrich ? lastEnrichLaneInFlight : lastFetcherLaneInFlight;
     if (laneBusy) return true;
-    for (const [k] of runStateByKey) {
+    for (const [k, st] of runStateByKey) {
+      if (!CANCELLABLE_CHIP_STATES.has(st)) continue;
       if (isEnrichKey(k) === enrich) return true;
     }
     return false;
   }
   function isQueueFull() {
-    return inFlightCount() >= MAX_IN_FLIGHT || lastServerInFlight;
+    return cancellableCount() >= MAX_IN_FLIGHT || lastServerInFlight;
   }
   const WAIT_QUEUE_SNAPSHOT_POLL_MS = 2000;
   function waitForQueueSlot({ batchEpoch, key } = {}) {
@@ -890,7 +907,7 @@ export const fetcherRunner = (() => {
     if (!panel) return;
     const btn = panel.querySelector('[data-role="cancel"]');
     if (!btn) return;
-    const show = isApiAvailable() && (inFlightCount() > 0 || lastServerInFlight);
+    const show = isApiAvailable() && (cancellableCount() > 0 || lastServerInFlight);
     btn.classList.toggle('hidden', !show);
     if (cancelInFlight) {
       btn.disabled = true;
@@ -1041,7 +1058,7 @@ export const fetcherRunner = (() => {
       for (const q of snap?.queue || []) ids.push(q.id);
       if (snap?.enrich_active) ids.push(snap.enrich_active.id);
       for (const q of snap?.enrich_queue || []) ids.push(q.id);
-      const clientStale = inFlightCount() > 0;
+      const clientStale = cancellableCount() > 0;
       if (!ids.length && !force && !clientStale && !lastServerInFlight) {
         return;
       }
@@ -1110,6 +1127,7 @@ export const fetcherRunner = (() => {
         } else {
           lastRunFailedByKey.set(key, Date.now());
           markChipState(key, 'failed');
+          scheduleFailedChipClear(key);
         }
         if (hist.id) clearLastSeq(hist.id);
       } else {
@@ -1313,20 +1331,45 @@ export const fetcherRunner = (() => {
     }
     updateGlobalFetcherIndicator(runStateByKey, source);
     renderDashboardFetcherHealth();
-    if (runState) ensureInFlightPolling();
-    else if (runStateByKey.size === 0) {
-      stopInFlightPolling();
+    if (runState) {
+      ensureInFlightPolling();
+      updateCancelButton();
+    } else if (runStateByKey.size === 0) {
       revertFetcherLayoutIfIdle();
-      // Client chip cleared — re-check server truth so stale lastServerInFlight
-      // does not keep isQueueFull() latched after a run ends locally.
-      void fetchRunsSnapshot()
+      // Force a fresh snapshot so a coalesced in-flight /api/runs response
+      // (common for short enrichers like Covers) cannot re-latch Cancel after
+      // the client chip already cleared. Keep polling until server is idle.
+      void fetchRunsSnapshot({ force: true })
         .then((snap) => {
           if (snap) applyServerSnapshotInFlight(snap);
+          else clearServerInFlightLatch();
           updateCancelButton();
+          if (lastServerInFlight || sourcesByRunId.size > 0 || runStateByKey.size > 0) {
+            ensureInFlightPolling();
+          } else {
+            stopInFlightPolling();
+          }
         })
-        .catch(() => {});
+        .catch(() => {
+          clearServerInFlightLatch();
+          updateCancelButton();
+          if (sourcesByRunId.size === 0 && runStateByKey.size === 0) {
+            stopInFlightPolling();
+          }
+        });
+    } else {
+      updateCancelButton();
     }
     updateFetcherBar();
+  }
+
+  const FAILED_CHIP_CLEAR_MS = 10_000;
+  function scheduleFailedChipClear(key) {
+    setTimeout(() => {
+      if (runStateByKey.get(key) === 'failed') {
+        markChipState(key, null);
+      }
+    }, FAILED_CHIP_CLEAR_MS);
   }
 
   // Returns true only when a run was actually submitted to the server; false on
@@ -1644,12 +1687,7 @@ export const fetcherRunner = (() => {
           lastRunFailedByKey.set(key, Date.now());
           markChipState(key, 'failed');
           handleFetcherAuthOutcome(key, data, recentLog.join('\n'));
-          setTimeout(() => {
-            if (runStateByKey.get(key) === 'failed') {
-              runStateByKey.delete(key);
-              renderDashboardFetcherHealth();
-            }
-          }, 10000);
+          scheduleFailedChipClear(key);
         }
       } catch (err) {
         logEvent('error', `[client] parse error on done: ${err}`);
@@ -1712,12 +1750,7 @@ export const fetcherRunner = (() => {
             lastRunFailedByKey.set(key, Date.now());
             markChipState(key, 'failed');
             handleFetcherAuthOutcome(key, finished, '');
-            setTimeout(() => {
-              if (runStateByKey.get(key) === 'failed') {
-                runStateByKey.delete(key);
-                renderDashboardFetcherHealth();
-              }
-            }, 10000);
+            scheduleFailedChipClear(key);
           }
           if (liveRunId === runId) liveRunId = null;
           revertFetcherLayoutIfIdle();
@@ -1774,25 +1807,32 @@ export const fetcherRunner = (() => {
     const pending = [];
     if (snap.active) pending.push(snap.active);
     for (const q of snap.queue || []) pending.push(q);
+    if (snap.enrich_active) pending.push(snap.enrich_active);
+    for (const q of snap.enrich_queue || []) pending.push(q);
 
     const visiblePending = pending.filter(r => !suppressedRunIds.has(r.id));
     if (visiblePending.length) {
-      const panelSrc = source(snap.active?.key) || source(visiblePending[0].key);
+      const panelSrc = source(snap.active?.key)
+        || source(snap.enrich_active?.key)
+        || source(visiblePending[0].key);
       ensurePanel(panelSrc);
       const isFirstSync = !syncedOnce;
       syncedOnce = true;
       if (isFirstSync) {
         const parts = [];
-        if (snap.active && !suppressedRunIds.has(snap.active.id)) {
-          const aLabel = source(snap.active.key)?.label || snap.active.key;
-          const aState = snap.active.status === 'launching'
+        const describeActive = (run) => {
+          if (!run || suppressedRunIds.has(run.id)) return;
+          const aLabel = source(run.key)?.label || run.key;
+          const aState = run.status === 'launching'
             ? 'launching'
-            : snap.active.status === 'cancelling'
+            : run.status === 'cancelling'
               ? 'cancelling'
               : 'running';
           parts.push(`${aLabel} ${aState}`);
-        }
-        for (const q of snap.queue || []) {
+        };
+        describeActive(snap.active);
+        describeActive(snap.enrich_active);
+        for (const q of [...(snap.queue || []), ...(snap.enrich_queue || [])]) {
           if (suppressedRunIds.has(q.id)) continue;
           const qLabel = source(q.key)?.label || q.key;
           parts.push(`${qLabel} queued`);
@@ -1804,24 +1844,27 @@ export const fetcherRunner = (() => {
       for (const run of visiblePending) {
         const src = source(run.key);
         if (!src) continue;
-        const chipState = serverChipState(run.status) || 'queued';
+        const chipState = serverChipState(run.status);
+        if (!chipState) continue;
         markChipState(run.key, chipState, run.id);
         if (run.status === 'running' || run.status === 'launching' || run.status === 'cancelling') {
           liveRunId = run.id;
         }
         if (run.status === 'cancelling') continue;
         if (sourcesByRunId.has(run.id)) continue;
-        if (run.status === 'queued' && snap.active?.id !== run.id) continue;
+        const isLaneActive = snap.active?.id === run.id || snap.enrich_active?.id === run.id;
+        if (run.status === 'queued' && !isLaneActive) continue;
         subscribe(run.id, run.key, src, { reconnect: true, quiet: true });
       }
       updateCancelButton();
-      if (snap.active && panelSrc) {
-        const st = snap.active.status;
+      const chromeRun = snap.active || snap.enrich_active;
+      if (chromeRun && panelSrc) {
+        const st = chromeRun.status;
         if (st === 'cancelling') syncLogPanelChrome(panelSrc, 'cancelling');
         else if (st === 'launching' || st === 'running') syncLogPanelChrome(panelSrc, st);
         else syncLogPanelChrome(panelSrc, 'running');
-      } else if (snap.queue?.length) {
-        const qRun = snap.queue[0];
+      } else if ((snap.queue?.length || snap.enrich_queue?.length)) {
+        const qRun = snap.queue?.[0] || snap.enrich_queue?.[0];
         const qSrc = source(qRun.key) || panelSrc;
         if (qSrc) {
           const qExtra = queueStatusExtra(snap, qRun.id);
@@ -1905,6 +1948,7 @@ export const fetcherRunner = (() => {
     apiProbeFinished,
     stateFor,
     inFlightCount,
+    cancellableCount,
     isQueueFull,
     isQueueFullForKey,
     waitForQueueSlot,

--- a/tests/cancel-in-flight.test.js
+++ b/tests/cancel-in-flight.test.js
@@ -525,3 +525,242 @@ describe('cancelInFlightRuns server truth', () => {
     expect(runPosts).toBe(1);
   });
 });
+
+describe('Cancel button after finished runs', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    localStorage.clear();
+    sessionStorage.clear();
+    document.body.innerHTML = '<div id="fetcherRunLog"></div>';
+    installMockEventSource();
+  });
+
+  afterEach(() => {
+    delete global.EventSource;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  async function setupRunner(runsHandler) {
+    const fetchMock = vi.fn(async (url) => {
+      const u = String(url);
+      if (u.includes('/api/runs') && !u.includes('/cancel')) {
+        return { ok: true, json: async () => runsHandler() };
+      }
+      if (u.includes('/api/fetchers') || u.includes('manifest.json')) {
+        return {
+          ok: true,
+          json: async () => ({
+            fetchers: [
+              {
+                key: 'steamCovers',
+                label: 'Covers',
+                group: 'enrich',
+                metaKey: 'steamCovers',
+                available: true,
+                cmd: 'enrich_steam_covers.py',
+              },
+              {
+                key: 'hltb',
+                label: 'HLTB',
+                group: 'enrich',
+                metaKey: 'hltb',
+                available: true,
+                cmd: 'enrich_hltb.py',
+              },
+              {
+                key: 'steam',
+                label: 'Steam',
+                group: 'library',
+                metaKey: 'steam',
+                available: true,
+                cmd: 'fetch_steam.py',
+              },
+            ],
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    global.fetch = fetchMock;
+    const { fetcherRunner, loadFetcherSources } = await import('../js/fetcher-health.js');
+    await fetcherRunner.probeApi(true);
+    await loadFetcherSources(true);
+    return { fetcherRunner, fetchMock };
+  }
+
+  function cancelHidden(fetcherRunner) {
+    fetcherRunner.ensurePanelForTest({ label: 'Covers', key: 'steamCovers' }, 'done');
+    const btn = document.querySelector('[data-role="cancel"]');
+    return !!btn?.classList.contains('hidden');
+  }
+
+  it('hides Cancel after steamCovers chip clears when server is idle', async () => {
+    const idle = {
+      active: null,
+      queue: [],
+      enrich_active: null,
+      enrich_queue: [],
+      history: [],
+    };
+    const { fetcherRunner } = await setupRunner(() => idle);
+    fetcherRunner.ensurePanelForTest({ label: 'Covers', key: 'steamCovers' }, 'running');
+    fetcherRunner.applyServerSnapshotInFlight({
+      enrich_active: { id: 'cover-1', key: 'steamCovers', status: 'running' },
+      enrich_queue: [],
+      active: null,
+      queue: [],
+      history: [],
+    });
+    fetcherRunner.markChipStateForTest('steamCovers', 'running', 'cover-1');
+    expect(document.querySelector('[data-role="cancel"]')?.classList.contains('hidden')).toBe(false);
+
+    fetcherRunner.markChipStateForTest('steamCovers', null);
+    await vi.waitFor(() => {
+      expect(fetcherRunner.getLastServerInFlight()).toBe(false);
+      expect(document.querySelector('[data-role="cancel"]')?.classList.contains('hidden')).toBe(true);
+    });
+  });
+
+  it('force-refreshes idle snap so coalesced in-flight snap cannot re-latch Cancel', async () => {
+    let runsCalls = 0;
+    const { fetcherRunner } = await setupRunner(() => {
+      runsCalls += 1;
+      // First non-force call during the coalesce window would return stale
+      // enrich_active; force:true after chip clear must get idle.
+      if (runsCalls === 1) {
+        return {
+          active: null,
+          queue: [],
+          enrich_active: { id: 'cover-2', key: 'steamCovers', status: 'running', line_count: 3 },
+          enrich_queue: [],
+          history: [],
+        };
+      }
+      return {
+        active: null,
+        queue: [],
+        enrich_active: null,
+        enrich_queue: [],
+        history: [
+          {
+            id: 'cover-2',
+            key: 'steamCovers',
+            status: 'done',
+            exit_code: 0,
+            ended_at: Date.now() / 1000,
+          },
+        ],
+      };
+    });
+
+    fetcherRunner.ensurePanelForTest({ label: 'Covers', key: 'steamCovers' }, 'running');
+    // Seed coalesce cache with the stale in-flight snap (call 1).
+    await fetcherRunner.syncFromServer();
+    expect(fetcherRunner.stateFor('steamCovers')).toBe('running');
+    expect(document.querySelector('[data-role="cancel"]')?.classList.contains('hidden')).toBe(false);
+
+    // Chip clear forces a fresh idle snap (call 2+), not the coalesced one.
+    fetcherRunner.markChipStateForTest('steamCovers', null);
+    await vi.waitFor(() => {
+      expect(runsCalls).toBeGreaterThanOrEqual(2);
+      expect(fetcherRunner.getLastServerInFlight()).toBe(false);
+      expect(document.querySelector('[data-role="cancel"]')?.classList.contains('hidden')).toBe(true);
+    });
+  });
+
+  it('does not keep Cancel visible for failed-only chip state', async () => {
+    const { fetcherRunner } = await setupRunner(() => ({
+      active: null,
+      queue: [],
+      enrich_active: null,
+      enrich_queue: [],
+      history: [],
+    }));
+    fetcherRunner.applyServerSnapshotInFlight({});
+    fetcherRunner.markChipStateForTest('hltb', 'failed');
+    expect(fetcherRunner.cancellableCount()).toBe(0);
+    expect(fetcherRunner.isQueueFull()).toBe(false);
+    expect(cancelHidden(fetcherRunner)).toBe(true);
+  });
+
+  it('reconcile failed schedules clear so Cancel is not held indefinitely', async () => {
+    vi.useFakeTimers();
+    const { fetcherRunner } = await setupRunner(() => ({
+      active: null,
+      queue: [],
+      enrich_active: null,
+      enrich_queue: [],
+      history: [],
+    }));
+    fetcherRunner.ensurePanelForTest({ label: 'HLTB', key: 'hltb' }, 'running');
+    fetcherRunner.markChipStateForTest('hltb', 'running', 'hltb-fail-1');
+    fetcherRunner.reconcileRunStateFromSnapshot({
+      active: null,
+      queue: [],
+      enrich_active: null,
+      enrich_queue: [],
+      history: [
+        {
+          id: 'hltb-fail-1',
+          key: 'hltb',
+          status: 'failed',
+          exit_code: 1,
+          ended_at: Date.now() / 1000,
+        },
+      ],
+    });
+    expect(fetcherRunner.stateFor('hltb')).toBe('failed');
+    expect(fetcherRunner.cancellableCount()).toBe(0);
+    expect(document.querySelector('[data-role="cancel"]')?.classList.contains('hidden')).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(fetcherRunner.stateFor('hltb')).toBeNull();
+    expect(fetcherRunner.isRunFailedForTest('hltb')).toBe(true);
+  });
+
+  it('syncFromServer reattaches enrich_active and clears Cancel when history says done', async () => {
+    let phase = 'running';
+    const { fetcherRunner } = await setupRunner(() => {
+      if (phase === 'running') {
+        return {
+          active: null,
+          queue: [],
+          enrich_active: { id: 'cover-3', key: 'steamCovers', status: 'running', line_count: 2 },
+          enrich_queue: [],
+          history: [],
+        };
+      }
+      return {
+        active: null,
+        queue: [],
+        enrich_active: null,
+        enrich_queue: [],
+        history: [
+          {
+            id: 'cover-3',
+            key: 'steamCovers',
+            status: 'done',
+            exit_code: 0,
+            ended_at: Date.now() / 1000,
+          },
+        ],
+      };
+    });
+
+    await fetcherRunner.syncFromServer();
+    expect(fetcherRunner.stateFor('steamCovers')).toBe('running');
+    expect(document.querySelector('[data-role="cancel"]')?.classList.contains('hidden')).toBe(false);
+
+    phase = 'done';
+    // Let the /api/runs coalesce window expire so the next sync sees idle truth.
+    await new Promise((r) => setTimeout(r, 1600));
+    await fetcherRunner.syncFromServer();
+    await vi.waitFor(() => {
+      expect(fetcherRunner.stateFor('steamCovers')).toBeNull();
+      expect(fetcherRunner.getLastServerInFlight()).toBe(false);
+      expect(document.querySelector('[data-role="cancel"]')?.classList.contains('hidden')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Cancel button stays hidden once chips clear and the server is idle (force-refresh avoids coalesced `/api/runs` re-latch).
- Only `running`/`queued` chip states count as cancellable / queue-blocking (`failed` flash no longer holds Cancel).
- `syncFromServer` reattaches enrich-lane active/queue the same way as fetcher lane.

Same version **0.8.45** — retag after merge.

## Test plan
- [x] `vitest` `tests/cancel-in-flight.test.js` (17)
- [ ] Run a short enricher (Covers) — Cancel appears while running, hides when done
- [ ] Enrich still active after page reload — Cancel reappears / stream reattaches