### PR TITLE
fix: clear sticky Co-op tags pending after failed appdetails

### DIFF
--- a/enrichers/enrich_steam_tags.py
+++ b/enrichers/enrich_steam_tags.py
@@ -16,7 +16,11 @@ the row:
 
 The script never calls the Steam *search* endpoint — that's
 ``enrich_steam_reviews.py``'s job. If a row's appid hasn't been mapped yet, we
-skip it; running review enrichment first is the prerequisite.
+skip it; running review enrichment first is the prerequisite. When Steam
+``appdetails`` returns ``success: false`` (delisted / bad match / cached miss),
+we still write ``coop_online`` / ``coop_local`` as ``False`` so the dashboard
+chip does not keep counting the row as "new". Transient network errors leave
+the fields unset so a later run can retry.
 
 Covered stores: gog, epic, psn, amazon, xbox, battlenet, ubisoft, nintendo,
 itch (videogame classification only).
@@ -174,12 +178,15 @@ def main(argv: list[str] | None = None) -> int:
             try:
                 result = steam.get_app_details(int(appid), refresh=args.refresh)
             except Exception as e:  # noqa: BLE001 - log + continue
+                # Transient network/parse failure: leave coop fields unset so a
+                # later run can still count the row as pending.
                 stats.warn(f"appdetails error for {g.get('name')} ({appid}): {e}")
                 continue
-            if not result or not result.get("success"):
-                continue
-
-            enrichment = enrichment_from_appdetails(result.get("data"))
+            # Steam returns success:false for delisted / bad / region-blocked
+            # appids (and caches that result). Still write coop false/false so
+            # the Co-op tags chip stops counting the row as "N new" forever.
+            details = result.get("data") if result and result.get("success") else None
+            enrichment = enrichment_from_appdetails(details)
             before = {k: g.get(k) for k in ALWAYS_WRITE_FIELDS | FILL_IF_MISSING_FIELDS}
             apply_enrichment_to_row(g, enrichment)
             if _row_changed(before, g):

--- a/tests/test_enrich_steam_tags.py
+++ b/tests/test_enrich_steam_tags.py
@@ -149,6 +149,61 @@ def test_enricher_writes_coop_and_fills_missing_genres(
     assert "fetched_at" in meta
 
 
+def test_enricher_marks_failed_appdetails_as_checked(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """success:false must still write coop false/false so the chip clears."""
+    for mod in ("enrichers.enrich_steam_tags", "clients.steam_client"):
+        sys.modules.pop(mod, None)
+    import enrichers.enrich_steam_tags as enrich_steam_tags
+    from clients.steam_client import SteamClient
+
+    def fake_get_app_details(self, appid: int, refresh: bool = False) -> dict | None:
+        return {"success": False, "data": None}
+
+    monkeypatch.setattr(SteamClient, "get_app_details", fake_get_app_details)
+
+    exit_code = enrich_steam_tags.main([])
+    assert exit_code == 0
+
+    written = json.loads((workspace / "games_gog.json").read_text(encoding="utf-8"))
+    rows = {g["id"]: g for g in written["games"]}
+
+    g1 = rows["1"]
+    assert g1["coop_online"] is False
+    assert g1["coop_local"] is False
+    # Failed details must not invent genres / release date.
+    assert "genres" not in g1
+    assert "release_date" not in g1
+
+    # Unmapped / known-miss rows stay untouched.
+    assert "coop_online" not in rows["2"]
+    assert "coop_online" not in rows["3"]
+
+
+def test_enricher_leaves_pending_on_appdetails_exception(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Network errors must not clear the pending chip — retry later."""
+    for mod in ("enrichers.enrich_steam_tags", "clients.steam_client"):
+        sys.modules.pop(mod, None)
+    import enrichers.enrich_steam_tags as enrich_steam_tags
+    from clients.steam_client import SteamClient
+
+    def fake_get_app_details(self, appid: int, refresh: bool = False) -> dict | None:
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(SteamClient, "get_app_details", fake_get_app_details)
+
+    exit_code = enrich_steam_tags.main([])
+    assert exit_code == 0
+
+    written = json.loads((workspace / "games_gog.json").read_text(encoding="utf-8"))
+    rows = {g["id"]: g for g in written["games"]}
+    assert "coop_online" not in rows["1"]
+    assert "coop_local" not in rows["1"]
+
+
 def test_enricher_dry_run_does_not_write(
     workspace: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
﻿## Summary
- Co-op tags chip could stick at "1 new" because a Steam appdetails success:false (delisted / bad match / cached miss) skipped the row without writing coop_online / coop_local.
- Failed details now write both flags as false, which clears the pending count. Network exceptions still leave fields unset so a later run can retry.
- Regression tests cover both the failed-details and exception paths.

## Test plan
- [x] pytest tests/test_enrich_steam_tags.py (5 passed)
- [ ] After merge: click Co-op tags once on a library that previously stuck at 1 new and confirm the chip drops the pending count
