### PR TITLE
fix: hide in-house Pro banners pending funnel refresh (0.8.47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [Unreleased]
 
+## [0.8.47] - 2026-08-01
+
+### Changed
+
+- Hide in-house Pro upgrade banners (dashboard/wishlist/library/itch stripes and spotlight house slides) behind `HOUSE_PRO_BANNERS_ENABLED` until the Pro funnel is ready for stranger beta. Paid placement paths are unchanged.
+
 ## [0.8.46] - 2026-08-01
 
 ### Fixed

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <!-- Must match pyproject.toml + package.json (see CHANGELOG release discipline). Read at runtime by js/error-boundary.js for bug-bundle metadata. -->
     <!-- Optional override for bug report endpoint during local testing: content="http://127.0.0.1:3000/api/report" -->
     <!-- <meta name="baklog-report-endpoint" content="https://baklog.app/api/report" /> -->
-    <meta name="baklog-version" content="0.8.46" />
+    <meta name="baklog-version" content="0.8.47" />
     <meta name="theme-color" content="#0f172a" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <script>

--- a/js/sponsored-deals.js
+++ b/js/sponsored-deals.js
@@ -55,6 +55,22 @@ const SPONSORS_FALLBACK_PATH = 'curated/sponsors.json';
 export const SPONSORS_HOSTED_URL = 'https://baklog.app/sponsors.json';
 const SPONSORS_REMOTE_TIMEOUT_MS = 3000;
 
+/** Set true when Pro funnel creatives are ready for stranger beta. */
+export const HOUSE_PRO_BANNERS_ENABLED = false;
+
+/** @type {boolean | null} null = use HOUSE_PRO_BANNERS_ENABLED */
+let _houseProBannersForceForTest = null;
+export function setHouseProBannersForTest(enabled) {
+  _houseProBannersForceForTest = enabled !== false;
+}
+export function __resetHouseProBannersForTest() {
+  _houseProBannersForceForTest = null;
+}
+function houseProBannersLive() {
+  if (_houseProBannersForceForTest != null) return _houseProBannersForceForTest;
+  return HOUSE_PRO_BANNERS_ENABLED;
+}
+
 export function getSponsorsEndpoint() {
   return (document.querySelector('meta[name="baklog-sponsors-endpoint"]')?.content)
     || window.__BAKLOG_SPONSORS_ENDPOINT
@@ -637,10 +653,14 @@ export function getAdsForLocation(locationKey, { count = 1 } = {}) {
   if (!AD_LOCATION_SET.has(key)) return [];
   const ids = state.adLocations?.[key] || [];
   const now = Date.now();
+  const houseLive = houseProBannersLive();
   const eligible = [];
   for (const id of ids) {
     const item = resolveAd(id);
-    if (item && isEligibleAd(item, now)) eligible.push(item);
+    if (!item || !isEligibleAd(item, now)) continue;
+    // Hide in-house Pro creatives when the funnel flag is off; paid sponsors stay.
+    if (!houseLive && String(item.kind || '').toLowerCase() === 'house') continue;
+    eligible.push(item);
   }
   if (!eligible.length) return [];
   const cap = LOCATION_CAPACITY[key] ?? count;
@@ -661,6 +681,7 @@ export function getAdsForLocation(locationKey, { count = 1 } = {}) {
  * @returns {object[]} feed-shaped ad items (empty for Pro users)
  */
 export function getSpotlightHouseAds() {
+  if (!houseProBannersLive()) return [];
   if (!spotlightHouseAdsLive()) return [];
   const out = [];
   for (const id of SPOTLIGHT_PRO_AD_IDS) {
@@ -993,6 +1014,7 @@ export function proPromoBannerHtml(item) {
 
 /** Markup for the dashboard house slot (dash-house — Pro upsell). */
 export function proPromoSlotHtml() {
+  if (!houseProBannersLive()) return '';
   if (isPro()) return '';
   const item = getAdsForLocation('dash-house')[0] || PRO_PROMO_ITEM;
   return proPromoBannerHtml(item);
@@ -1022,6 +1044,11 @@ export function houseStripeCardHtml(item, { variant = 'lib' } = {}) {
 export function renderHouseLocationSlot(locationKey, slotElId, { variant } = {}) {
   const el = document.getElementById(slotElId);
   if (!el) return;
+  if (!houseProBannersLive()) {
+    el.classList.add('hidden');
+    el.innerHTML = '';
+    return;
+  }
   const item = getAdsForLocation(locationKey)[0];
   if (!item) {
     el.classList.add('hidden');
@@ -1078,6 +1105,7 @@ export function sponsoredDealCardHtml(item) {
 
 /** Markup for the wishlist house banner (wish-house location), green accent. */
 export function sponsoredDealSlotHtml() {
+  if (!houseProBannersLive()) return '';
   const item = getAdsForLocation('wish-house')[0];
   if (!item) return '';
   return houseDealBannerHtml(item, { accent: 'green' });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog",
-  "version": "0.8.46",
+  "version": "0.8.47",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["auth*", "clients*", "fetchers*", "enrichers*", "shared*"]
 
 [project]
 name = "steam-backlog"
-version = "0.8.46"
+version = "0.8.47"
 description = "Local multi-store game library dashboard and fetchers"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/sponsored-deals.test.js
+++ b/tests/sponsored-deals.test.js
@@ -15,6 +15,9 @@ import {
   rotateLocationAd,
   getSpotlightHouseAds,
   setSpotlightHouseAdsForTest,
+  setHouseProBannersForTest,
+  __resetHouseProBannersForTest,
+  HOUSE_PRO_BANNERS_ENABLED,
   itemPlacements,
   sponsorCoverUrl,
   sponsorActionAttrs,
@@ -101,10 +104,13 @@ beforeEach(() => {
   __resetDismissedSponsorsForTest();
   __resetSpotlightHouseAdsForTest();
   __resetLocationCursorsForTest();
+  // Existing house-creative suites exercise the on path; flag-off coverage is separate.
+  setHouseProBannersForTest(true);
   __setSponsorsForTest({ version: 2, ads: {}, locations: {} });
 });
 
 afterEach(() => {
+  __resetHouseProBannersForTest();
   state.sponsoredDeals = [];
   state.sponsoredAds = {};
   state.adLocations = {};
@@ -583,6 +589,64 @@ describe('sponsorToSpotlightGame', () => {
       scheme: 'rainbow',
     });
     expect(unknown._spotlightAd.scheme).toBe('');
+  });
+});
+
+describe('HOUSE_PRO_BANNERS_ENABLED', () => {
+  beforeEach(() => {
+    setHouseProBannersForTest(false);
+  });
+
+  it('defaults to false for stranger beta', () => {
+    expect(HOUSE_PRO_BANNERS_ENABLED).toBe(false);
+  });
+
+  it('filters house creatives from locations but keeps paid placements', () => {
+    __setSponsorsForTest(v2Doc(
+      {
+        house: { id: 'house', kind: 'house', title: 'Pro stripe' },
+        paid: sponsor({ id: 'paid', kind: 'sponsor', title: 'Paid Deal' }),
+      },
+      { 'dash-house': ['house'], 'wish-deal-hero': ['paid'], 'lib-pick': ['paid'] },
+    ));
+    expect(getAdsForLocation('dash-house')).toEqual([]);
+    expect(getAdsForLocation('wish-deal-hero').map((x) => x.id)).toEqual(['paid']);
+    expect(getAdsForLocation('lib-pick').map((x) => x.id)).toEqual(['paid']);
+  });
+
+  it('returns no spotlight house slides', () => {
+    setSpotlightHouseAdsForTest(true);
+    expect(getSpotlightHouseAds()).toEqual([]);
+  });
+
+  it('returns empty markup for dash/wish house slots', () => {
+    wireWishHouse();
+    expect(sponsoredDealSlotHtml()).toBe('');
+    expect(proPromoSlotHtml()).toBe('');
+  });
+
+  it('hides renderHouseLocationSlot DOM when the funnel flag is off', () => {
+    document.body.innerHTML = '<div id="dashHouse">stale</div><div id="libHouse">stale</div>';
+    __setSponsorsForTest(v2Doc(
+      { pro: { kind: 'house', title: 'Pro slot', tagline: 'Upsell', cta: 'Go', url: 'https://baklog.app/' } },
+      { 'dash-house': ['pro'], 'lib-house': ['pro'] },
+    ));
+    renderHouseLocationSlot('dash-house', 'dashHouse');
+    renderHouseLocationSlot('lib-house', 'libHouse', { variant: 'lib' });
+    const dash = document.getElementById('dashHouse');
+    const lib = document.getElementById('libHouse');
+    expect(dash.classList.contains('hidden')).toBe(true);
+    expect(dash.innerHTML).toBe('');
+    expect(lib.classList.contains('hidden')).toBe(true);
+    expect(lib.innerHTML).toBe('');
+  });
+
+  it('restores house creatives when setHouseProBannersForTest(true)', () => {
+    setHouseProBannersForTest(true);
+    setSpotlightHouseAdsForTest(true);
+    wireWishHouse();
+    expect(sponsoredDealSlotHtml()).toContain('sponsored-deal-house');
+    expect(getSpotlightHouseAds().length).toBeGreaterThan(0);
   });
 });
 

--- a/tests/spotlight-sponsored.test.js
+++ b/tests/spotlight-sponsored.test.js
@@ -79,6 +79,8 @@ describe('spotlight sponsored slides', () => {
   let resetSpotlightRecentKeysForTest;
   let __setSponsorsForTest;
   let setSpotlightHouseAdsForTest;
+  let setHouseProBannersForTest;
+  let __resetHouseProBannersForTest;
   let state;
 
   beforeEach(async () => {
@@ -103,8 +105,14 @@ describe('spotlight sponsored slides', () => {
       setScoreJitterForTest,
       resetSpotlightRecentKeysForTest,
     } = await import('../js/dashboard-spotlight.js'));
-    ({ __setSponsorsForTest, setSpotlightHouseAdsForTest } = await import('../js/sponsored-deals.js'));
+    ({
+      __setSponsorsForTest,
+      setSpotlightHouseAdsForTest,
+      setHouseProBannersForTest,
+      __resetHouseProBannersForTest,
+    } = await import('../js/sponsored-deals.js'));
 
+    setHouseProBannersForTest(true);
     setSpotlightHouseAdsForTest(true);
     setSpotlightCurrentKey(null);
     setStinkerChanceForTest(0);
@@ -135,6 +143,7 @@ describe('spotlight sponsored slides', () => {
   });
 
   afterEach(() => {
+    __resetHouseProBannersForTest();
     localStorage.clear();
   });
 


### PR DESCRIPTION
## Summary
- Hide in-house Pro upgrade banners (dashboard/wishlist/library/itch stripes and spotlight house slides) behind `HOUSE_PRO_BANNERS_ENABLED=false` until the Pro funnel is ready for stranger beta.
- Paid placement paths remain unchanged; vitest coverage covers the flag off/on paths via `setHouseProBannersForTest`.
- Bump version to 0.8.47.

## Test plan
- [x] `npx vitest run tests/sponsored-deals.test.js tests/spotlight-sponsored.test.js`
- [ ] Spot-check dashboard/wishlist/library/itch: no in-house Pro stripes or spotlight house slides for free users
- [ ] Confirm paid placements (deal hero / pick slots) still resolve when configured