### PR TITLE
fix: CodeQL hostname allowlists and release gate wording (0.8.46)

### DIFF
--- a/.cursor/rules/release.mdc
+++ b/.cursor/rules/release.mdc
@@ -1,16 +1,17 @@
 ---
-description: Release gates — clean tree and green CI before tag/publish
+description: Release gates — clean tree and green CI before tag/publish only
 alwaysApply: true
 ---
 
 # Release gates
 
-Before tagging or publishing any release (`vX.Y.Z`, `replace_release_tag.ps1`, GitHub Release):
+**Ship code** (commit → push → merge) is separate from cutting a release. Do not block merge on a long CI wait unless branch protection requires it.
 
-1. **Working tree clean** on the release commit (`git status` shows nothing to commit). No leftover WIP, untracked release-critical files, or half-staged changes.
-2. **CI green** on that commit after it is on `main` (or on the PR that will merge to `main`). Do not tag from a red or still-running required check. Wait for GitHub Actions CI on the merge commit to pass before `git tag` / push tag.
+Before **tagging or publishing** any release (`vX.Y.Z`, `replace_release_tag.ps1`, GitHub Release):
+
+1. **Working tree clean** on the release commit on `main` (`git status` shows nothing to commit).
+2. **CI green** on that `main` commit. Do not tag while required checks are red or still pending. Wait for GitHub Actions on the merge commit to pass, then tag.
 3. Version stamps match (`pyproject.toml`, `package.json`, `index.html` meta/`brandVersionBadge`) and CHANGELOG has `[X.Y.Z]` notes.
-4. Prefer: merge PR → confirm `main` clean + CI green on the merge commit → then tag `vX.Y.Z` and push the tag so `release.yml` builds assets.
+4. Flow: commit → push → merge to `main` → confirm clean tree + CI green on that commit → `git tag -a vX.Y.Z` and `git push origin vX.Y.Z` so `release.yml` builds assets.
 
 Do **not** tag a dirty tree, an unmerged feature branch, or a commit whose CI failed/is pending.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 4. **Before tagging:** run `.\scripts\release_preflight.ps1 -TagVersion vX.Y.Z`
    on Windows (includes pytest, Inno ISCC compile, optional full
    `build_windows.ps1`). CI `python-windows` must also compile `baklog.iss`.
-5. **Gates:** working tree must be clean and GitHub CI must be green on the release commit on `main` before tagging. Never tag WIP or a red/pending CI commit.
+5. **Gates (tagging only):** working tree must be clean and GitHub CI must be green on the release commit on `main` before tagging — not before merge. Ship via commit → push → merge; wait for clean tree + green CI only before `git tag`. Never tag WIP or a red/pending CI commit.
 6. **Broken public installer:** do not bump version for a bad build alone. Fix
    on `main`, keep `pyproject.toml` on the same version, run
    `.\scripts\replace_release_tag.ps1 -Version X.Y.Z -Force` to replace the tag
@@ -36,6 +36,10 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 - Dashboard no longer shows leftover Library/Wishlist/itch #summary chips after navigate (including cached dashboard returns).
 - Library/Wishlist/itch status chips (e.g. Backlog) wrap in the same row as store/stat chips instead of a forced extra row.
+- Connect URL/host checks use hostname allowlists (Battle.net/Epic) instead of substring/endswith host matching (CodeQL).
+- Release gates rule: commit/push/merge first; clean tree + green CI only before tag.
+- Connect URL/host checks use hostname allowlists (Battle.net/Epic) instead of substring/`endswith` host matching (CodeQL).
+- Release gates rule: commit/push/merge first; clean tree + green CI only before tag.
 
 ## [0.8.45] - 2026-08-01
 

--- a/auth/connect_extractors.py
+++ b/auth/connect_extractors.py
@@ -8,6 +8,8 @@ import threading
 from collections.abc import Callable
 from typing import Any
 
+from auth.url_hosts import cookie_domain_matches, host_matches
+
 HUMBLE_LIBRARY_URL = "https://www.humblebundle.com/home/library"
 HUMBLE_ORDERS_API = "https://www.humblebundle.com/api/v1/user/order"
 BATTLENET_GAMES_URL = "https://account.battle.net/games"
