### PR TITLE
fix: opt house-creative suites into Pro banner test flag

### DIFF
--- a/tests/dashboard-picks-row.test.js
+++ b/tests/dashboard-picks-row.test.js
@@ -44,6 +44,9 @@ describe('dashboard picks row', () => {
     vi.resetModules();
     ({ state } = await import('../js/state.js'));
     ({ applyItchVisibility } = await import('../js/dashboard-cards.js'));
+    const { setHouseProBannersForTest } = await import('../js/sponsored-deals.js');
+    // Suite exercises house versus creatives; production flag stays off for stranger beta.
+    setHouseProBannersForTest(true);
     state.itchGames = [];
     state.prefs = { quickWinMaxHours: 15 };
     state.personal = {
@@ -52,7 +55,9 @@ describe('dashboard picks row', () => {
     };
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    const { __resetHouseProBannersForTest } = await import('../js/sponsored-deals.js');
+    __resetHouseProBannersForTest();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -156,7 +161,9 @@ describe('dashboard picks row', () => {
     const authGate = await import('../js/auth-gate.js');
     vi.spyOn(authGate, 'isPro').mockReturnValue(false);
     const { renderDashboardPicksVersus } = await import('../js/dashboard-cards.js');
-    const { __setSponsorsForTest } = await import('../js/sponsored-deals.js');
+    const { __setSponsorsForTest, setHouseProBannersForTest } = await import('../js/sponsored-deals.js');
+    // Versus suites still cover house creatives; production flag stays off until funnel refresh.
+    setHouseProBannersForTest(true);
     __setSponsorsForTest({
       version: 2,
       ads: {
@@ -216,14 +223,19 @@ describe('dashboard picks row', () => {
     const authGate = await import('../js/auth-gate.js');
     vi.spyOn(authGate, 'isPro').mockReturnValue(false);
     const { renderDashboardPicksVersus } = await import('../js/dashboard-cards.js');
-    const { dismissSponsoredDeal, __resetDismissedSponsorsForTest } = await import('../js/sponsored-deals.js');
+    const {
+      dismissSponsoredDeal,
+      __resetDismissedSponsorsForTest,
+      __setSponsorsForTest,
+      setHouseProBannersForTest,
+    } = await import('../js/sponsored-deals.js');
+    setHouseProBannersForTest(true);
     __resetDismissedSponsorsForTest();
     // itch present => maxPicks caps each column at 5 rows; ad displaces the last slot.
     state.itchGames = [{ store: 'itch', id: 'x', name: 'X' }];
     state.personal = Object.fromEntries(
       Array.from({ length: 7 }, (_, i) => [`steam:g${i}`, { status: 'backlog' }]),
     );
-    const { __setSponsorsForTest } = await import('../js/sponsored-deals.js');
     __setSponsorsForTest({
       version: 2,
       ads: {

--- a/tests/table-fingerprint.test.js
+++ b/tests/table-fingerprint.test.js
@@ -2,7 +2,7 @@
  * Tests for js/table-ui.js::tableFingerprint — cache invalidation inputs.
  */
 
-import { describe, expect, it, beforeEach } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { state } from '../js/state.js';
 import { loadSessionPrefs } from '../js/prefs.js';
 import { syncSponsoredTableAfterDismiss, tableFingerprint } from '../js/table-ui.js';
@@ -10,6 +10,8 @@ import {
   dismissSponsoredDeal,
   __resetDismissedSponsorsForTest,
   __setSponsorsForTest,
+  setHouseProBannersForTest,
+  __resetHouseProBannersForTest,
   sponsoredTableRowHtml,
 } from '../js/sponsored-deals.js';
 
@@ -97,7 +99,13 @@ describe('tableFingerprint', () => {
 describe('syncSponsoredTableAfterDismiss', () => {
   beforeEach(() => {
     __resetDismissedSponsorsForTest();
+    // House fallback creative coverage; production HOUSE_PRO_BANNERS_ENABLED stays false.
+    setHouseProBannersForTest(true);
     __setSponsorsForTest({ version: 2, ads: {}, locations: {} });
+  });
+
+  afterEach(() => {
+    __resetHouseProBannersForTest();
   });
 
   it('removes the sponsored table row when no creative remains', () => {


### PR DESCRIPTION
## Summary
- CI on main failed after #142 because vitest suites still expected house creatives while `HOUSE_PRO_BANNERS_ENABLED` defaults to false.
- Opt `dashboard-picks-row` and `syncSponsoredTableAfterDismiss` house-fallback coverage into `setHouseProBannersForTest(true)`, matching the pattern already used in sponsored-deals / spotlight suites.

## Test plan
- [x] `npx vitest run tests/dashboard-picks-row.test.js tests/table-fingerprint.test.js`
- [ ] CI JavaScript (vitest) green on this PR

Made with [Cursor](https://cursor.com)