### PR TITLE
fix: dashboard summary chips + library chip wrap (0.8.46)

### DIFF
--- a/.cursor/rules/release.mdc
+++ b/.cursor/rules/release.mdc
@@ -1,0 +1,16 @@
+---
+description: Release gates — clean tree and green CI before tag/publish
+alwaysApply: true
+---
+
+# Release gates
+
+Before tagging or publishing any release (`vX.Y.Z`, `replace_release_tag.ps1`, GitHub Release):
+
+1. **Working tree clean** on the release commit (`git status` shows nothing to commit). No leftover WIP, untracked release-critical files, or half-staged changes.
+2. **CI green** on that commit after it is on `main` (or on the PR that will merge to `main`). Do not tag from a red or still-running required check. Wait for GitHub Actions CI on the merge commit to pass before `git tag` / push tag.
+3. Version stamps match (`pyproject.toml`, `package.json`, `index.html` meta/`brandVersionBadge`) and CHANGELOG has `[X.Y.Z]` notes.
+4. Prefer: merge PR → confirm `main` clean + CI green on the merge commit → then tag `vX.Y.Z` and push the tag so `release.yml` builds assets.
+
+Do **not** tag a dirty tree, an unmerged feature branch, or a commit whose CI failed/is pending.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,20 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 4. **Before tagging:** run `.\scripts\release_preflight.ps1 -TagVersion vX.Y.Z`
    on Windows (includes pytest, Inno ISCC compile, optional full
    `build_windows.ps1`). CI `python-windows` must also compile `baklog.iss`.
-5. **Broken public installer:** do not bump version for a bad build alone. Fix
+5. **Gates:** working tree must be clean and GitHub CI must be green on the release commit on `main` before tagging. Never tag WIP or a red/pending CI commit.
+6. **Broken public installer:** do not bump version for a bad build alone. Fix
    on `main`, keep `pyproject.toml` on the same version, run
    `.\scripts\replace_release_tag.ps1 -Version X.Y.Z -Force` to replace the tag
    and re-publish assets at the same version.
 
 ## [Unreleased]
+
+## [0.8.46] - 2026-08-01
+
+### Fixed
+
+- Dashboard no longer shows leftover Library/Wishlist/itch #summary chips after navigate (including cached dashboard returns).
+- Library/Wishlist/itch status chips (e.g. Backlog) wrap in the same row as store/stat chips instead of a forced extra row.
 
 ## [0.8.45] - 2026-08-01
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <!-- Must match pyproject.toml + package.json (see CHANGELOG release discipline). Read at runtime by js/error-boundary.js for bug-bundle metadata. -->
     <!-- Optional override for bug report endpoint during local testing: content="http://127.0.0.1:3000/api/report" -->
     <!-- <meta name="baklog-report-endpoint" content="https://baklog.app/api/report" /> -->
-    <meta name="baklog-version" content="0.8.45" />
+    <meta name="baklog-version" content="0.8.46" />
     <meta name="theme-color" content="#0f172a" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <script>

