### PR TITLE
fix: stop all baklog servers before frozen release smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [Unreleased]
 
+### Fixed
+
+- Windows release build fully stops stray servers on port 8765 before frozen smoke (was `--dedupe`, which keeps a live listener and can fail the installer publish).
+
 ## [0.8.47] - 2026-08-02
 
 ### Changed

--- a/packaging/build_windows.ps1
+++ b/packaging/build_windows.ps1
@@ -81,8 +81,10 @@ Write-Host "  Auth env: BAKLOG_SUPABASE_URL=$(if ($urlSet) { 'set' } else { 'MIS
 & $Python (Join-Path $Root "scripts\write_bundle_auth_env.py") $OutDir
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-Write-Host "Deduping stray BAKLOG servers on port 8765..."
-& $Python scripts/stop_baklog.py --dedupe
+# Full stop (not --dedupe): frozen smoke needs 8765 free. --dedupe keeps any
+# live listener, which then fails frozen_bundle_smoke with port_collision.
+Write-Host "Stopping stray BAKLOG servers on port 8765..."
+& $Python scripts/stop_baklog.py
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 Write-Host "Smoke: frozen bundle (migration + /api/config + fetcher dispatch)..."

--- a/scripts/smoke_port_guard.py
+++ b/scripts/smoke_port_guard.py
@@ -85,5 +85,5 @@ def port_collision_message(
 ) -> str:
     return (
         f"port {host}:{port} already in use by pid {holder}; "
-        "run scripts/stop_baklog.py --dedupe"
+        "run scripts/stop_baklog.py"
     )

--- a/tests/test_run_manager.py
+++ b/tests/test_run_manager.py
@@ -1033,8 +1033,25 @@ def test_internal_lane_parallel_to_fetcher(runs_env, internal_jobs) -> None:
     assert snap["queue"] == []
 
 
-def test_fetcher_lane_parallel_to_internal(runs_env, internal_jobs) -> None:
+def test_fetcher_lane_parallel_to_internal(
+    runs_env, internal_jobs, monkeypatch: pytest.MonkeyPatch
+) -> None:
     mgr, runs_dir = runs_env
+    # Keep the fetcher alive long enough for the worker to admit it; print('ok')
+    # alone races past _active on fast CI hosts.
+    monkeypatch.setitem(
+        server.FETCHERS,
+        "demo",
+        {
+            "label": "Demo",
+            "argv": [server.sys.executable, "-c", "import time; time.sleep(30)"],
+            "refreshArgs": [],
+            "metaKey": "demo",
+            "group": "library",
+            "color": "#fff",
+            "requires": [],
+        },
+    )
     internal = server.Run(
         "buildClaims",
         runs_dir=runs_dir,
@@ -1049,9 +1066,18 @@ def test_fetcher_lane_parallel_to_internal(runs_env, internal_jobs) -> None:
     fetcher = mgr.submit("demo")
 
     assert not fetcher._internal
+    deadline = time.time() + 5
     snap = mgr.snapshot()
+    while time.time() < deadline:
+        snap = mgr.snapshot()
+        if snap.get("active") and snap["active"]["id"] == fetcher.id:
+            break
+        time.sleep(0.02)
+    else:
+        pytest.fail(f"fetcher never became active: {snap}")
     assert snap["internal_active"]["key"] == "buildClaims"
     assert snap["active"]["key"] == "demo"
+    mgr.cancel(fetcher.id)
 
 
 def test_enrich_lane_parallel_to_fetcher(runs_env) -> None:


### PR DESCRIPTION
## Summary
- `packaging/build_windows.ps1` called `stop_baklog.py --dedupe` before frozen smoke. `--dedupe` keeps the live listener on 8765, so smoke can fail with `port_collision` (seen on the first `v0.8.47` release run).
- Switch to a full stop, and point `port_collision_message` at the same command.

## Test plan
- [ ] CI green
- [ ] If `v0.8.47` release rerun still fails on port collision, merge this then `.\scripts\replace_release_tag.ps1 -Version 0.8.47 -Force`