### PR TITLE
fix: auto-hide fab-listing-live library noise

### DIFF
--- a/js/library-noise.js
+++ b/js/library-noise.js
@@ -7,6 +7,7 @@ const TRADEMARK_RE = /[™®©]/g;
 
 export const NOISE_EXACT_TITLES = new Set([
   "live",
+  "fab listing live",
   "hbo max",
   "hbo go",
   "shadow costume for sonic",

--- a/shared/library_noise.py
+++ b/shared/library_noise.py
@@ -12,6 +12,7 @@ _TRADEMARK_RE = re.compile(r"[™®©]")
 NOISE_EXACT_TITLES = frozenset(
     {
         "live",
+        "fab listing live",
         "hbo max",
         "hbo go",
         "shadow costume for sonic",

--- a/tests/fixtures/library_noise.json
+++ b/tests/fixtures/library_noise.json
@@ -2,6 +2,7 @@
   { "title": "YouTube", "should_auto_hide": true },
   { "title": "Hulu", "should_auto_hide": true },
   { "title": "Freedom to buy games", "should_auto_hide": true },
+  { "title": "fab-listing-live", "should_auto_hide": true },
   { "title": "Hades", "should_auto_hide": false },
   { "title": "Wallpaper Engine", "should_auto_hide": false },
   { "title": "Sonic Digital Art Book", "should_auto_hide": true },


### PR DESCRIPTION
## Summary
- Add `fab-listing-live` / `fab listing live` as an exact-title library noise entry (JS + Python)
- Extend the library noise fixture so auto-hide coverage is asserted for this listing

## Test plan
- [ ] Confirm fixture case fab-listing-live` expects `should_auto_hide: true`
- [ ] Run library noise tests / fixture checks covering exact-title matching
- [ ] Spot-check that a title matching fab-listing-live is seeded into auto-hidden like other noise listings