@@ -66,8 +68,8 @@ def _humble_has_session(context: Any) -> bool:
 
 def _battlenet_has_session(context: Any) -> bool:
     for c in context.cookies():
-        domain = (c.get("domain") or "").lstrip(".")
-        if domain.endswith("battle.net") and c.get("name") and c.get("value"):
+        domain = c.get("domain") or ""
+        if cookie_domain_matches(domain, "battle.net") and c.get("name") and c.get("value"):
             return True
     return False
 
@@ -243,8 +245,8 @@ def _battlenet_cookie_count(cookies: list[dict]) -> tuple[int, bool]:
     count = 0
     has_xsrf = False
     for c in cookies:
-        domain = (c.get("domain") or "").lstrip(".")
-        if not domain.endswith("battle.net"):
+        domain = c.get("domain") or ""
+        if not cookie_domain_matches(domain, "battle.net"):
             continue
         if c.get("name") and c.get("value") is not None:
             count += 1
@@ -506,10 +508,11 @@ def extract_battlenet_session(
 
 
 def battlenet_connect_hint(page: Any) -> str:
-    url = (getattr(page, "url", None) or "").lower()
-    if "login" in url or "signin" in url or "authorize" in url:
+    url = getattr(page, "url", None) or ""
+    url_low = url.lower()
+    if "login" in url_low or "signin" in url_low or "authorize" in url_low:
         return "Sign in to your Battle.net account in the browser window."
-    if "battle.net" not in url:
+    if not host_matches(url, "battle.net"):
         return "Open account.battle.net/games after signing in."
     return (
         "On your Games page? Wait until your library list finishes loading, "

--- a/auth/runner.py
+++ b/auth/runner.py
@@ -28,6 +28,7 @@ from auth.cdp_browser import (
 from auth.epic_wishlist_session import EPIC_WISHLIST_URL, epic_store_login_url
 from auth.registry import spec_for
 from auth.secrets import profile_dir
+from auth.url_hosts import host_matches
 
 SUCCESS_WAIT_SEC = 300
 POLL_SEC = 0.5
@@ -161,12 +162,12 @@ def _battlenet_live_page(page, context):
     """Prefer the Games SPA tab over blank OAuth popups / stale login tabs."""
     pages = _connect_pages(page, context)
     for pg in pages:
-        url = (getattr(pg, "url", None) or "").lower()
-        if "account.battle.net" in url and "/games" in url:
+        url = getattr(pg, "url", None) or ""
+        if host_matches(url, "account.battle.net") and "/games" in (urlparse(url).path or "").lower():
             return pg
     for pg in pages:
-        url = (getattr(pg, "url", None) or "").lower()
-        if "battle.net" in url and not is_blank_browser_url(url):
+        url = getattr(pg, "url", None) or ""
+        if host_matches(url, "battle.net") and not is_blank_browser_url(url):
             return pg
     return _drive_connect_page(page, context)
 
@@ -466,7 +467,7 @@ def _extract_epic_inline(page, context, session: AuthSession | None = None) -> d
                 last_hint = now
                 if cf_pages and cf_opened_until and cf_opened_until[0] > now:
                     msg = EPIC_CF_CHALLENGE_HINT
-                elif "login" in url or "id.epicgames.com" in url:
+                elif "login" in url or host_matches(url, "id.epicgames.com"):
                     msg = "Sign in to your Epic account in the browser window."
                 else:
                     msg = "Capturing your Epic authorization code — keep the window open."
@@ -684,12 +685,12 @@ def _extract_psn(page, context, session: AuthSession | None = None) -> dict[str,
 
 def _epic_on_wishlist(url: str) -> bool:
     ul = (url or "").lower()
-    return "store.epicgames.com" in ul and "wishlist" in ul
+    return host_matches(url, "store.epicgames.com") and "wishlist" in ul
 
 
 def _epic_on_login_page(url: str) -> bool:
     ul = (url or "").lower()
-    return "id.epicgames.com" in ul or "/id/login" in ul
+    return host_matches(url, "id.epicgames.com") or "/id/login" in ul
 
 
 def _extract_epic_wishlist_inline(page, context, session) -> dict[str, str]:
@@ -803,7 +804,7 @@ def _extract_epic_wishlist_inline(page, context, session) -> dict[str, str]:
                     )
                 elif on_wishlist:
                     msg = "On the wishlist page? Give it a moment to load."
-                elif "store.epicgames.com" in ul:
+                elif host_matches(url, "store.epicgames.com"):
                     msg = (
                         "Signed in? Opening your wishlist — give it a moment to load."
                     )
@@ -856,8 +857,7 @@ def _xbox_url_on_wishlist(url: str) -> bool:
         parsed = urlparse(url or "")
     except Exception:  # noqa: BLE001
         return False
-    host = (parsed.hostname or "").lower()
-    if host != "xbox.com" and not host.endswith(".xbox.com"):
+    if not host_matches(url, "xbox.com"):
         return False
     return "/wishlist" in (parsed.path or "").lower()
 

--- a/auth/url_hosts.py
+++ b/auth/url_hosts.py
@@ -1,0 +1,37 @@
+"""Hostname allowlist helpers for Connect URL/cookie checks (CodeQL-safe)."""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+
+def hostname_of(url_or_host: str) -> str:
+    """Return lowercase hostname from a URL or bare host string."""
+    raw = (url_or_host or "").strip()
+    if not raw:
+        return ""
+    if "://" not in raw and "/" not in raw and "?" not in raw:
+        return raw.lstrip(".").lower()
+    try:
+        host = urlparse(raw if "://" in raw else f"https://{raw}").hostname
+    except Exception:  # noqa: BLE001
+        return ""
+    return (host or "").lower()
+
+
+def host_matches(url_or_host: str, allowed: str) -> bool:
+    """True if hostname equals allowed or is a subdomain (*.allowed)."""
+    host = hostname_of(url_or_host)
+    allowed = (allowed or "").lstrip(".").lower()
+    if not host or not allowed:
+        return False
+    return host == allowed or host.endswith("." + allowed)
+
+
+def cookie_domain_matches(domain: str, allowed: str) -> bool:
+    """True if a cookie domain belongs to allowed registrable host."""
+    host = (domain or "").lstrip(".").lower()
+    allowed = (allowed or "").lstrip(".").lower()
+    if not host or not allowed:
+        return False
+    return host == allowed or host.endswith("." + allowed)

--- a/tests/test_url_hosts.py
+++ b/tests/test_url_hosts.py
@@ -1,0 +1,33 @@
+"""Tests for CodeQL-safe hostname allowlist helpers."""
+
+from auth.url_hosts import cookie_domain_matches, host_matches
+
+
+def test_host_matches_battlenet_subdomain() -> None:
+    assert host_matches("https://account.battle.net/games", "battle.net") is True
+
+
+def test_host_matches_exact_account_host() -> None:
+    assert host_matches("https://account.battle.net/games", "account.battle.net") is True
+
+
+def test_host_matches_rejects_suffix_spoof() -> None:
+    assert host_matches("https://evilbattle.net/", "battle.net") is False
+    assert host_matches("https://notbattle.net/", "battle.net") is False
+
+
+def test_host_matches_epic_store() -> None:
+    assert host_matches("https://store.epicgames.com/wishlist", "store.epicgames.com") is True
+
+
+def test_host_matches_rejects_epic_host_spoof() -> None:
+    assert (
+        host_matches("https://evilstore.epicgames.com.attacker.tld/", "store.epicgames.com")
+        is False
+    )
+
+
+def test_cookie_domain_matches_battlenet() -> None:
+    assert cookie_domain_matches(".battle.net", "battle.net") is True
+    assert cookie_domain_matches("account.battle.net", "battle.net") is True
+    assert cookie_domain_matches("notbattle.net", "battle.net") is False


### PR DESCRIPTION
## Summary
- Replace substring/endswith Battle.net and Epic host checks with hostname allowlists (`auth/url_hosts.py`) to satisfy CodeQL.
- Clarify release gates: clean tree + green CI gate **tagging**, not merge; update CHANGELOG discipline + 0.8.46 Fixed notes.

## Test plan
- [x] `.\.venv\Scripts\python.exe -m pytest tests/test_url_hosts.py tests/test_battlenet_connect_loop.py -q` (29 passed)
- [ ] Spot-check Battle.net / Epic Connect URL detection after merge if desired

Made with [Cursor](https://cursor.com)