### PR TITLE
fix: theme update install/restart modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 ### Fixed
 
 - Windows release build fully stops stray servers on port 8765 before frozen smoke (was `--dedupe`, which keeps a live listener and can fail the installer publish).
+- In-app update modals (Install and restart / Update available) follow the active theme tokens instead of fixed slate/sky defaults; extend sky utility remaps (`bg-sky-500/700`, hover variants) to `--accent`.
 
 ## [0.8.47] - 2026-08-02
 

--- a/app.css
+++ b/app.css
@@ -4384,8 +4384,16 @@ html[data-theme="ember"] .brand-logo-pills {
 .hover\:text-sky-300:hover {
   color: var(--accent-muted);
 }
-.bg-sky-600 {
+.bg-sky-500,
+.bg-sky-600,
+.bg-sky-700 {
   background: var(--accent-dim);
+  color: var(--text-bright);
+}
+.hover\:bg-sky-500:hover,
+.hover\:bg-sky-600:hover,
+.hover\:bg-sky-700:hover {
+  background: var(--accent);
 }
 /* === Dashboard === */
 .dash-card {
@@ -9159,28 +9167,63 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
   color: var(--accent-muted);
 }
 
-/* Standalone dialog panels (secrets bundle) reuse the same token mapping. */
-.app-modal-panel.bg-slate-800 {
+/* Standalone dialog panels (secrets bundle, update install) reuse the same
+   token mapping when they are not nested under .app-modal. */
+.app-modal-panel.bg-slate-800,
+.update-modal-panel.bg-slate-800 {
   background: var(--bg-panel);
   color: var(--text-bright);
 }
-.app-modal-panel .bg-slate-700 {
+.app-modal-panel .bg-slate-700,
+.update-modal-panel .bg-slate-700 {
   background: var(--bg-elev);
 }
-.app-modal-panel .hover\:bg-slate-600:hover {
+.app-modal-panel .bg-slate-900\/80,
+.update-modal-panel .bg-slate-900\/80 {
+  background: color-mix(in srgb, var(--bg) 80%, transparent);
+}
+.app-modal-panel .hover\:bg-slate-600:hover,
+.app-modal-panel .hover\:bg-slate-700:hover,
+.update-modal-panel .hover\:bg-slate-600:hover,
+.update-modal-panel .hover\:bg-slate-700:hover {
   background: var(--bg-hover);
 }
-.app-modal-panel .border-slate-600 {
+.app-modal-panel .border-slate-600,
+.app-modal-panel .border-slate-700,
+.update-modal-panel .border-slate-600,
+.update-modal-panel .border-slate-700 {
   border-color: var(--border);
 }
-.app-modal-panel .text-slate-100 {
+.app-modal-panel .text-slate-100,
+.update-modal-panel .text-slate-100 {
   color: var(--text-bright);
 }
-.app-modal-panel .text-slate-300 {
+.app-modal-panel .text-slate-300,
+.update-modal-panel .text-slate-300 {
   color: var(--text-dim);
 }
-.app-modal-panel .text-slate-400 {
+.app-modal-panel .text-slate-400,
+.app-modal-panel .text-slate-500,
+.update-modal-panel .text-slate-400,
+.update-modal-panel .text-slate-500 {
   color: var(--text-mute);
+}
+.app-modal-panel .bg-cyan-700,
+.app-modal-panel .bg-cyan-800,
+.app-modal-panel .bg-sky-700,
+.update-modal-panel .bg-cyan-700,
+.update-modal-panel .bg-cyan-800,
+.update-modal-panel .bg-sky-700 {
+  background: var(--accent-dim);
+  color: var(--text-bright);
+}
+.app-modal-panel .hover\:bg-cyan-600:hover,
+.app-modal-panel .hover\:bg-cyan-700:hover,
+.app-modal-panel .hover\:bg-sky-600:hover,
+.update-modal-panel .hover\:bg-cyan-600:hover,
+.update-modal-panel .hover\:bg-cyan-700:hover,
+.update-modal-panel .hover\:bg-sky-600:hover {
+  background: var(--accent);
 }
 
 /* Column picker: width cap without relying on purged max-w-md utility. */

--- a/js/update-check.js
+++ b/js/update-check.js
@@ -338,17 +338,17 @@ export function renderUpdateModalHtml(parsed) {
     : '<p class="text-sm text-slate-400 mt-3">See the release page for details.</p>';
   const canUpdateNow = parsed.applySupported && !updateMutationsBlocked(parsed);
   const updateBtn = canUpdateNow
-    ? '<button type="button" class="update-modal-apply bg-sky-700 hover:bg-sky-600 px-3 py-2 rounded text-sm">Update now</button>'
+    ? '<button type="button" class="update-modal-apply bg-cyan-700 hover:bg-cyan-600 px-3 py-2 rounded text-sm text-white">Update now</button>'
     : "";
   return (
-    `<div class="update-modal-panel bg-slate-800 border border-slate-600 rounded-lg shadow-xl max-w-lg w-full mx-4 p-6" role="dialog" aria-modal="true" aria-labelledby="updateModalTitle">` +
+    `<div class="update-modal-panel app-modal-panel bg-slate-800 border border-slate-600 rounded-lg shadow-xl max-w-lg w-full mx-4 p-6" role="dialog" aria-modal="true" aria-labelledby="updateModalTitle">` +
     `<h2 id="updateModalTitle" class="text-lg font-semibold text-slate-100">Update available: v${escapeHtml(parsed.latest || "")}</h2>` +
     `<p class="text-sm text-slate-400 mt-1">You have v${escapeHtml(parsed.current)}.</p>` +
     renderApplyBlockedHint(parsed) +
     notes +
     `<div class="flex flex-wrap gap-2 justify-end mt-4">` +
     `<a href="${escapeHtml(href)}" class="update-modal-release text-sm text-sky-300 hover:underline px-3 py-2" target="_blank" rel="noopener noreferrer">Release page</a>` +
-    '<button type="button" class="update-modal-later text-sm px-3 py-2 rounded hover:bg-slate-700">Remind me later</button>' +
+    '<button type="button" class="update-modal-later text-sm px-3 py-2 rounded hover:bg-slate-700 text-slate-300">Remind me later</button>' +
     updateBtn +
     "</div></div>"
   );
@@ -356,13 +356,13 @@ export function renderUpdateModalHtml(parsed) {
 
 function renderInstallConfirmModalHtml(hints = _installHints) {
   return (
-    `<div class="update-modal-panel bg-slate-800 border border-slate-600 rounded-lg shadow-xl max-w-md w-full mx-4 p-6" role="dialog" aria-modal="true" aria-labelledby="updateInstallTitle">` +
+    `<div class="update-modal-panel app-modal-panel bg-slate-800 border border-slate-600 rounded-lg shadow-xl max-w-md w-full mx-4 p-6" role="dialog" aria-modal="true" aria-labelledby="updateInstallTitle">` +
     '<h2 id="updateInstallTitle" class="text-lg font-semibold text-slate-100">Install and restart?</h2>' +
     '<p class="text-sm text-slate-400 mt-2">The update is downloaded and verified. BAKLOG will restart to finish installing. Your library data stays where it is.</p>' +
     renderSetupArpFootnote(hints) +
     '<div class="flex flex-wrap gap-2 justify-end mt-4">' +
-    '<button type="button" class="update-install-decline text-sm px-3 py-2 rounded hover:bg-slate-700">Not yet</button>' +
-    '<button type="button" class="update-install-confirm bg-sky-700 hover:bg-sky-600 px-3 py-2 rounded text-sm">Install &amp; restart</button>' +
+    '<button type="button" class="update-install-decline text-sm px-3 py-2 rounded hover:bg-slate-700 text-slate-300">Not yet</button>' +
+    '<button type="button" class="update-install-confirm bg-cyan-700 hover:bg-cyan-600 px-3 py-2 rounded text-sm text-white">Install &amp; restart</button>' +
     "</div></div>"
   );
 }
@@ -457,10 +457,12 @@ export function showUpdateModal(parsed, handlers = {}) {
     modal = document.createElement("div");
     modal.id = UPDATE_MODAL_ID;
     modal.className =
-      "fixed inset-0 z-50 hidden flex items-center justify-center bg-black/60";
+      "app-modal fixed inset-0 z-50 hidden flex items-center justify-center bg-black/60";
     modal.tabIndex = -1;
     document.body.appendChild(modal);
   }
+  modal.className =
+    "app-modal fixed inset-0 z-50 flex items-center justify-center bg-black/60";
   modal.replaceChildren();
   modal.insertAdjacentHTML("beforeend", renderUpdateModalHtml(parsed));
   modal.classList.remove("hidden");
@@ -495,10 +497,12 @@ export function confirmInstallUpdate() {
       modal = document.createElement("div");
       modal.id = UPDATE_INSTALL_MODAL_ID;
       modal.className =
-        "fixed inset-0 z-[60] hidden flex items-center justify-center bg-black/60";
+        "app-modal fixed inset-0 z-[60] hidden flex items-center justify-center bg-black/60";
       modal.tabIndex = -1;
       document.body.appendChild(modal);
     }
+    modal.className =
+      "app-modal fixed inset-0 z-[60] flex items-center justify-center bg-black/60";
     modal.replaceChildren();
     modal.insertAdjacentHTML("beforeend", renderInstallConfirmModalHtml());
     modal.classList.remove("hidden");

--- a/tests/update-check.test.js
+++ b/tests/update-check.test.js
@@ -578,6 +578,18 @@ describe('renderUpdateModalHtml', () => {
     expect(html).toContain('Remind me later');
   });
 
+  it('uses themed app-modal-panel classes (not fixed sky-700)', () => {
+    const html = renderUpdateModalHtml({
+      current: '0.8.25',
+      latest: '0.8.26',
+      url: 'https://example.com',
+      applySupported: true,
+    });
+    expect(html).toContain('app-modal-panel');
+    expect(html).toContain('bg-cyan-700');
+    expect(html).not.toContain('bg-sky-700');
+  });
+
   it('hides Update now when fetchers are in flight', () => {
     const html = renderUpdateModalHtml({
       current: '0.8.25',


### PR DESCRIPTION
## Summary
- Update Install and restart / Update available overlays now use `app-modal` + `app-modal-panel`, so slate surfaces map to `--bg-panel` / `--text-*` like other dialogs.
- Primary actions use cyan utilities already remapped under `.app-modal` to `--accent-dim` / `--accent` (matches Columns/Add game modals).
- Close a gap in global sky remaps: `bg-sky-500/700` and hover variants now follow `--accent` (claim CTAs already used `bg-sky-600`).
- Amber attention text in banners left intentional (warning tone, not brand accent).

## Test plan
- [ ] Vitest `tests/update-check.test.js`
- [ ] With ember/orange (or any non-default) theme: trigger Install and restart and confirm panel + primary button match theme
- [ ] Confirm other app-modals still look correct
- [ ] No release tag