### PR TITLE
fix: stop publishing unlinkable epic_mobile claim rows

### DIFF
--- a/curated/free_claims.fallback.json
+++ b/curated/free_claims.fallback.json
@@ -119,8 +119,9 @@
     },
     {
       "id": "itad-56b70d2f45d3",
-      "store": "epic_mobile",
+      "store": "epic",
       "title": "Mutazione free on MOBILE from EGS on Epic Game Store",
+      "claim_url": "https://isthereanydeal.com/giveaways/16439/",
       "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/1080750/header.jpg?t=1781632988",
       "genres": [],
       "blurb": "Mutazione",

--- a/fetchers/build_free_claims.py
+++ b/fetchers/build_free_claims.py
@@ -306,13 +306,28 @@ _MOBILE_EPIC_HINT = re.compile(r"mobile", re.IGNORECASE)
 _EGS_EPIC_HINT = re.compile(r"\b(epic|egs)\b", re.IGNORECASE)
 
 
-def _infer_store_from_text(store: str, title: str, blurb: object, claim_url: str) -> str:
-    """GamerPower often tags itch.io/IndieGala giveaways as store='other'. Infer from text."""
+def _infer_store_from_text(
+    store: str,
+    title: str,
+    blurb: object,
+    claim_url: str,
+    claim_urls: object = None,
+) -> str:
+    """GamerPower often tags itch.io/IndieGala giveaways as store='other'. Infer from text.
+
+    Epic Mobile is only used when we actually have platform claim_urls. Title
+    text alone (ITAD "free on MOBILE from EGS") must not upgrade a clickable
+    epic+claim_url row into an unlinkable epic_mobile row with no claim_urls.
+    """
     haystack = " ".join(
         part for part in (title, str(blurb or ""), claim_url) if part
     )
     if _MOBILE_EPIC_HINT.search(haystack) and _EGS_EPIC_HINT.search(haystack):
-        return EPIC_MOBILE_STORE
+        if normalize_claim_urls(claim_urls):
+            return EPIC_MOBILE_STORE
+        if store and store != "other":
+            return store
+        return "epic"
     if store and store != "other":
         return store
     if _ITCH_HINT.search(haystack):
@@ -387,6 +402,7 @@ def _enrich_item(
         title,
         raw.get("blurb"),
         claim_url,
+        raw.get("claim_urls"),
     )
     appid = raw.get("steam_appid")
     if appid is not None:
@@ -1100,6 +1116,7 @@ def _enrich_item_light(
         title,
         raw.get("blurb"),
         claim_url,
+        raw.get("claim_urls"),
     )
     appid = raw.get("steam_appid")
     if appid is not None:

--- a/fetchers/fetch_free_claims.py
+++ b/fetchers/fetch_free_claims.py
@@ -61,17 +61,25 @@ def main() -> int:
     raw_items = data.get("items") or []
     valid_items: list[dict] = []
     invalid = 0
+    dropped_ids: list[str] = []
     for item in raw_items:
         if not isinstance(item, dict):
             invalid += 1
+            dropped_ids.append("<non-object>")
             continue
         if not item.get("id") or not item.get("store") or not has_valid_claim_links(item):
             invalid += 1
+            dropped_ids.append(str(item.get("id") or "<missing-id>"))
             continue
         valid_items.append(item)
     valid = len(valid_items)
     if invalid:
-        stats.warn(f"dropped {invalid} malformed claim row(s) (need id, store, and valid claim link(s))")
+        sample = ", ".join(dropped_ids[:5])
+        more = f" (+{invalid - 5} more)" if invalid > 5 else ""
+        stats.warn(
+            f"dropped {invalid} malformed claim row(s) "
+            f"(need id, store, and valid claim link(s)): {sample}{more}"
+        )
 
     # Refuse to overwrite the user's claims with nothing unless explicitly allowed.
     if valid == 0 and not args.allow_empty:

--- a/landing/free-claims.json
+++ b/landing/free-claims.json
@@ -119,8 +119,9 @@
     },
     {
       "id": "itad-56b70d2f45d3",
-      "store": "epic_mobile",
+      "store": "epic",
       "title": "Mutazione free on MOBILE from EGS on Epic Game Store",
+      "claim_url": "https://isthereanydeal.com/giveaways/16439/",
       "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/1080750/header.jpg?t=1781632988",
       "genres": [],
       "blurb": "Mutazione",

--- a/tests/test_build_free_claims_approved.py
+++ b/tests/test_build_free_claims_approved.py
@@ -887,7 +887,10 @@ def test_enrich_item_resolves_steam_cover_for_non_steam_row(
 
     out = bfc._enrich_item(raw, [0.0])
 
-    assert out["store"] == "epic_mobile"
+    # Title says mobile/EGS but there are no claim_urls - keep epic + claim_url.
+    assert out["store"] == "epic"
+    assert out["claim_url"] == "https://isthereanydeal.com/giveaways/16242/"
+    assert "claim_urls" not in out
     assert out["steam_appid"] == 1016800
     assert out["header_image"] == bfc._steam_portrait_cover(1016800)
     assert out["review_percent"] == 91

--- a/tests/test_free_claims_epic_mobile.py
+++ b/tests/test_free_claims_epic_mobile.py
@@ -72,8 +72,20 @@ def test_infer_store_from_text_mobile_epic():
         "TMNT free on Mobile from EGS on Epic Game Store",
         None,
         "https://isthereanydeal.com/giveaways/1/",
+        {"ios": "https://apps.apple.com/app/id1"},
     )
     assert store == "epic_mobile"
+
+
+def test_infer_store_from_text_mobile_epic_keeps_claim_url_without_platform_urls():
+    """ITAD mobile-from-EGS titles must not become unlinkable epic_mobile rows."""
+    store = _infer_store_from_text(
+        "epic",
+        "Mutazione free on MOBILE from EGS on Epic Game Store",
+        "Mutazione",
+        "https://isthereanydeal.com/giveaways/16439/",
+    )
+    assert store == "epic"
 
 
 def test_preview_publish_items_epic_mobile_manual(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
﻿## Summary
- Root cause: ITAD Mutazione ("free on MOBILE from EGS") was upgraded to `epic_mobile` on publish, which dropped the ITAD `claim_url` and left no `claim_urls`. Every client free-claims fetch then warned: dropped 1 malformed claim row.
- Fix: only promote to `epic_mobile` when platform `claim_urls` exist; otherwise keep `epic` + `claim_url`.
- Repaired Mutazione in `landing/free-claims.json` and `curated/free_claims.fallback.json` so baklog.app stops serving the bad row after Vercel redeploy.
- Fetch warning now names dropped claim ids.

## Test plan
- [x] pytest tests/test_free_claims_epic_mobile.py + related enrich/infer tests (16 passed)
- [ ] After Vercel deploy: `Invoke-WebRequest https://baklog.app/free-claims.json` and confirm Mutazione has store=epic and claim_url
- [ ] Click Free claims fetch and confirm the malformed-row warning is gone