--- a/js/filters-ui.js
+++ b/js/filters-ui.js
@@ -400,6 +400,7 @@ export async function refreshFilterUI(options) {
   renderFiltersButtonBadge();
   renderActiveFilterPills();
   if (state.activeView === "dashboard") {
+    renderSummary(); // empties #summary on dashboard
     if (!options?.skipDashboardSchedule) scheduleDashboardRender();
     return;
   }
@@ -694,7 +695,9 @@ export function switchView(view) {
     updateBulkBar();
     const skipDashboardSchedule = view === "dashboard";
     const deferTableChrome = useOverlay && !drillIn && view !== "dashboard";
-    updateViewChrome({ drillIn, skipDashboardSchedule, deferTableChrome, skipSummary: true });
+    // skipSummary avoids double paint on table views (refreshFilterUI paints).
+    // Dashboard early-returns from refreshFilterUI without clearing #summary.
+    updateViewChrome({ drillIn, skipDashboardSchedule, deferTableChrome, skipSummary: view !== "dashboard" });
     void flushDeferredRenders();
     const refreshDone = refreshFilterUI({ force: true, drillIn, skipDashboardSchedule });
     const paintDashboard = () => {
@@ -816,8 +819,8 @@ export function renderSummary() {
         ${onSaleChip}
         ${lowChip}
         ${ownedChip}
-      </div>
-      ${statusChips ? `<div class="w-full flex flex-wrap gap-2">${statusChips}</div>` : ""}`;
+        ${statusChips || ""}
+      </div>`;
     return;
   }
   if (state.activeView === "itch") {
@@ -843,8 +846,8 @@ export function renderSummary() {
         <div class="summary-stat-chip summary-stat-chip--itch" title="itch.io items with a community rating">Rated <span class="text-slate-100 font-semibold ml-1">${rated.length}</span></div>
         <div class="summary-stat-chip summary-stat-chip--itch" title="Mean itch.io review % (rated items)">Avg rating <span class="text-slate-100 font-semibold ml-1">${avg}${avg !== " - " ? "%" : ""}</span></div>
         ${fetched ? `<div class="summary-stat-chip summary-stat-chip--itch text-slate-400" title="Last itch.io library fetch time">Fetched ${escapeHtml(fetched)}</div>` : ""}
-      </div>
-      ${statusChips ? `<div class="w-full flex flex-wrap gap-2">${statusChips}</div>` : ""}`;
+        ${statusChips || ""}
+      </div>`;
     return;
   }
   const visibleAll = filterOutHidden(state.allGames.filter(g => !state.crossStoreHiddenKeys.has(gameKey(g))));
@@ -901,8 +904,8 @@ export function renderSummary() {
       ${noiseChip}
       ${staleChip}
       ${storeChips}
-    </div>
-    ${statusChips ? `<div class="w-full flex flex-wrap gap-2">${statusChips}</div>` : ""}`;
+      ${statusChips || ""}
+    </div>`;
 }
 
 export function renderStoreChips() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog",
-  "version": "0.8.45",
+  "version": "0.8.46",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["auth*", "clients*", "fetchers*", "enrichers*", "shared*"]
 
 [project]
 name = "steam-backlog"
-version = "0.8.45"
+version = "0.8.46"
 description = "Local multi-store game library dashboard and fetchers"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/dashboard-summary-chips.test.js
+++ b/tests/dashboard-summary-chips.test.js
@@ -1,0 +1,51 @@
+﻿import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { hydrateIndexDocument } from './a11y/hydrate-index.js';
+
+describe('dashboard clears #summary chips', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    hydrateIndexDocument();
+  });
+
+  it('empties #summary when switching to a cached dashboard', async () => {
+    const dash = await import('../js/dashboard.js');
+    vi.spyOn(dash, 'dashboardWasRendered').mockReturnValue(true);
+    vi.spyOn(dash, 'renderDashboard').mockResolvedValue(undefined);
+    vi.spyOn(dash, 'scheduleDashboardRender').mockImplementation(() => {});
+    vi.spyOn(dash, 'cancelScheduledDashboardRender').mockImplementation(() => {});
+    vi.spyOn(dash, 'stopDashboardRotations').mockImplementation(() => {});
+    vi.spyOn(dash, 'setDashReplayAllowed').mockImplementation(() => {});
+
+    const chart = await import('../js/chart-loader.js');
+    vi.spyOn(chart, 'ensureChartJs').mockResolvedValue(undefined);
+
+    const { state } = await import('../js/state.js');
+    state.activeView = 'library';
+    state.allGames = [];
+    state.wishlistGames = [];
+    state.itchGames = [];
+    state.personal = {};
+    state.prefs = {
+      ...(state.prefs || {}),
+      storeFilter: '',
+      genreFilters: [],
+      picksTab: 'topRated',
+      libraryPicksTab: 'topRated',
+    };
+    state.sessionPrefs = { ...(state.sessionPrefs || {}), staleOnly: false, statusFilter: '' };
+    state.selectedKeys = new Set();
+    state.crossStoreHiddenKeys = new Set();
+    state.wishlistCrossStoreHiddenKeys = new Set();
+
+    const summary = document.getElementById('summary');
+    expect(summary).toBeTruthy();
+    summary.innerHTML = '<button type="button" class="summary-chip">Library chip</button>';
+
+    const { switchView } = await import('../js/filters-ui.js');
+    switchView('dashboard');
+
+    expect(state.activeView).toBe('dashboard');
+    expect(summary.innerHTML.trim()).toBe('');
+    expect(summary.children.length).toBe(0);
+  });
+});

--- a/tests/filters-summary-noise.test.js
+++ b/tests/filters-summary-noise.test.js
@@ -47,6 +47,15 @@ describe('renderSummary noise chip', () => {
     expect(chip.textContent).toMatch(/1/);
     expect(chip.textContent).toMatch(/non-games/);
   });
+
+  it('puts status chips in the same wrapper as store/stat chips', () => {
+    renderSummary();
+    const summary = document.getElementById('summary');
+    expect(summary.children.length).toBe(1);
+    const wrap = summary.firstElementChild;
+    expect(wrap.querySelector('.summary-stat-chip, .summary-store-chip')).toBeTruthy();
+    expect(wrap.querySelector('.status-chip')).toBeTruthy();
+  });
 });
 
 describe('summary noise chip opens hidden panel', () => {


### PR DESCRIPTION
## Summary
- Clear leftover #summary chips when navigating to Dashboard (including cached returns).
- Merge status/Backlog chips into the same flex-wrap row as store/stat chips on Library/Wishlist/itch.
- Release gates rule: clean working tree + green CI before tagging.
- Bump to 0.8.46.

## Test plan
- [ ] Navigate Library → Dashboard (second time in session): no chips above dashboard
- [ ] Library summary: Backlog chip wraps with store chips (no lone Backlog row)
- [ ] vitest dashboard-summary-chips + filters-summary-noise
- [ ] CI green before merge/tag