### PR TITLE
fix: app phone/tablet usable through R5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ review-handoff.md
 review-report.json
 scripts/_diag_personal.py
 scripts/perf-last-run.json
+scripts/responsive-overflow-last-run.json
 
 .vercel
 .env*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,41 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Fixed
 
+- R5 responsive closeout: type tokens for ribbon/insight/score digits; tablet insight wrap; reduced-motion for error toast + pick/coop hover lifts; year-chart Chart.js duration gated; short-landscape chart/ribbon height trim; leftover app.css media (`640`/`760`/`767`/`768`/`520`/`420`) onto `1023.98`/`639.98`/`400`; fetcher `LOG_DESKTOP_MQ` `768`→`1024`.
+- Responsive final UX audit: A–Z hit slop ≤1023.98; update/install `app-modal` sheets; sheet-mode MQ for phone landscape (`max-height: 480px` + `hover: none`) on modals/fetcher; auth gate bottom sheet + toast safe-area; `#picksGrid` holds 4 cols through tablet (6 at 1024); coop-versus 3-panel at 1024; scoreboards 1-col in sheet mode; Connections sticky Steam wrap + scrollIntoView; Pro compare `min-width` 22rem on phone; `test:responsive` adds 844×390 + Columns/Filters overlay smoke.
+- p45 viewport leftovers: phone modals/dialogs/popovers as bottom sheets (safe-area + touch close); Connections sticky selected rail chip + pane body scroll + `conn-hint-row` on 1023.98 ladder; dash chart/ribbon heights on tablet/phone; retire leftover 900px library-count-host rule. Opt-in `npm run test:responsive` (`scripts/responsive-overflow-audit.mjs`) asserts no page overflow at 1024/768/390/360 × five views.
+- Phone/tablet UX audit: dashboard picks stack at ≤1023.98 even with sponsored slot (`:has` 4-col override); wishlist/dash deal radar 1-col below 1024 (scoreboards no longer crush); filter pills + bulk bar horizontal scroll with 10px scrollbar pad; `#tableShell` A-Z gutter; phone sticky safe-area + back-to-top pin via bar bottom; Pro compare `overflow-x`; filter drawer safe-area + close touch; row-loading overlay centered above sticky; house banner breakpoints on 1023.98 / 639.98 ladder.
+- Picks grid stays at least 2 columns on phone (`#picksGrid` CSS; committed Tailwind lacked `.grid-cols-2`, so the class alone collapsed to 1 col). Wider breakpoints still 4 / 6 / 8.
+- Phone `#summary` chips hug content (not fixed equal width) with padded edges; the chip row scrolls inside `#summary` (`max-width: 100%`) so pills never widen the page.
+- Phone LIBRARY sticky: compact rail back-to-top (no 44px touch inflate); header `#backToTopPhone` in the sticky strip (stand-in for thead `#backToTopCover`, which is hidden in card mode) shows while the table is pinned.
+- Phone LIBRARY sticky bar: square top (no corner radius), opaque panel background, light bottom shadow so card chrome cannot peek through; A-Z rail / back-to-top raised and given a solid touch target so the arrow stays reachable.
+- Phone library cards: keep store badges at fixed 16px (phone hug rule no longer sets `width: auto` on them, which collapsed Steam glyphs into a blank indent before coop pills); slightly stronger Steam badge outline on the default theme.
+- Phone library cards: hide low-confidence `HLTB match:` hint to keep the three-line card compact (still available above phone / via HLTB override).
+- Phone library cards: EA / hidden-gem sit immediately after the title (left, vertically centered on the title row) instead of trailing on the right.
+- Phone library toolbar: Columns (|||) and kebab sit at the front of the Filters / Add game row (not above search); both icon buttons stay identical square size including touch targets.
+- Phone library cards: keep three content lines (title + EA/gem beside title, meta chips, status under meta) - outer name flex stays row so badges are not a fourth line.
+- Phone library cards: Status select stacks under the title/meta row (left-aligned in the content column) instead of floating end-aligned on the right.
+- Phone library cards: coop/EA pills no longer stretch full width (scoped `.table-phone` name-cell flex to the direct child; meta chips wrap and hug; status select stays auto-width).
+- Library Game column: revert fixed 14rem / max-width Game + sticky left cluster (they truncated titles and left empty mid-table gaps at full width); Game is fluid again (`width: 100%`); mid-width density + crush detection kept, with `min-width: 11.5rem` only under `#tableWrap.table-density`.
+- Library mid-width table: denser auto-hide (through Steam/Played/HLTB if needed) when the Game title would crush.
+- Library mid-width table: auto density hides Notes/Genres (then Last played/Released, then Price) so sticky thead survives (no `#tableWrap overflow-x:auto`); A–Z rail stays available below 1280px; phone sticky chrome bar; drill-to-row uses rect scroll on `table-phone` so spotlight/picks land correctly; notes mini-dialog when Notes column is hidden.
+- Dashboard hero store strip snaps wrapped rows to balanced columns (e.g. 12 logos → 6+6, not 11+1).
+- Dashboard stacked spotlight parks portrait/low-res covers about two-thirds across (right of center); `applySpotlightArtFit` stamps the offset so inline `object-position` no longer keeps them centered.
+- Dashboard stacked spotlight caption hugs its text (`width: fit-content`) instead of stretching edge-to-edge.
+- Dashboard mega-hero phone polish: stacked spotlight bleeds to the card top/sides so left/right corners match; phone pillars prefer a centered 2-over-1 row and wrap to a centered stack when too wide; insight pill hugs its text (`fit-content`, not full-bleed `display:block`).
+- Dashboard mega-hero tagline on phone stacks one stat per line and hides the · separators.
+- Header sheet: fetcher status circle is slightly smaller than the hamburger (1.75rem) and vertically centered (no upward translate).
+- Dashboard picks on tablet/phone: Recently added (and versus) hug content height instead of keeping a desktop equal-row empty tail under a short list.
+- Dashboard mega-hero on tablet/phone: spotlight art is contained to a stacked band (relative wrap + clip) so pillars/insight no longer cover the caption; pillars hug content width instead of full-bleed `1fr` cells; hero breakpoints migrate to the 1023.98 / 639.98 / 1024 ladder.
+- Header sheet chrome: fetcher control sits left of the hamburger, sheet-mode fetcher pill matches icon-button size, and the beta pill keeps its full border (no upward translate under brand `overflow: hidden`).
+- Phone/tablet usability: header brand/actions density, phone fullscreen fetcher sheet (reuse `#fetcherPopover`), connections stack on the tablet ladder (retire ad-hoc 720px), and dashboard strip containment so views stay usable without page-level horizontal scroll.
 - Windows release build fully stops stray servers on port 8765 before frozen smoke (was `--dedupe`, which keeps a live listener and can fail the installer publish).
 
+### Changed
+
+- Permanent Discord invite is `https://discord.gg/VFvxN5nCCB` (`shared/community.json`); linked from app kebab + footer socials, landing footer icons + Community column, README, and guide/getting-help.
+- Fetcher health on phone opens as a fullscreen overlay sheet with sticky titled head; tablet keeps the anchored popover (dvh-capped).
+- Main view tabs collapse to a hamburger sheet at tablet and below (replaces the phone horizontal scroll strip), and also when the inline header would wrap; sheet mode hides fullscreen and moves Report bug + profile into the overlay.
 ## [0.8.47] - 2026-08-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **BAKLOG pulls every game you own into one local, honest table.** Free forever to import · **twelve libraries and eight wishlists** · runs on your machine, no telemetry by default. Connect your stores once — Steam, GOG, PlayStation, Epic, Amazon, Xbox, Battle.net, Ubisoft Connect, Nintendo Switch, itch.io, Humble Bundle, and EA App — then decide what to play next and whether that "deal" is actually worth opening. Your credentials and library JSON stay on your machine (see [PRIVACY.md](PRIVACY.md) for the few optional network calls).
 
-**Open source (MIT)** — [read the code on GitHub](https://github.com/Ogrods/BAKLOG) and verify the privacy story yourself. **Free forever to import · Invite-only early access.** Request access at **[baklog.app](https://baklog.app)**.
+**Open source (MIT)** - [read the code on GitHub](https://github.com/Ogrods/BAKLOG) and verify the privacy story yourself. **Free forever to import · Invite-only early access.** Request access at **[baklog.app](https://baklog.app)**. Community chat: **[Discord](https://discord.gg/VFvxN5nCCB)** (canonical invite in [`shared/community.json`](shared/community.json)).
 
 **Reviewing the repo?** See [ARCHITECTURE.md](ARCHITECTURE.md) for an honest map (local vs network, monolith shape, Pro licensing, store ToS).
 
@@ -241,7 +241,7 @@ Then open http://localhost:8765 in your browser. Click any chip in the **Fetcher
 
 ### Reporting a bug, support, and personal data
 
-Bug reports, Discord, GitHub issues, email, and how personal edits are stored: **[guide/getting-help.md](guide/getting-help.md)** and **[guide/using-the-dashboard.md](guide/using-the-dashboard.md)**.
+Bug reports, Discord ([invite](https://discord.gg/VFvxN5nCCB)), GitHub issues, email, and how personal edits are stored: **[guide/getting-help.md](guide/getting-help.md)** and **[guide/using-the-dashboard.md](guide/using-the-dashboard.md)**.
 
 ## Auto-refresh on a schedule
 

--- a/app.css
+++ b/app.css
@@ -11,6 +11,24 @@
    (--touch-min in phone block below).
    ========================================================================== */
 
+/* R5 type tokens — tablet/phone only; desktop keeps literal sizes below. */
+@media (max-width: 1023.98px) {
+  :root {
+    --type-ribbon: 0.78rem;
+    --type-insight: 0.8rem;
+    --type-score-lg: 1.45rem;
+    --type-score-coop: 1.05rem;
+  }
+}
+@media (max-width: 639.98px), (max-height: 480px) and (hover: none) {
+  :root {
+    --type-ribbon: 0.75rem;
+    --type-insight: 0.78rem;
+    --type-score-lg: 1.35rem;
+    --type-score-coop: 1rem;
+  }
+}
+
 /* === Global error toast ===
    Surfaces uncaught errors + unhandled promise rejections. Top-right so it
    never collides with the bottom-right undoToast / debug overlay. Sticky
@@ -18,8 +36,8 @@
    actively dismiss or fix them. */
 .baklog-error-toast {
   position: fixed;
-  top: 16px;
-  right: 16px;
+  top: max(16px, env(safe-area-inset-top, 0px));
+  right: max(16px, env(safe-area-inset-right, 0px));
   z-index: 10000;
   width: min(420px, calc(100vw - 32px));
   background: rgba(15, 23, 42, 0.97);
@@ -31,6 +49,23 @@
   font-size: 13px;
   line-height: 1.45;
   animation: baklogErrorIn 180ms ease-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .baklog-error-toast {
+    animation: none;
+  }
+}
+@media (max-width: 639.98px), (max-height: 480px) and (hover: none) {
+  .baklog-error-toast {
+    left: max(12px, env(safe-area-inset-left, 0px));
+    right: max(12px, env(safe-area-inset-right, 0px));
+    width: auto;
+    max-width: none;
+  }
+  .baklog-error-toast-dismiss,
+  .baklog-error-toast-btn {
+    min-height: var(--touch-min, 44px);
+  }
 }
 @keyframes baklogErrorIn {
   from {
@@ -601,6 +636,39 @@ html[data-theme] body {
   background: var(--bg);
   padding: 1.5rem;
 }
+@media (max-width: 639.98px), (max-height: 480px) and (hover: none) {
+  #authGateOverlay:not([hidden]) {
+    align-items: flex-end;
+    justify-content: stretch;
+    padding: 0;
+  }
+  #authGateOverlay .auth-gate-card {
+    max-width: none;
+    width: 100%;
+    margin: 0;
+    border-radius: 0.75rem 0.75rem 0 0;
+    border-left: none;
+    border-right: none;
+    border-bottom: none;
+    max-height: min(92dvh, calc(100dvh - env(safe-area-inset-top, 0px)));
+    overflow-y: auto;
+    padding: 1.25rem 1.25rem max(1.25rem, env(safe-area-inset-bottom, 0px));
+    box-sizing: border-box;
+  }
+  #authGateOverlay .auth-gate-input,
+  #authGateOverlay .auth-gate-submit,
+  #authGateOverlay .auth-gate-link {
+    min-height: var(--touch-min, 44px);
+  }
+  #authGateOverlay .auth-gate-input {
+    box-sizing: border-box;
+  }
+  #authGateOverlay .auth-gate-submit {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
 /* While the sign-in gate is up, suppress the boot curtain entirely so its
    spinner/tips don't bleed or flicker behind the (now opaque) auth card. */
 html[data-auth-required] #bootLoadingOverlay {
@@ -763,7 +831,7 @@ html[data-boot-loading] #bootLoadingOverlay {
 .boot-loading-tip.is-fading {
   opacity: 0;
 }
-@media (max-width: 640px) {
+@media (max-width: 639.98px) {
   .boot-loading-tip {
     max-width: 42ch;
     text-wrap: balance;
@@ -1075,12 +1143,38 @@ button[disabled] {
     background 0.1s ease;
   background: var(--accent-subtle);
 }
+/* Tailwind's committed build has .grid-cols-3 but not .grid-cols-2 - without
+   an explicit template the grid collapses to 1 col. Always keep >=2.
+   Ladder: 2 → 4 through tablet → 6 at desktop → 8 at xl (not 6 at 768). */
+#picksGrid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+@media (min-width: 640px) {
+  #picksGrid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+@media (min-width: 1024px) {
+  #picksGrid {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+}
+@media (min-width: 1280px) {
+  #picksGrid {
+    grid-template-columns: repeat(8, minmax(0, 1fr));
+  }
+}
 .pick-card:hover {
   transform: translateY(-2px);
   background: color-mix(in srgb, var(--accent) 24%, transparent);
 }
 .picks-grid--custom-reorder .pick-card:hover {
   transform: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  .pick-card:hover {
+    transform: none;
+  }
 }
 .pick-card-drag-handle {
   position: absolute;
@@ -1904,7 +1998,7 @@ input[type="range"] {
    slate background - outline it like Epic so the glyph stays legible. Scoped to
    the default theme only; other themes have enough contrast. */
 html[data-theme="default"] .store-badge.steam {
-  box-shadow: inset 0 0 0 1px #64748b;
+  box-shadow: inset 0 0 0 1px #94a3b8;
 }
 .store-badge.gog {
   background: var(--brand-gog);
@@ -2152,12 +2246,18 @@ html[data-theme="default"] .store-badge.steam {
   transform: translate(-1px, 0);
 }
 
-/* Store badge strip layout — js/store-logos.js */
+/* Store badge strip layout — js/store-logos.js (balanced wrap via
+   .is-balanced-wrap + --store-strip-cols when a lonely last row would appear). */
 .store-logo-strip {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 6px;
+}
+.store-logo-strip.is-balanced-wrap {
+  display: grid;
+  grid-template-columns: repeat(var(--store-strip-cols), max-content);
+  justify-content: start;
 }
 .store-logo-strip [role="listitem"] {
   display: inline-flex;
@@ -2976,7 +3076,7 @@ html[data-theme="default"] .store-badge.steam {
   white-space: nowrap;
   padding: 0.3rem 0.7rem;
 }
-@media (max-width: 768px) {
+@media (max-width: 639.98px) {
   .claim-rows-header {
     display: none;
   }
@@ -3776,19 +3876,14 @@ html[data-page-hidden] .dash-spotlight-hero-zoom img {
 html[data-boot-loading] .view-tab {
   visibility: hidden;
 }
-/* === A–Z jump nav === */
+/* === A–Z jump nav (visible on all library widths; compact below desktop) === */
 #alphaNavWrap {
   position: fixed;
   right: 4px;
   top: 50%;
   transform: translateY(-50%);
   z-index: 35;
-  display: none;
-}
-@media (min-width: 1280px) {
-  #alphaNavWrap {
-    display: block;
-  }
+  display: block;
 }
 #alphaNav {
   position: relative;
@@ -3822,12 +3917,67 @@ html[data-boot-loading] .view-tab {
 .alpha-nav-btn.enabled:hover {
   color: var(--accent);
 }
+@media (max-width: 1279.98px) {
+  #alphaNav {
+    max-height: calc(100vh - 100px);
+    padding: 3px 1px;
+    gap: 0;
+  }
+  .alpha-nav-btn {
+    font-size: 9px;
+    line-height: 1.05;
+    padding: 1px 3px;
+    min-width: 14px;
+  }
+}
+/* Expand A–Z hit targets without growing glyph size (tablet + phone). */
+@media (max-width: 1023.98px) {
+  .alpha-nav-btn.enabled {
+    position: relative;
+    z-index: 0;
+  }
+  .alpha-nav-btn.enabled::before {
+    content: "";
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: max(100%, 28px);
+    height: max(100%, 22px);
+    z-index: -1;
+  }
+}
+@media (max-width: 639.98px), (max-height: 480px) and (hover: none) {
+  .alpha-nav-btn.enabled::before {
+    width: max(100%, 36px);
+    height: max(100%, 28px);
+  }
+}
+@media (max-width: 639.98px) {
+  #alphaNavWrap {
+    right: 2px;
+    top: auto;
+    /* Clear bulk bar / home indicator and leave room for #backToTop above the rail */
+    bottom: max(88px, calc(env(safe-area-inset-bottom, 0px) + 72px));
+    transform: none;
+    z-index: 40;
+  }
+  #alphaNav {
+    max-height: min(48vh, 320px);
+  }
+  #backToTop {
+    /* Keep compact (match desktop rail control) - solid so it reads on cards */
+    background: var(--bg-panel);
+    bottom: calc(100% + 6px);
+  }
+}
 /* === Back to top ===
    Two variants share one look: #backToTop sits above the A–Z rail (shows past
    400px scroll); #backToTopCover lives in the cover-art column of the sticky
    table header and only shows while that header is pinned. */
 #backToTop,
-#backToTopCover {
+#backToTopCover,
+#backToTopPhone {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -3854,24 +4004,28 @@ html[data-boot-loading] .view-tab {
   width: 100%;
 }
 #backToTop.show,
-#backToTopCover.show {
+#backToTopCover.show,
+#backToTopPhone.show {
   opacity: 0.85;
   pointer-events: auto;
 }
 #backToTop:hover,
-#backToTopCover:hover {
+#backToTopCover:hover,
+#backToTopPhone:hover {
   opacity: 1;
   color: var(--accent);
   transform: translateY(-1px);
 }
 #backToTop:focus-visible,
-#backToTopCover:focus-visible {
+#backToTopCover:focus-visible,
+#backToTopPhone:focus-visible {
   opacity: 1;
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
 #backToTop svg,
-#backToTopCover svg {
+#backToTopCover svg,
+#backToTopPhone svg {
   width: 14px;
   height: 14px;
 }
@@ -3887,12 +4041,14 @@ html[data-boot-loading] .view-tab {
   }
 }
 #backToTop.show svg,
-#backToTopCover.show svg {
+#backToTopCover.show svg,
+#backToTopPhone.show svg {
   animation: backToTopBob 1.8s ease-in-out infinite;
 }
 @media (prefers-reduced-motion: reduce) {
   #backToTop.show svg,
-  #backToTopCover.show svg {
+  #backToTopCover.show svg,
+  #backToTopPhone.show svg {
     animation: none;
   }
 }
@@ -4638,7 +4794,7 @@ html[data-theme="ember"] .brand-logo-pills {
 .sponsored-deal-banner:hover .house-banner-cta {
   background: #7dd3fc;
 }
-@media (max-width: 900px) {
+@media (max-width: 1023.98px) {
   .house-banner-grid {
     flex-wrap: wrap;
   }
@@ -4653,7 +4809,7 @@ html[data-theme="ember"] .brand-logo-pills {
     margin-left: auto;
   }
 }
-@media (max-width: 640px) {
+@media (max-width: 639.98px) {
   .house-banner-features {
     flex-direction: column;
     gap: 0.6rem;
@@ -5225,7 +5381,7 @@ html[data-theme="ember"] .brand-logo-pills {
   color: #fff;
   background: rgba(2, 6, 23, 0.85);
 }
-@media (max-width: 640px) {
+@media (max-width: 639.98px) {
   .sponsored-feature-blurb {
     max-width: none;
   }
@@ -5352,7 +5508,7 @@ html[data-theme="ember"] .brand-logo-pills {
   margin-left: auto;
   align-self: center;
 }
-@media (max-width: 760px) {
+@media (max-width: 1023.98px) {
   .sponsored-feature-card--banner .sponsored-feature-art {
     width: 100%;
   }
@@ -5460,7 +5616,7 @@ html[data-theme="ember"] .brand-logo-pills {
 .sponsored-claim-feature .sponsored-feature-stat {
   min-width: 0;
 }
-@media (max-width: 767px) {
+@media (max-width: 1023.98px) {
   .sponsored-claim-feature {
     flex-basis: 100%;
   }
@@ -5543,6 +5699,11 @@ html[data-theme="ember"] .brand-logo-pills {
   background: color-mix(in srgb, #f87171 12%, var(--bg-elev));
   color: #fecaca;
   border-color: rgba(248, 113, 113, 0.45);
+}
+@media (prefers-reduced-motion: reduce) {
+  .update-notice-toast {
+    transition: none;
+  }
 }
 .update-available-banner-body,
 .update-ready-banner-body,
@@ -6643,7 +6804,7 @@ html[data-theme="ember"] .brand-logo-pills {
   color: #64748b;
   font-style: italic;
 }
-@media (max-width: 767px) {
+@media (max-width: 1023.98px) {
   .fh-row.is-expanded {
     grid-template-columns: 1fr;
   }
@@ -7714,6 +7875,22 @@ html[data-theme="dark"]
   max-height: 180px;
   max-width: 100%;
 }
+@media (max-width: 1023.98px) {
+  .dash-ribbon-chart {
+    height: 150px;
+  }
+  .dash-ribbon-chart canvas {
+    max-height: 150px;
+  }
+}
+@media (max-width: 639.98px) {
+  .dash-ribbon-chart {
+    height: 140px;
+  }
+  .dash-ribbon-chart canvas {
+    max-height: 140px;
+  }
+}
 
 /* While the viewport is actively resizing (js toggles html.ui-resizing with a
    ~200ms trailing debounce), pause the spotlight float/sheen animations only.
@@ -7727,7 +7904,7 @@ html.ui-resizing
 }
 .dash-ribbon-headline {
   text-align: center;
-  font-size: 13px;
+  font-size: var(--type-ribbon, 13px);
   color: #cbd5e1;
 }
 .dash-ribbon-headline strong {
@@ -7738,7 +7915,7 @@ html.ui-resizing
   display: inline-block;
   margin-top: 16px;
   max-width: 100%;
-  font-size: 12px;
+  font-size: var(--type-insight, 12px);
   line-height: 1.5;
   min-height: calc(
     1em * 1.5 + 12px + 2px
@@ -7782,40 +7959,94 @@ html.ui-resizing
 /* Desktop: bleed the spotlight art to the card's top/right edges so it fills the
    full height of the mega hero. The .dash-mega padding (28px top / 32px right)
    otherwise insets the absolutely-positioned wrap; cancel it with negative
-   offsets. The card clips via overflow:hidden + border-radius. Below 900px the
-   wrap is position:static (stacked), so this is scoped to the desktop layout. */
-@media (min-width: 901px) {
+   offsets. The card clips via overflow:hidden + border-radius. Below 1024px the
+   wrap is a stacked relative band, so this is scoped to the desktop layout. */
+@media (min-width: 1024px) {
   .dash-mega--has-spotlight .dash-spotlight-wrap {
     top: -28px;
     right: -32px;
   }
 }
-@media (max-width: 900px) {
+/* Tablet/phone: stack spotlight above hero copy. Wrap must be position:relative
+   (not static) so .dash-spotlight absolute;inset:0 binds to the band, not
+   .dash-mega-hero - otherwise art fills the whole hero and pillars cover the
+   caption. Ladder: 1023.98 / 639.98 (retire legacy 900 / 640 / 901). */
+@media (max-width: 1023.98px) {
   .dash-ribbon {
     grid-template-columns: 1fr;
   }
+  /* Hug text; do not stretch full hero width (display:block was the culprit). */
   .dash-insight,
   .dash-mega--has-spotlight .dash-insight {
-    max-width: none;
-    display: block;
+    display: inline-block;
+    width: fit-content;
+    max-width: 100%;
+    white-space: normal;
+    overflow: visible;
+    text-wrap: balance;
+  }
+  /* Bleed band to mega top/sides so card overflow+radius clips both edges
+     equally (inset band looked square-left / round-right). Base mega padding
+     is 28px 32px; phone retunes below. */
+  .dash-mega--has-spotlight .dash-spotlight-wrap {
+    position: relative;
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
+    width: calc(100% + 64px);
+    height: 170px;
+    margin: -28px -32px 16px;
+    overflow: hidden;
+    border-radius: 0;
+    border-bottom-left-radius: 12px;
+    border-bottom-right-radius: 12px;
+    z-index: 0;
   }
   .dash-spotlight-wrap {
-    position: static;
+    position: relative;
+    top: auto;
+    right: auto;
+    bottom: auto;
     width: 100%;
-    height: 140px;
+    height: 170px;
     margin-bottom: 16px;
+    overflow: hidden;
+    border-radius: 10px;
+    z-index: 0;
   }
   .dash-spotlight {
-    border-radius: 10px;
+    border-radius: 0;
+    overflow: hidden;
   }
-  .dash-spotlight-art {
+  .dash-mega--has-spotlight .dash-spotlight {
+    border-radius: 0;
+  }
+  .dash-spotlight-art,
+  .dash-spotlight-art-bg,
+  .dash-spotlight.has-portrait-art .dash-spotlight-sheen {
     -webkit-mask-image: none;
     mask-image: none;
   }
+  /* Park cover ~2/3 across (right of center). Inline object-position from
+     js/covers.js applySpotlightArtFit also stamps 66% on this ladder. */
+  .dash-spotlight-art {
+    object-position: 66% 40%;
+  }
+  .dash-spotlight.is-lowres-art .dash-spotlight-art {
+    object-position: 66% 40%;
+  }
+  .dash-spotlight.has-portrait-art .dash-spotlight-art {
+    object-position: 66% 40%;
+  }
+  .dash-spotlight.has-portrait-art .dash-spotlight-sheen {
+    left: 66%;
+  }
   .dash-spotlight-body {
     left: 16px;
-    right: 16px;
-    max-width: none;
+    right: auto;
+    width: fit-content;
+    max-width: calc(100% - 32px);
     text-align: left;
     align-items: flex-start;
   }
@@ -7825,8 +8056,9 @@ html.ui-resizing
   }
   .dash-spotlight.has-logo-art .dash-spotlight-body {
     left: 16px;
-    right: 16px;
-    max-width: none;
+    right: auto;
+    width: fit-content;
+    max-width: calc(100% - 32px);
     text-align: left;
     align-items: flex-start;
   }
@@ -7856,10 +8088,51 @@ html.ui-resizing
   .dash-mega .dash-hero-pillars {
     max-width: none;
   }
-}
-@media (max-width: 640px) {
+  /* Content-width pillars: snug 3-col under the tagline, not full-bleed 1fr. */
   .dash-hero-pillars {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(3, max-content);
+    width: fit-content;
+    max-width: 100%;
+  }
+  .dash-hero-pillar {
+    width: fit-content;
+    max-width: 100%;
+  }
+}
+@media (max-width: 639.98px) {
+  /* Phone mega padding is 1.1rem 1rem - retune spotlight bleed to match. */
+  .dash-mega--has-spotlight .dash-spotlight-wrap {
+    width: calc(100% + 2rem);
+    margin: -1.1rem -1rem 16px;
+  }
+  /* Prefer 2-over-1 centered; wrap to a centered stack when two abreast
+     do not fit (flex-wrap, not a rigid 2-col grid). */
+  .dash-hero-pillars {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: stretch;
+    gap: 12px;
+    width: 100%;
+    max-width: 100%;
+  }
+  .dash-hero-pillar {
+    width: fit-content;
+    max-width: 100%;
+    flex: 0 1 auto;
+  }
+  .dash-insight,
+  .dash-mega--has-spotlight .dash-insight {
+    white-space: normal;
+  }
+  /* Stack tagline stats one per line; drop the · separators (avoid orphan seps on wrap). */
+  .dash-hero-tagline {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+  }
+  .dash-hero-tagline .sep {
+    display: none;
   }
 }
 /* === Wishlist deal dashboard cards === */
@@ -8102,7 +8375,7 @@ html.ui-resizing
   color: #94a3b8;
 }
 .sale-stat-value {
-  font-size: 1.75rem;
+  font-size: var(--type-score-lg, 1.75rem);
   font-weight: 800;
   color: #f1f5f9;
   line-height: 1.1;
@@ -8246,7 +8519,7 @@ html.ui-resizing
   grid-template-columns: 1fr;
   gap: 0.75rem;
 }
-@media (min-width: 768px) {
+@media (min-width: 1024px) {
   .coop-versus {
     grid-template-columns: 1fr 140px 1fr;
     gap: 0;
@@ -8270,6 +8543,11 @@ html.ui-resizing
 }
 .coop-side:hover {
   transform: translateY(-1px);
+}
+@media (prefers-reduced-motion: reduce) {
+  .coop-side:hover {
+    transform: none;
+  }
 }
 .coop-side:focus-visible {
   outline: 2px solid var(--accent);
@@ -8307,7 +8585,7 @@ html.ui-resizing
     color-mix(in srgb, var(--bg-hover) 65%, transparent) 80%
   );
 }
-@media (min-width: 768px) {
+@media (min-width: 1024px) {
   .coop-side-online {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
@@ -8369,7 +8647,7 @@ html.ui-resizing
   color: #94a3b8;
 }
 .coop-side-stat-value {
-  font-size: 1.1rem;
+  font-size: var(--type-score-coop, 1.1rem);
   font-weight: 800;
   color: #f1f5f9;
   line-height: 1.1;
@@ -8485,7 +8763,7 @@ html.ui-resizing
   padding: 0.6rem 0.5rem;
   position: relative;
 }
-@media (min-width: 768px) {
+@media (min-width: 1024px) {
   .coop-connector {
     flex-direction: column;
     border-radius: 0;
@@ -8543,7 +8821,7 @@ button.coop-connector-stat:focus-visible {
   height: 60%;
   background: rgba(71, 85, 105, 0.5);
 }
-@media (min-width: 768px) {
+@media (min-width: 1024px) {
   .coop-connector-divider {
     width: 60%;
     height: 1px;
@@ -8749,6 +9027,37 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
 }
 .dash-chart-wrap.tall {
   height: 320px;
+}
+@media (max-width: 1023.98px) {
+  .dash-chart-wrap {
+    height: 240px;
+  }
+  .dash-chart-wrap.tall {
+    height: 280px;
+  }
+}
+@media (max-width: 639.98px) {
+  .dash-chart-wrap {
+    height: 200px;
+  }
+  .dash-chart-wrap.tall {
+    height: 240px;
+  }
+}
+/* Short landscape (tablet width, phone height): trim further than tablet defaults. */
+@media (max-height: 480px) and (hover: none) {
+  .dash-chart-wrap {
+    height: 160px;
+  }
+  .dash-chart-wrap.tall {
+    height: 190px;
+  }
+  .dash-ribbon-chart {
+    height: 110px;
+  }
+  .dash-ribbon-chart canvas {
+    max-height: 110px;
+  }
 }
 #dashboardContent .dash-chart-wrap canvas,
 #dashboardContent .dash-chart-wrap canvas:hover {
@@ -9065,6 +9374,109 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
 .table-hide-notes col.col-notes {
   width: 0;
 }
+
+/* Mid-width density: drop forced 1280 min-width so hidden cols free space.
+   Title-fit is driven by js density (crushed game cell bumps tier). */
+#tableWrap.table-density .games-table {
+  min-width: 0;
+  width: 100%;
+}
+
+/* Floor Game title width only when density is active - never cap/fix width
+   at full viewport (that truncated titles while metric cols left empty gaps). */
+#tableWrap.table-density .games-table th.col-game,
+#tableWrap.table-density .games-table td.col-game,
+#tableWrap.table-density .games-table td.game-name-cell {
+  min-width: 11.5rem;
+}
+
+.notes-open-btn {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: color-mix(in srgb, var(--accent) 85%, #94a3b8);
+  font-size: 11px;
+  padding: 0;
+  cursor: pointer;
+  line-height: 1.2;
+}
+.notes-open-btn--empty {
+  color: #64748b;
+}
+.notes-open-btn:hover {
+  color: var(--text-bright);
+}
+.notes-dialog-input {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  resize: vertical;
+  min-height: 7rem;
+}
+
+/* Phone sticky chrome (thead is display:none in card mode).
+   Square top + opaque fill so first-card chrome cannot peek through corner
+   cutouts / blur when the bar sticks. */
+.table-phone-sticky {
+  position: sticky;
+  top: env(safe-area-inset-top, 0px);
+  z-index: 12;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.65rem;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+  border-radius: 0;
+  box-shadow: 0 6px 12px -8px color-mix(in srgb, #000 55%, transparent);
+}
+.table-phone-sticky[hidden] {
+  display: none !important;
+}
+/* Compact header back-to-top (phone stand-in for #backToTopCover / thead). */
+#backToTopPhone.table-phone-sticky-top {
+  flex: 0 0 auto;
+  width: 1.625rem;
+  height: 1.625rem;
+  padding: 0;
+  background: var(--bg-elev);
+}
+@media (max-width: 639.98px), (max-height: 480px) and (hover: none) {
+  #backToTopPhone.table-phone-sticky-top {
+    width: var(--touch-min, 44px);
+    height: var(--touch-min, 44px);
+    min-width: var(--touch-min, 44px);
+    min-height: var(--touch-min, 44px);
+  }
+  .sponsored-deal-dismiss {
+    width: var(--touch-min, 44px);
+    height: var(--touch-min, 44px);
+    min-width: var(--touch-min, 44px);
+    min-height: var(--touch-min, 44px);
+    box-sizing: border-box;
+  }
+}
+.table-phone-sticky-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+.table-phone-sticky-count {
+  flex: 0 0 auto;
+  font-size: 0.75rem;
+  color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+}
+#tableWrap.table-phone {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
 .columns-picker-row input {
   flex-shrink: 0;
 }
@@ -9076,10 +9488,16 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  box-sizing: border-box;
   width: 2.375rem;
   height: 2.375rem;
+  min-width: 2.375rem;
+  min-height: 2.375rem;
+  max-width: 2.375rem;
+  max-height: 2.375rem;
   padding: 0;
   line-height: 1;
+  flex: 0 0 2.375rem;
 }
 #kebabBtn {
   font-size: 1.125rem;
@@ -9197,6 +9615,125 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
   margin: auto;
 }
 
+/* === Phone / short-viewport modal sheets (R4+) — bottom-anchored, safe-area.
+   Sheet mode: portrait phone OR short coarse viewport (phone landscape). === */
+@media (max-width: 639.98px), (max-height: 480px) and (hover: none) {
+  :root {
+    --touch-min: 44px;
+  }
+  .app-modal {
+    align-items: flex-end;
+    justify-content: stretch;
+    padding: 0 !important;
+  }
+  .app-modal > [role="dialog"],
+  .app-modal > .profile-modal-card,
+  .app-modal > .baklog-bug-report-card,
+  .app-modal > .update-modal-panel {
+    width: 100% !important;
+    max-width: none !important;
+    margin: 0 !important;
+    max-height: min(92dvh, calc(100dvh - env(safe-area-inset-top, 0px)));
+    border-bottom-left-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
+    border-top-left-radius: 0.75rem !important;
+    border-top-right-radius: 0.75rem !important;
+    padding-bottom: max(0.75rem, env(safe-area-inset-bottom, 0px));
+  }
+  .app-modal .baklog-bug-report-card {
+    max-height: min(92dvh, calc(100dvh - env(safe-area-inset-top, 0px)));
+  }
+  .app-modal [aria-label="Close"],
+  .app-modal [aria-label="Close filters"],
+  .app-modal .baklog-bug-report-close,
+  .app-modal button.text-2xl,
+  .app-modal button.text-xl,
+  .app-modal .update-modal-later,
+  .app-modal .update-modal-apply,
+  .app-modal .update-install-decline,
+  .app-modal .update-install-confirm {
+    min-width: var(--touch-min, 44px);
+    min-height: var(--touch-min, 44px);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+  }
+  .app-modal .app-modal-panel,
+  #secretsBundleDialog.app-modal-panel,
+  #secretsBundleDialog[open] {
+    width: 100% !important;
+    max-width: none !important;
+    margin: auto 0 0 !important;
+    max-height: min(92dvh, calc(100dvh - env(safe-area-inset-top, 0px)));
+    border-radius: 0.75rem 0.75rem 0 0 !important;
+    padding-bottom: max(1rem, env(safe-area-inset-bottom, 0px));
+    box-sizing: border-box;
+  }
+  #customListsDialog[open] {
+    margin: auto 0 0;
+    width: 100%;
+    max-width: 100%;
+    max-height: min(92dvh, calc(100dvh - env(safe-area-inset-top, 0px)));
+    border-radius: 0.75rem 0.75rem 0 0;
+    padding-bottom: max(1.1rem, env(safe-area-inset-bottom, 0px));
+    box-sizing: border-box;
+    overflow: auto;
+  }
+  .claim-detail-dialog[open],
+  .cover-gallery-dialog[open] {
+    margin: auto 0 0;
+    width: 100%;
+    max-width: 100%;
+    max-height: min(92dvh, calc(100dvh - env(safe-area-inset-top, 0px)));
+    border-radius: 0.75rem 0.75rem 0 0;
+  }
+  .claim-detail-dialog[open] .claim-detail-panel {
+    max-height: min(92dvh, calc(100dvh - env(safe-area-inset-top, 0px)));
+    border-radius: 0.75rem 0.75rem 0 0;
+    padding-bottom: max(1rem, env(safe-area-inset-bottom, 0px));
+  }
+  .claim-detail-close,
+  .cover-gallery-dialog button {
+    min-width: var(--touch-min, 44px);
+    min-height: var(--touch-min, 44px);
+  }
+  .conn-popover {
+    top: auto;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    transform: none;
+    width: 100%;
+    max-width: none;
+    max-height: min(92dvh, calc(100dvh - env(safe-area-inset-top, 0px)));
+    border-radius: 0.75rem 0.75rem 0 0;
+    padding-bottom: max(1rem, env(safe-area-inset-bottom, 0px));
+    box-sizing: border-box;
+  }
+  .conn-popover-close {
+    min-width: var(--touch-min, 44px);
+    min-height: var(--touch-min, 44px);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .custom-lists-dialog__btn,
+  .custom-lists-dialog__footer button,
+  .baklog-bug-report-btn {
+    min-height: var(--touch-min, 44px);
+  }
+  .sale-scoreboard,
+  .itch-value-grid,
+  .coop-side-stats {
+    grid-template-columns: 1fr;
+  }
+  .pro-view-compare {
+    min-width: 22rem;
+    font-size: 0.84rem;
+  }
+}
+
 /* Multi-column (not grid) so checkboxes read top-to-bottom down the first
    column, then continue down the second — i.e. in order as you go down. */
 #columnsList {
@@ -9215,7 +9752,7 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
   color: var(--text);
 }
 
-@media (max-width: 420px) {
+@media (max-width: 400px) {
   #columnsList {
     column-count: 1;
   }
@@ -9240,9 +9777,9 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
   tbody
   tr:not(.virtual-spacer):not(.table-empty-state-row) {
   display: grid;
-  grid-template-columns: 36px 56px 1fr auto;
+  grid-template-columns: 36px 56px 1fr;
   grid-template-rows: auto auto;
-  gap: 0 8px;
+  gap: 4px 8px;
   align-items: center;
   height: auto;
   min-height: 72px;
@@ -9266,22 +9803,50 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
   align-self: center;
 }
 #tableWrap.table-phone .games-table tbody tr td:nth-child(3) {
-  grid-column: 3 / span 2;
+  grid-column: 3;
   grid-row: 1;
   min-width: 0;
 }
 #tableWrap.table-phone .games-table tbody tr td:nth-child(4) {
-  grid-column: 4;
+  grid-column: 3;
   grid-row: 2;
-  justify-self: end;
+  justify-self: start;
 }
 #tableWrap.table-phone .games-table tbody tr td:nth-child(n + 5) {
   display: none;
 }
-#tableWrap.table-phone .game-name-cell .flex {
-  flex-direction: column;
-  align-items: stretch;
-  gap: 4px;
+/* Title row holds EA/gem beside the name (left, vertically centered via
+   items-center). Meta chips + status stay below for three visual lines.
+   Do not use a descendant .flex rule with stretch (full-width coop/EA bars). */
+#tableWrap.table-phone .game-name-cell .row-meta {
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  width: 100%;
+}
+/* Hug chips - do not override .store-badge's fixed 16px box (width:auto
+   collapsed glyph badges into a near-invisible indent before coop pills). */
+#tableWrap.table-phone .game-name-cell .row-meta > *:not(.store-badge),
+#tableWrap.table-phone .game-name-cell .ea-pill,
+#tableWrap.table-phone .game-name-cell .coop-pill {
+  flex: 0 0 auto;
+  width: auto;
+  max-width: 100%;
+  align-self: auto;
+}
+#tableWrap.table-phone .game-name-cell .store-badge {
+  flex: 0 0 16px;
+  width: 16px;
+  height: 16px;
+  min-width: 16px;
+  max-width: 16px;
+}
+#tableWrap.table-phone .col-status select {
+  width: auto;
+  max-width: 100%;
+}
+#tableWrap.table-phone .hltb-match-hint {
+  display: none;
 }
 #tableWrap.table-phone .cover-wrap {
   width: 48px;
@@ -10017,8 +10582,15 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
   flex-shrink: 0;
   font-size: 12px;
 }
-@media (max-width: 900px) {
+/* Stack picks on the tablet ladder. Drop desktop equal-height reservation so
+   Recently added / versus do not keep a tall empty tail under a few rows. */
+@media (max-width: 1023.98px) {
   .dash-picks-row {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
+  /* Beat .dash-picks-row:has(sponsored) repeat(4) so versus/recent stay stacked. */
+  .dash-picks-row:has(.dash-sponsored-pick-slot:not(.hidden)) {
     grid-template-columns: 1fr;
   }
   .dash-picks-row .dash-picks-versus,
@@ -10026,15 +10598,25 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
   .dash-picks-row .dash-recent-card,
   .dash-picks-row .dash-sponsored-pick-slot {
     grid-column: auto;
+    height: auto;
   }
   .dash-picks-row .dash-versus-grid {
     grid-template-columns: 1fr;
-    grid-template-rows: 1fr auto 1fr;
+    grid-template-rows: auto auto auto;
   }
   .dash-picks-row .dash-versus-divider {
     width: 100%;
     height: 1px;
     min-height: 1px;
+  }
+  .dash-picks-row .dash-versus-list {
+    flex: 0 0 auto;
+    justify-content: flex-start;
+  }
+  .dash-picks-row .dash-recent-list {
+    flex: 0 0 auto;
+    grid-template-rows: none;
+    grid-auto-rows: auto;
   }
 }
 .dash-picks-versus {
@@ -10182,7 +10764,7 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
   font-weight: 700;
   margin-left: 4px;
 }
-@media (max-width: 640px) {
+@media (max-width: 639.98px) {
   .dash-versus-grid {
     grid-template-columns: 1fr;
   }
@@ -10311,7 +10893,7 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
   min-width: 0;
   margin: 0;
 }
-@media (max-width: 720px) {
+@media (max-width: 1023.98px) {
   .conn-hint-row {
     flex-direction: column;
   }
@@ -10445,7 +11027,7 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
 .pro-view-hero .pro-view-pricing .pro-view-founder {
   text-align: right;
 }
-@media (max-width: 640px) {
+@media (max-width: 639.98px) {
   .pro-view-hero .pro-view-pricing {
     flex-basis: 100%;
     align-items: flex-start;
@@ -10552,6 +11134,8 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
   border-radius: 12px;
   border: 1px solid var(--border);
   background: var(--bg-panel);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 .pro-view-compare-lead {
   margin: 0 0 0.75rem;
@@ -10561,6 +11145,7 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
 }
 .pro-view-compare {
   width: 100%;
+  min-width: 28rem;
   border-collapse: collapse;
   font-size: 0.8rem;
 }
@@ -10767,7 +11352,7 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
   line-height: 1.45;
   color: var(--text-mute);
 }
-@media (max-width: 720px) {
+@media (max-width: 639.98px) {
   .pro-view-perk-grid,
   .pro-view-trust-list {
     grid-template-columns: 1fr;
@@ -11012,9 +11597,13 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
 .conn-rail-item * {
   cursor: pointer;
 }
-@media (max-width: 720px) {
+/* Connections stack on tablet+phone (ladder). R3: sticky selected chip + pane clip. */
+@media (max-width: 1023.98px) {
   #connLayout {
     grid-template-columns: 1fr;
+    min-width: 0;
+    max-width: 100%;
+    gap: 10px;
   }
   #connRail {
     flex-direction: row;
@@ -11024,7 +11613,9 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
     position: static;
     max-height: none;
     gap: 8px;
-    padding-bottom: 4px;
+    padding-bottom: 10px;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
   }
   .conn-rail-steam-wrap {
     flex-direction: row;
@@ -11034,7 +11625,40 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
   }
   .conn-rail-item {
     flex-shrink: 0;
-    min-width: 180px;
+    min-width: 160px;
+  }
+  /* Keep the active provider visible while the rail scrolls. */
+  .conn-rail-item.is-selected {
+    position: sticky;
+    left: 0;
+    z-index: 2;
+    box-shadow: 6px 0 10px -6px color-mix(in srgb, #000 55%, transparent);
+  }
+  /* Steam wrap: sticky as a unit so rec caption stays with the selected chip. */
+  .conn-rail-steam-wrap:has(.conn-rail-item.is-selected) {
+    position: sticky;
+    left: 0;
+    z-index: 2;
+    box-shadow: 6px 0 10px -6px color-mix(in srgb, #000 55%, transparent);
+  }
+  .conn-rail-steam-wrap:has(.conn-rail-item.is-selected) .conn-rail-item.is-selected {
+    position: static;
+    box-shadow: none;
+  }
+  #connPane {
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: clip;
+    min-height: 0;
+  }
+  #connPane .conn-card {
+    min-height: 0;
+  }
+  #connPane .conn-card-body {
+    max-height: min(70vh, 36rem);
+    overflow-y: auto;
+    overflow-x: hidden;
+    -webkit-overflow-scrolling: touch;
   }
 }
 /* Header icon buttons (full screen, report bug, etc.) */
@@ -11579,7 +12203,7 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
   align-self: flex-end;
 }
 /* Narrow cards: notes stack full-width beneath the main content. */
-@media (max-width: 520px) {
+@media (max-width: 639.98px) {
   .conn-notes {
     max-width: none;
     flex-basis: 100%;
@@ -11944,7 +12568,7 @@ html[data-theme="ember"] .conn-primary:hover {
   max-width: none;
   display: block;
 }
-@media (max-width: 900px) {
+@media (max-width: 1023.98px) {
   .dash-mega .library-count-host:has(> .dash-hero-number) {
     max-width: none;
   }
@@ -12046,35 +12670,229 @@ html[data-theme="ember"] .conn-primary:hover {
 }
 #tableWrap {
   /* clip (not auto) keeps overflow-y visible so thead sticky pins to the page,
-     not this wrapper — page scroll drives virtualization in table-ui.js */
+     not this wrapper — page scroll drives virtualization in table-ui.js.
+     Do not switch to overflow-x:auto on shrink: that kills sticky thead.
+     Mid-width fit comes from table density (js/table-density.js). */
   overflow-x: clip;
   max-width: 100%;
 }
-@media (max-width: 1327.98px) {
-  #tableWrap {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-  }
+
+/* --- Header main-nav hamburger (sheet mode: tablet ladder OR fit overflow) --- */
+.header-nav-toggle {
+  display: none;
+}
+.header-nav-backdrop {
+  display: none;
+}
+/* Desktop / inline: panel is a passthrough so .app-header-nav stays in the header flex row. */
+.header-nav-panel {
+  display: contents;
+}
+.header-nav-sheet-extras {
+  display: none;
+}
+.header-nav-sheet-action-label {
+  display: none;
+}
+/* Prefer a single header row; sheet mode engages before wrap (JS fit check). */
+.app-header-row {
+  flex-wrap: nowrap;
+}
+
+html.header-nav-sheet .app-header-row {
+  row-gap: 0.5rem;
+  align-items: center;
+  flex-wrap: nowrap;
+}
+html.header-nav-sheet .app-header-brand {
+  order: 1;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+html.header-nav-sheet .app-header-actions {
+  margin-left: auto;
+  order: 2;
+  flex-shrink: 0;
+  gap: 0.55rem;
+}
+/* Sheet mode: compact fetcher circle (slightly under hamburger 2rem); hide label. */
+html.header-nav-sheet .fh-global-status {
+  position: relative;
+  box-sizing: border-box;
+  width: 1.75rem;
+  height: 1.75rem;
+  min-width: 1.75rem;
+  min-height: 1.75rem;
+  max-width: 1.75rem;
+  padding: 0;
+  justify-content: center;
+  align-items: center;
+  align-self: center;
+  /* Base pill uses translateY(-1px) for desktop text row - cancel for icon align. */
+  transform: none;
+}
+html.header-nav-sheet .fetcher-popover-anchor {
+  display: inline-flex;
+  align-items: center;
+  align-self: center;
+}
+html.header-nav-sheet .fh-global-status .fh-global-status-tail {
+  display: none;
+}
+html.header-nav-sheet .fh-global-status #fetcherGlobalStatusText {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+/* Beta pill: drop upward translate so overflow:hidden on brand does not clip
+   the top/left border in sheet/phone density. */
+html.header-nav-sheet .brand-beta {
+  transform: none;
+}
+html.header-nav-sheet .header-nav-toggle {
+  display: inline-flex;
+}
+html.header-nav-sheet #headerFullscreenBtn {
+  display: none !important;
+}
+/* Keep wrap out of the header flex flow; panel is a fixed sheet. */
+html.header-nav-sheet .app-header-nav-wrap {
+  position: fixed;
+  inset: 0;
+  z-index: 88;
+  flex: 0 0 0 !important;
+  width: 0 !important;
+  height: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  overflow: visible;
+  pointer-events: none;
+  order: 0;
+}
+html.header-nav-sheet .app-header-nav-wrap.is-open {
+  pointer-events: auto;
+}
+html.header-nav-sheet .header-nav-backdrop {
+  display: block;
+  position: fixed;
+  inset: 0;
+  background: var(--overlay-scrim-soft);
+  z-index: 0;
+}
+html.header-nav-sheet .header-nav-backdrop[hidden] {
+  display: none !important;
+}
+html.header-nav-sheet .header-nav-panel {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  width: min(18.5rem, 86vw);
+  max-width: 100%;
+  padding: max(0.85rem, env(safe-area-inset-top, 0px))
+    0.85rem
+    max(0.85rem, env(safe-area-inset-bottom, 0px));
+  padding-left: max(0.85rem, env(safe-area-inset-left, 0px));
+  background: var(--bg-panel);
+  border-right: 1px solid var(--border);
+  box-shadow: 8px 0 28px rgba(0, 0, 0, 0.35);
+  transform: translateX(-105%);
+  transition: transform 0.18s ease;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+html.header-nav-sheet .app-header-nav-wrap.is-open .header-nav-panel {
+  transform: translateX(0);
+}
+html.header-nav-sheet .header-nav-panel[hidden] {
+  display: none !important;
+}
+html.header-nav-sheet .app-header-nav {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  align-items: stretch;
+  gap: 0.4rem;
+  width: 100%;
+}
+html.header-nav-sheet .app-header-nav .view-tab {
+  width: 100%;
+  justify-content: flex-start;
+  text-align: left;
+  min-height: var(--touch-min, 44px);
+  padding: 0.65rem 0.85rem;
+}
+html.header-nav-sheet .header-nav-sheet-extras {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.45rem;
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--border-subtle);
+}
+html.header-nav-sheet .header-nav-sheet-extras #reportBugHeader {
+  width: 100%;
+  min-width: 0;
+  min-height: var(--touch-min, 44px);
+  justify-content: flex-start;
+  gap: 0.55rem;
+  padding: 0 0.85rem;
+}
+html.header-nav-sheet .header-nav-sheet-action-label {
+  display: inline;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-dim);
+}
+html.header-nav-sheet .header-nav-sheet-extras .profile-menu-wrap {
+  width: 100%;
+}
+html.header-nav-sheet .header-nav-sheet-extras .profile-menu-trigger {
+  width: 100%;
+  min-height: var(--touch-min, 44px);
+  max-width: none;
+  justify-content: space-between;
+  padding-left: 0.85rem;
+  padding-right: 0.85rem;
+}
+html.header-nav-sheet .header-nav-sheet-extras .profile-menu-label {
+  max-width: none;
+}
+html.header-nav-sheet .header-nav-sheet-extras .profile-menu-panel {
+  position: static;
+  width: 100%;
+  margin-top: 0.35rem;
+  box-shadow: none;
 }
 
 /* --- Tablet (<= 1023.98px) --- */
 @media (max-width: 1023.98px) {
-  .app-header-row {
-    row-gap: 0.5rem;
+  .runtime-mode-banner-detail {
+    max-width: 9rem;
   }
-  /* Order the row flex children (brand | nav-wrap | actions), not the nested nav. */
-  .app-header-nav-wrap {
-    flex: 1 1 100%;
-    order: 3;
-    max-width: 100%;
-    min-width: 0;
+  /* Wishlist / dash deal radar: sm:grid-cols-3 crushes 3-col scoreboards mid-tablet. */
+  .dash-wishlist-stats-target {
+    grid-template-columns: 1fr;
   }
-  .app-header-actions {
-    margin-left: auto;
-    order: 2;
+  /* Clear fixed A-Z rail on library/wishlist/itch (not dash/connections/pro). */
+  html:not([data-init-view="dashboard"]):not([data-init-view="connections"]):not([data-init-view="pro"])
+    #tableShell {
+    padding-right: 1.25rem;
   }
-  .app-header-brand {
-    order: 1;
+}
+@media (min-width: 1024px) {
+  .dash-wishlist-stats-target {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 
@@ -12087,8 +12905,13 @@ html[data-theme="ember"] .conn-primary:hover {
     padding-left: 0.75rem;
     padding-right: 0.75rem;
   }
+  header.app-header {
+    max-width: 100%;
+    min-width: 0;
+    overflow-x: clip;
+  }
   .app-header-row {
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     align-items: center;
     gap: 0.5rem 0.75rem;
   }
@@ -12097,6 +12920,8 @@ html[data-theme="ember"] .conn-primary:hover {
     flex: 1 1 auto;
     min-width: 0;
     margin-right: 0 !important;
+    /* Brand stays one line; overflow clips beta/runtime chrome, not the wordmark. */
+    overflow: hidden;
   }
   .app-header-brand h1 {
     font-size: 1.25rem;
@@ -12104,57 +12929,45 @@ html[data-theme="ember"] .conn-primary:hover {
   .app-header-brand img {
     height: 24px !important;
   }
+  .brand-logo-mark {
+    height: 26px;
+  }
+  .runtime-mode-banner {
+    display: none;
+  }
   .app-header-actions {
     order: 2;
     margin-left: auto;
     flex-shrink: 0;
+    gap: 0.45rem;
   }
-  .app-header-nav-wrap {
-    order: 3;
-    flex: 1 1 100%;
-    min-width: 0;
+  .fh-global-status,
+  html.header-nav-sheet .fh-global-status {
     position: relative;
-    max-width: 100%;
-  }
-  .app-header-nav-wrap::after {
-    content: "";
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    width: 28px;
-    pointer-events: none;
-    background: linear-gradient(90deg, transparent, var(--bg) 85%);
-  }
-  .app-header-nav {
-    display: flex;
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    overflow-y: hidden;
-    gap: 0.35rem;
-    padding-bottom: 2px;
-    -webkit-overflow-scrolling: touch;
-    scroll-snap-type: x proximity;
-    scrollbar-width: thin;
-  }
-  .app-header-nav .view-tab {
-    flex: 0 0 auto;
-    scroll-snap-align: start;
-    min-height: var(--touch-min);
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
-  }
-  .fh-global-status {
-    position: relative;
-    min-height: var(--touch-min);
-    min-width: var(--touch-min);
-    padding: 0 0.55rem;
+    /* Slightly under hamburger touch box; keep optical center (no translateY). */
+    box-sizing: border-box;
+    width: 1.75rem;
+    height: 1.75rem;
+    min-width: 1.75rem;
+    min-height: 1.75rem;
+    max-width: 1.75rem;
+    padding: 0;
     justify-content: center;
+    align-items: center;
+    align-self: center;
+    transform: none;
   }
-  .fh-global-status .fh-global-status-tail {
+  .fetcher-popover-anchor {
+    display: inline-flex;
+    align-items: center;
+    align-self: center;
+  }
+  .fh-global-status .fh-global-status-tail,
+  html.header-nav-sheet .fh-global-status .fh-global-status-tail {
     display: none;
   }
-  .fh-global-status #fetcherGlobalStatusText {
+  .fh-global-status #fetcherGlobalStatusText,
+  html.header-nav-sheet .fh-global-status #fetcherGlobalStatusText {
     position: absolute;
     width: 1px;
     height: 1px;
@@ -12164,6 +12977,10 @@ html[data-theme="ember"] .conn-primary:hover {
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
     border: 0;
+  }
+  .brand-beta,
+  html.header-nav-sheet .brand-beta {
+    transform: none;
   }
   .profile-menu-trigger {
     min-height: var(--touch-min);
@@ -12178,10 +12995,15 @@ html[data-theme="ember"] .conn-primary:hover {
     overflow-x: auto;
     overflow-y: hidden;
     gap: 0.5rem;
-    padding-bottom: 4px;
+    /* Space chips above the horizontal scrollbar so they don't sit on the track. */
+    padding-bottom: 10px;
     -webkit-overflow-scrolling: touch;
     scrollbar-width: thin;
     align-items: stretch;
+    max-width: 100%;
+    min-width: 0;
+    /* Keep the scroll strip inside the viewport - never widen the page. */
+    overscroll-behavior-x: contain;
   }
   #summary > .summary-scroll-row,
   #summary > div {
@@ -12192,16 +13014,40 @@ html[data-theme="ember"] .conn-primary:hover {
     width: max-content;
     max-width: none;
   }
+  /* Hug label width; pad so text clears the accent; clip if somehow overlong. */
   #summary .summary-store-chip,
   #summary .summary-deal-chip,
   #summary .summary-stat-chip,
   #summary .summary-jump-chip,
   #summary > div > div,
   #summary button {
-    flex-shrink: 0;
-    min-height: var(--touch-min);
+    box-sizing: border-box;
+    flex: 0 0 auto;
+    width: max-content;
+    max-width: min(100%, 18rem);
+    min-width: 0;
+    min-height: 1.85rem;
+    height: auto;
     display: inline-flex;
     align-items: center;
+    justify-content: flex-start;
+    gap: 0.25rem;
+    padding: 0.25rem 0.65rem 0.25rem 0.75rem;
+    font-size: 0.75rem;
+    line-height: 1.15;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  #summary .summary-stat-chip .font-semibold,
+  #summary .summary-store-chip .font-semibold,
+  #summary .summary-deal-chip .font-semibold,
+  #summary .summary-jump-chip .font-semibold,
+  #summary .summary-stat-chip .text-slate-100,
+  #summary button .font-semibold {
+    flex: 0 0 auto;
+    font-size: 0.75rem;
+    margin-left: 0;
   }
   #toolbarSection .toolbar-row {
     gap: 0.5rem;
@@ -12213,11 +13059,33 @@ html[data-theme="ember"] .conn-primary:hover {
     order: 1;
     min-height: var(--touch-min);
   }
-  #toolbarSection #openFiltersBtn,
-  #toolbarSection #addGameBtn,
-  #toolbarSection #kebabBtn {
+  /* Action row: ||| , ⋯ , Filters, Add game (columns/kebab were order 0 and
+     sat alone above search because kebab order targeted the inner button). */
+  #toolbarSection #openColumnsBtn {
     order: 2;
+  }
+  #toolbarSection .toolbar-kebab-wrap {
+    order: 3;
+  }
+  #toolbarSection #openFiltersBtn {
+    order: 4;
     min-height: var(--touch-min);
+  }
+  #toolbarSection #addGameBtn {
+    order: 5;
+    min-height: var(--touch-min);
+  }
+  #toolbarSection #openColumnsBtn,
+  #toolbarSection #kebabBtn {
+    width: var(--touch-min);
+    height: var(--touch-min);
+    min-width: var(--touch-min);
+    min-height: var(--touch-min);
+    max-width: var(--touch-min);
+    max-height: var(--touch-min);
+    flex: 0 0 var(--touch-min);
+    box-sizing: border-box;
+    padding: 0;
   }
   #toolbarSection #pickForMe {
     display: none;
@@ -12231,10 +13099,55 @@ html[data-theme="ember"] .conn-primary:hover {
     overflow-y: hidden;
     -webkit-overflow-scrolling: touch;
     scrollbar-width: thin;
-    padding-bottom: 2px;
+    padding-bottom: 10px;
+    overscroll-behavior-x: contain;
   }
   #activeFilterPills > * {
     flex-shrink: 0;
+  }
+
+  /* Bulk bar: one horizontal row so 56px body pad stays valid (no wrap over table). */
+  #bulkBar > div {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 10px;
+    overscroll-behavior-x: contain;
+  }
+  #bulkBar > div > *,
+  #bulkStatusButtons {
+    flex-shrink: 0;
+  }
+  #bulkStatusButtons {
+    flex-wrap: nowrap;
+  }
+
+  /* Phone sticky: already uses safe-area top; keep pin detection via bar bottom. */
+  .row-loading-overlay {
+    top: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 13;
+  }
+
+  #filterDrawer {
+    padding-top: env(safe-area-inset-top, 0px);
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+    padding-left: env(safe-area-inset-left, 0px);
+    padding-right: env(safe-area-inset-right, 0px);
+  }
+  #closeFiltersBtn {
+    min-width: var(--touch-min);
+    min-height: var(--touch-min);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+  }
+
+  .pro-view-toggle-btn,
+  .pro-view-btn {
+    min-height: var(--touch-min);
   }
 
   /* Phone spacing pass: tighten hero cards and stack deal/conn chrome. */
@@ -12285,6 +13198,18 @@ html[data-theme="ember"] .conn-primary:hover {
     min-width: 0;
     width: auto;
   }
+
+  /* Contain dashboard strips so KPI/ribbon never force page-level overflow. */
+  .dash-ribbon,
+  .dash-mega,
+  .dash-hero,
+  #viewDashboard {
+    max-width: 100%;
+    min-width: 0;
+  }
+  .dash-ribbon {
+    overflow-x: clip;
+  }
 }
 
 #toolbarSection .toolbar-kebab-pick--phone {
@@ -12301,6 +13226,19 @@ html[data-theme="ember"] .conn-primary:hover {
     font-size: 0.75rem;
     padding-left: 0.5rem;
     padding-right: 0.5rem;
+  }
+  .app-header-brand h1 {
+    font-size: 1.125rem;
+  }
+  .brand-logo-mark {
+    height: 22px;
+  }
+  .brand-beta {
+    font-size: 0.52rem;
+    padding: 0.14em 0.35em;
+  }
+  #summary {
+    gap: 0.35rem;
   }
 }
 
@@ -12339,6 +13277,12 @@ body {
   z-index: 91;
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.55);
   color: var(--text-dim);
+}
+/* Tablet: keep anchored popover; tighten cap + respect safe-area. */
+@media (max-width: 1023.98px) and (min-width: 640px) {
+  .fetcher-popover {
+    max-height: min(85dvh, calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px) - 24px));
+  }
 }
 /* Slimmer in compact, wider in landscape so source chips get more room.
    Layout flag lives on the nested #dashboardFetcherHealth (data-stat-layout). */
@@ -13011,23 +13955,75 @@ body {
   overflow-y: auto;
   overscroll-behavior: auto;
 }
-@media (max-width: 639.98px) {
-  .fetcher-popover {
+/* Phone / short coarse viewport: fetcher module becomes a fullscreen sheet. */
+@media (max-width: 639.98px), (max-height: 480px) and (hover: none) {
+  .fetcher-popover,
+  .fetcher-popover.fetcher-popover--sheet {
     position: fixed;
-    top: 10px;
-    right: 10px;
-    left: 10px;
-    bottom: 10px;
-    width: auto;
+    inset: 0;
+    top: env(safe-area-inset-top, 0px);
+    right: env(safe-area-inset-right, 0px);
+    bottom: env(safe-area-inset-bottom, 0px);
+    left: env(safe-area-inset-left, 0px);
+    width: 100%;
+    max-width: none;
+    height: 100dvh;
     max-height: none;
+    border-radius: 0;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+    z-index: 95;
+  }
+  .fetcher-popover:has([data-stat-layout="compact"]),
+  .fetcher-popover:has([data-stat-layout="landscape"]),
+  .fetcher-popover.fetcher-popover--sheet:has([data-stat-layout="compact"]),
+  .fetcher-popover.fetcher-popover--sheet:has([data-stat-layout="landscape"]) {
+    width: 100%;
+  }
+  .fetcher-popover-head {
+    position: sticky;
+    top: 0;
+    right: auto;
+    left: auto;
+    z-index: 3;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0.65rem 0.75rem;
+    margin: 0;
+    border-bottom: 1px solid var(--border-subtle);
+    background: var(--bg-panel);
+  }
+  .fetcher-popover-title {
+    display: block;
+    flex: 1 1 auto;
+    min-width: 0;
+    font-size: 0.95rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    color: var(--text-bright);
+  }
+  .fetcher-stat-layout-toggle {
+    margin-left: auto;
   }
   .fetcher-popover-scroll {
+    flex: 1 1 auto;
+    min-height: 0;
     overflow-y: auto;
+    overflow-x: hidden;
+    overscroll-behavior: contain;
+    padding: 0.75rem 0.75rem 1rem;
+    margin-right: 0;
+    padding-right: 0.75rem;
   }
   .fetcher-popover-close,
   .fetcher-stat-layout-toggle {
     min-height: var(--touch-min, 44px);
     min-width: var(--touch-min, 44px);
+    height: auto;
     display: inline-flex;
     align-items: center;
     justify-content: center;

--- a/guide/getting-help.md
+++ b/guide/getting-help.md
@@ -23,7 +23,7 @@ For local dev without hitting production, set `window.__BAKLOG_REPORT_ENDPOINT` 
 
 | Channel | Link | Best for |
 |---------|------|----------|
-| **Discord** | [discord.gg/baklog](https://discord.gg/baklog) | Beta chat, `#bug-reports`, `#feature-requests` |
+| **Discord** | [discord.gg/VFvxN5nCCB](https://discord.gg/VFvxN5nCCB) | Beta chat, `#bug-reports`, `#feature-requests` |
 | **GitHub** | [github.com/Ogrods/BAKLOG](https://github.com/Ogrods/BAKLOG) | Source code (MIT), reproducible bugs, feature requests |
 | **GitHub Issues** | [New issue](https://github.com/Ogrods/BAKLOG/issues/new) | Long-term bug and feature record |
 | **Email** | [dan@baklog.app](mailto:dan@baklog.app) | Invite or support questions |

--- a/index.html
+++ b/index.html
@@ -453,60 +453,73 @@
               aria-live="polite"
             ></span>
           </div>
-          <div class="app-header-nav-wrap min-w-0">
-            <nav
-              class="app-header-nav flex flex-wrap items-center gap-1.5"
-              aria-label="Main views"
-            >
-              <button
-                type="button"
-                class="view-tab px-3 py-1.5 rounded border border-slate-600 text-sm"
-                data-view="dashboard"
-                title="Overview: stats, spotlight, fetcher health"
+          <div class="app-header-nav-wrap min-w-0" id="appHeaderNavWrap">
+            <div
+              id="headerNavBackdrop"
+              class="header-nav-backdrop"
+              hidden
+            ></div>
+            <div id="headerNavPanel" class="header-nav-panel">
+              <nav
+                id="appHeaderNav"
+                class="app-header-nav flex flex-wrap items-center gap-1.5"
+                aria-label="Main views"
               >
-                Dashboard
-              </button>
-              <button
-                type="button"
-                class="view-tab px-3 py-1.5 rounded border border-slate-600 text-sm"
-                data-view="library"
-                title="Your full game library and filters"
-              >
-                Library
-              </button>
-              <button
-                type="button"
-                class="view-tab px-3 py-1.5 rounded border border-slate-600 text-sm"
-                data-view="wishlist"
-                title="Wishlist games and deal filters"
-              >
-                Wishlist
-              </button>
-              <button
-                type="button"
-                class="view-tab px-3 py-1.5 rounded border border-slate-600 text-sm"
-                data-view="itch"
-                title="itch.io library"
-              >
-                itch.io
-              </button>
-              <button
-                type="button"
-                class="view-tab px-3 py-1.5 rounded border border-slate-600 text-sm"
-                data-view="connections"
-                title="Connect stores and manage API keys / OAuth"
-              >
-                Connections
-              </button>
-              <button
-                type="button"
-                class="view-tab px-3 py-1.5 rounded border border-slate-600 text-sm"
-                data-view="pro"
-                title="Support BAKLOG - back the roadmap and activate"
-              >
-                Support
-              </button>
-            </nav>
+                <button
+                  type="button"
+                  class="view-tab px-3 py-1.5 rounded border border-slate-600 text-sm"
+                  data-view="dashboard"
+                  title="Overview: stats, spotlight, fetcher health"
+                >
+                  Dashboard
+                </button>
+                <button
+                  type="button"
+                  class="view-tab px-3 py-1.5 rounded border border-slate-600 text-sm"
+                  data-view="library"
+                  title="Your full game library and filters"
+                >
+                  Library
+                </button>
+                <button
+                  type="button"
+                  class="view-tab px-3 py-1.5 rounded border border-slate-600 text-sm"
+                  data-view="wishlist"
+                  title="Wishlist games and deal filters"
+                >
+                  Wishlist
+                </button>
+                <button
+                  type="button"
+                  class="view-tab px-3 py-1.5 rounded border border-slate-600 text-sm"
+                  data-view="itch"
+                  title="itch.io library"
+                >
+                  itch.io
+                </button>
+                <button
+                  type="button"
+                  class="view-tab px-3 py-1.5 rounded border border-slate-600 text-sm"
+                  data-view="connections"
+                  title="Connect stores and manage API keys / OAuth"
+                >
+                  Connections
+                </button>
+                <button
+                  type="button"
+                  class="view-tab px-3 py-1.5 rounded border border-slate-600 text-sm"
+                  data-view="pro"
+                  title="Support BAKLOG - back the roadmap and activate"
+                >
+                  Support
+                </button>
+              </nav>
+              <div
+                id="headerNavSheetExtras"
+                class="header-nav-sheet-extras"
+                hidden
+              ></div>
+            </div>
           </div>
           <div
             class="header-actions app-header-actions ml-auto flex items-center gap-2 shrink-0 self-center"
@@ -599,6 +612,29 @@
                 </div>
               </div>
             </div>
+            <button
+              type="button"
+              id="headerNavToggle"
+              class="header-nav-toggle header-icon-btn shrink-0"
+              title="Menu"
+              aria-label="Open menu"
+              aria-expanded="false"
+              aria-controls="headerNavPanel"
+            >
+              <svg
+                class="header-icon-btn-svg header-nav-toggle-icon"
+                viewBox="0 0 24 24"
+                width="18"
+                height="18"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  fill="currentColor"
+                  d="M4 6.75h16a.75.75 0 0 0 0-1.5H4a.75.75 0 0 0 0 1.5zm0 6h16a.75.75 0 0 0 0-1.5H4a.75.75 0 0 0 0 1.5zm0 6h16a.75.75 0 0 0 0-1.5H4a.75.75 0 0 0 0 1.5z"
+                />
+              </svg>
+            </button>
             <button
               type="button"
               id="headerFullscreenBtn"
@@ -695,6 +731,7 @@
                   stroke-linecap="round"
                 />
               </svg>
+              <span class="header-nav-sheet-action-label">Report bug</span>
             </button>
             <div
               id="profileMenuWrap"
@@ -1416,7 +1453,7 @@
           <div id="picksContainer" class="p-3">
             <div
               id="picksGrid"
-              class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 xl:grid-cols-8 gap-2"
+              class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-2"
             ></div>
           </div>
         </section>
@@ -1489,7 +1526,7 @@
                 <rect x="13" y="2" width="2" height="12" rx="0.5" />
               </svg>
             </button>
-            <div class="relative">
+            <div class="relative toolbar-kebab-wrap">
               <button
                 type="button"
                 id="kebabBtn"
@@ -1623,7 +1660,7 @@
                 <!-- Discord invite: keep in sync with shared/community.json + landing/index.html footer -->
                 <a
                   id="joinDiscord"
-                  href="https://discord.gg/baklog"
+                  href="https://discord.gg/VFvxN5nCCB"
                   target="_blank"
                   rel="noopener noreferrer"
                   class="w-full text-left px-3 py-2 hover:bg-slate-700 block"
@@ -1806,6 +1843,39 @@
 
         <div id="tableShell" class="relative">
           <div
+            id="tablePhoneSticky"
+            class="table-phone-sticky"
+            hidden
+            aria-live="polite"
+          >
+            <button
+              id="backToTopPhone"
+              type="button"
+              class="table-phone-sticky-top"
+              title="Back to top"
+              aria-label="Back to top"
+            >
+              <svg
+                viewBox="0 0 20 20"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M10 13 L10 7 M6 10 L10 6 L14 10" />
+              </svg>
+            </button>
+            <span id="tablePhoneStickyLabel" class="table-phone-sticky-label"
+              >Library</span
+            >
+            <span
+              id="tablePhoneStickyCount"
+              class="table-phone-sticky-count"
+            ></span>
+          </div>
+          <div
             id="rowLoadingOverlay"
             class="row-loading-overlay"
             aria-hidden="true"
@@ -1950,6 +2020,20 @@
       <!-- Social links: keep icons, URLs, and order in sync with landing/index.html .foot-social -->
       <footer class="app-footer" aria-label="Follow BAKLOG">
         <nav class="app-footer-social" aria-label="Social links">
+          <!-- Discord: keep in sync with shared/community.json discord_invite + landing/index.html .foot-social -->
+          <a
+            href="https://discord.gg/VFvxN5nCCB"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="BAKLOG on Discord"
+            title="Discord (community)"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.331c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"
+              />
+            </svg>
+          </a>
           <a
             href="https://www.instagram.com/baklog.app/"
             target="_blank"
@@ -2031,8 +2115,10 @@
       (function () {
         var btn = document.getElementById("backToTop");
         var coverBtn = document.getElementById("backToTopCover");
+        var phoneBtn = document.getElementById("backToTopPhone");
+        var phoneBar = document.getElementById("tablePhoneSticky");
         var tableWrap = document.getElementById("tableWrap");
-        if (!btn && !coverBtn) return;
+        if (!btn && !coverBtn && !phoneBtn) return;
         var jumpTop = function () {
           // Instant jump - smooth-scrolling a 1700-row table forces a paint per
           // animation frame and stalls for seconds. Snap to top instead.
@@ -2051,11 +2137,25 @@
             var stuck = r.top <= 0 && r.bottom > 80;
             coverBtn.classList.toggle("show", stuck);
           }
+          if (phoneBtn && tableWrap && phoneBar && !phoneBar.hidden) {
+            // Phone card mode hides thead (and #backToTopCover). Mirror pin
+            // detection against the LIBRARY sticky strip bottom (includes
+            // safe-area inset top) instead of height alone.
+            var pr = tableWrap.getBoundingClientRect();
+            var barBottom = phoneBar.getBoundingClientRect().bottom || 36;
+            phoneBtn.classList.toggle(
+              "show",
+              pr.top <= barBottom + 1 && pr.bottom > 80
+            );
+          } else if (phoneBtn) {
+            phoneBtn.classList.remove("show");
+          }
         };
         window.addEventListener("scroll", sync, { passive: true });
         window.addEventListener("resize", sync, { passive: true });
         if (btn) btn.addEventListener("click", jumpTop);
         if (coverBtn) coverBtn.addEventListener("click", jumpTop);
+        if (phoneBtn) phoneBtn.addEventListener("click", jumpTop);
         sync();
       })();
     </script>
@@ -3088,7 +3188,8 @@
         </div>
         <p class="px-3 pt-2 text-xs text-slate-400">
           Show or hide columns for the current view. Game, Status, and the row
-          checkbox always stay visible.
+          checkbox always stay visible. Checked columns stay shown even when the
+          table auto-hides extras to fit a narrower window.
         </p>
         <div
           id="columnsList"
@@ -3119,6 +3220,67 @@
             class="px-3 py-1.5 rounded bg-slate-700 hover:bg-slate-600"
           >
             Close
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Notes editor (when Notes column is density- or phone-hidden) -->
+    <div
+      id="notesDialogModal"
+      class="app-modal fixed inset-0 bg-black/70 z-50 hidden items-center justify-center p-4"
+      role="presentation"
+    >
+      <div
+        class="bg-slate-800 rounded-lg shadow-xl border border-slate-700 w-full max-w-md flex flex-col"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="notesDialogTitle"
+      >
+        <div
+          class="flex items-center justify-between border-b border-slate-700 p-3"
+        >
+          <h3
+            id="notesDialogTitle"
+            class="text-lg font-semibold text-slate-100 truncate pr-2"
+          >
+            Notes
+          </h3>
+          <button
+            id="notesDialogClose"
+            type="button"
+            class="text-slate-400 hover:text-slate-100 text-2xl leading-none px-2"
+            aria-label="Close"
+          >
+            &times;
+          </button>
+        </div>
+        <div class="p-3">
+          <label class="sr-only" for="notesDialogInput">Personal notes</label>
+          <textarea
+            id="notesDialogInput"
+            rows="6"
+            class="notes-dialog-input w-full rounded text-sm px-2 py-1.5"
+            placeholder="Notes..."
+            title="Personal notes - saved when you click Save"
+          ></textarea>
+        </div>
+        <div
+          class="border-t border-slate-700 p-3 flex justify-end gap-2 text-sm"
+        >
+          <button
+            type="button"
+            id="notesDialogCancel"
+            class="px-3 py-1.5 rounded bg-slate-700 hover:bg-slate-600"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            id="notesDialogSave"
+            class="px-3 py-1.5 rounded bg-sky-600 hover:bg-sky-500 text-white"
+          >
+            Save
           </button>
         </div>
       </div>

--- a/js/app.js
+++ b/js/app.js
@@ -229,6 +229,10 @@ async function bootstrap() {
   document.body.classList.toggle("row-hero-on", !!state.prefs.rowHeroBackdrop);
   syncCheckboxLabelTitles();
   applyColumnVisibility(state.activeView);
+  // Density observer is started from bind-events; sync once after prefs apply.
+  import("./table-density.js").then(({ scheduleTableDensitySync }) => {
+    scheduleTableDensitySync((v) => applyColumnVisibility(v), state.activeView);
+  });
   const genreModeEl = document.getElementById("genreMode");
   if (genreModeEl) genreModeEl.value = state.prefs.genreFilterMode;
   const quickWinMaxEl = document.getElementById("quickWinMax");

--- a/js/bind-events.js
+++ b/js/bind-events.js
@@ -45,9 +45,14 @@ import {
   cancelPendingScrollTarget,
   clearRowAdAnchor,
   initTablePhoneLayout,
+  initTableDensity,
   syncSponsoredTableAfterDismiss,
   syncRowCountLabel,
 } from './table-ui.js';
+import {
+  bindNotesDialog,
+  handleNotesAffordanceClick,
+} from './notes-dialog.js';
 import {
   renderPicks,
   normalizePicksLimit,
@@ -105,6 +110,7 @@ import { reloadGames } from './library-load.js';
 import { bindAddGameModal } from './add-game-modal.js';
 import { openBugReportDialog } from './bug-report.js';
 import { initFullscreenToggle } from './fullscreen-toggle.js';
+import { initHeaderNavMenu } from './header-nav-menu.js';
 import { reportError } from './error-boundary.js';
 import { bindOrphanPruneUI } from './orphan-prune.js';
 import { bindHiddenPanelUI, openHiddenPanel } from './hidden-panel.js';
@@ -753,11 +759,8 @@ export function bindEvents() {
     if (tr) preloadRowHeroEl(tr);
   });
   document.getElementById("tbody").addEventListener("click", e => {
-    const notesDot = e.target.closest(".has-notes-dot");
-    if (notesDot) {
+    if (handleNotesAffordanceClick(e.target)) {
       e.stopPropagation();
-      const tr = notesDot.closest("tr[data-row-key]");
-      tr?.querySelector(".notes-input")?.focus();
       return;
     }
     const coverEl = e.target.closest(".cover-wrap, .cover");
@@ -769,7 +772,7 @@ export function bindEvents() {
         return;
       }
     }
-    if (!e.target.closest("select, input, a, button, [data-hltb-edit], .has-notes-dot")) {
+    if (!e.target.closest("select, input, a, button, [data-hltb-edit], .has-notes-dot, .notes-open-btn")) {
       const tr = e.target.closest("tr[data-row-key]");
       if (tr) {
         state.focusedRowIndex = Number(tr.dataset.rowIndex || -1);
@@ -981,4 +984,7 @@ export function bindEvents() {
     e.target.value = "";
   });
   initTablePhoneLayout();
+  initTableDensity();
+  bindNotesDialog();
+  initHeaderNavMenu();
 }

--- a/js/column-picker.js
+++ b/js/column-picker.js
@@ -10,6 +10,7 @@ import {
   showAllColumns,
   applyColumnVisibility,
 } from './table-columns.js';
+import { scheduleTableDensitySync } from './table-density.js';
 
 const MODAL_ID = 'columnsModal';
 const LIST_ID = 'columnsList';
@@ -42,6 +43,7 @@ function render() {
 function persistAndApply(view) {
   savePrefs();
   applyColumnVisibility(view);
+  scheduleTableDensitySync((v) => applyColumnVisibility(v), view);
 }
 
 function open() {

--- a/js/connections.js
+++ b/js/connections.js
@@ -730,6 +730,11 @@ function handleLayoutClick(ev) {
     _selectedKey = railItem.dataset.provider;
 
     renderConnections();
+    queueMicrotask(() => {
+      document
+        .querySelector(".conn-rail-item.is-selected")
+        ?.scrollIntoView({ inline: "nearest", block: "nearest" });
+    });
   }
 }
 
@@ -781,6 +786,9 @@ function handleLayoutKeydown(ev) {
   document
     .querySelector(`.conn-rail-item[data-provider="${_selectedKey}"]`)
     ?.focus();
+  document
+    .querySelector(".conn-rail-item.is-selected")
+    ?.scrollIntoView({ inline: "nearest", block: "nearest" });
 }
 
 function wireGridEvents() {

--- a/js/covers.js
+++ b/js/covers.js
@@ -122,11 +122,51 @@ function assignPortraitAnimClass(spot) {
   spot.classList.add(`portrait-anim-${1 + Math.floor(Math.random() * PORTRAIT_ANIM_COUNT)}`);
 }
 const LOWRES_FACTOR = 0.7;
+/* Match app.css stacked-spotlight ladder (max-width: 1023.98px). Inline
+   object-position from this helper beats stylesheet rules, so stacked cover
+   offset must be stamped here (portrait defaults to center; low-res to 100%). */
+const SPOTLIGHT_STACK_MQ = "(max-width: 1023.98px)";
+const SPOTLIGHT_STACK_ART_POS = "66% 40%";
+const SPOTLIGHT_LOWRES_DESKTOP_POS = "100% 40%";
+
+function spotlightStackedArtPos() {
+  try {
+    return window.matchMedia?.(SPOTLIGHT_STACK_MQ)?.matches
+      ? SPOTLIGHT_STACK_ART_POS
+      : "";
+  } catch {
+    return "";
+  }
+}
+
+function reapplyAllSpotlightArtFits() {
+  document
+    .querySelectorAll(".dash-spotlight .dash-spotlight-art")
+    .forEach((img) => {
+      if (img.naturalWidth) window.applySpotlightArtFit(img);
+    });
+}
+
+let _spotlightStackMqWired = false;
+function wireSpotlightStackArtPos() {
+  if (_spotlightStackMqWired || typeof window.matchMedia !== "function") return;
+  _spotlightStackMqWired = true;
+  const mq = window.matchMedia(SPOTLIGHT_STACK_MQ);
+  const onChange = () => reapplyAllSpotlightArtFits();
+  if (typeof mq.addEventListener === "function") {
+    mq.addEventListener("change", onChange);
+  } else if (typeof mq.addListener === "function") {
+    mq.addListener(onChange);
+  }
+}
+
 window.applySpotlightArtFit = function (img) {
   if (!img?.naturalWidth) return;
+  wireSpotlightStackArtPos();
   const ratio = img.naturalWidth / img.naturalHeight;
   const crop = spotlightCropForAspect(ratio);
-  img.style.objectPosition = crop.pos;
+  const stackPos = spotlightStackedArtPos();
+  img.style.objectPosition = stackPos || crop.pos;
   const spot = img.closest(".dash-spotlight");
   if (!spot) return;
   const bg = spot.querySelector(".dash-spotlight-art-bg");
@@ -135,6 +175,7 @@ window.applySpotlightArtFit = function (img) {
 
   if (crop.portrait && bg) {
     img.style.objectFit = crop.fit;
+    img.style.objectPosition = stackPos || crop.pos;
     if (src && bg.src !== src) bg.src = src;
     spot.classList.add("has-portrait-art");
     spot.classList.remove("is-lowres-art");
@@ -155,9 +196,9 @@ window.applySpotlightArtFit = function (img) {
 
     if (lowRes && bg) {
       img.style.objectFit = "contain";
-      // Contained low-res art is pillarboxed; pin its right edge to the
-      // container's right edge (inline wins over the stylesheet rule).
-      img.style.objectPosition = "100% 40%";
+      // Contained low-res art is pillarboxed; desktop pins right edge, stacked
+      // parks ~2/3 across (inline wins over the stylesheet rule).
+      img.style.objectPosition = stackPos || SPOTLIGHT_LOWRES_DESKTOP_POS;
       if (src && bg.src !== src) bg.src = src;
       spot.classList.add("is-lowres-art");
       bg.classList.add("is-loaded");

--- a/js/dashboard-charts.js
+++ b/js/dashboard-charts.js
@@ -1313,7 +1313,10 @@ export function renderDashboardCharts(games, aggIn) {
       ],
     },
     options: dashChartOptions({
-      animation: { duration: 400, easing: "easeOutQuart" },
+      animation: {
+        duration: prefersReducedMotion() ? 0 : 400,
+        easing: "easeOutQuart",
+      },
       plugins: {
         legend: {
           display: true,

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -50,7 +50,7 @@ import { commitRenderedMetrics, restoreNotedMetricKeysFromArtifacts, snapshotNot
 import { connectedProviderCount, authStatusLoaded } from './connections.js';
 import { getLibrarySnapshot } from './sabermetrics.js';
 import { THEME_CHANGE_EVENT } from './theme.js';
-import { storeLogoStripHtml } from './store-logos.js';
+import { observeHeroStoreStrip, storeLogoStripHtml } from './store-logos.js';
 
 // Re-exports — dashboard.js stays the single public entry point for the
 // dashboard surface. External callers (app.js / bind-events.js / etc.)
@@ -309,6 +309,7 @@ function updateDashboardMegaInPlace(games, stats, spotlight, spotlightPool, marq
       ? storeLogoStripHtml(stats.storeKeys, { size: 'md' })
       : '';
     storeStrip.hidden = !stats.storeKeys.length;
+    if (stats.storeKeys.length) observeHeroStoreStrip(storeStrip);
   }
   const countHost = el.querySelector('.library-count-host, #dashHeroCount');
   if (countHost) countHost.title = 'Total games in your merged library across all connected stores';
@@ -420,6 +421,8 @@ function renderDashboardMega(games, snap, agg) {
 
   applyMegaHeroCounters(stats);
   primeSpotlightArt(document.getElementById('dashboardSpotlight'));
+  const storeHost = el.querySelector('.dash-hero-stores');
+  if (storeHost && !storeHost.hidden) observeHeroStoreStrip(storeHost);
   startInsightRotation(insightPool);
   commitRenderedMetrics();
   startSpotlightRotation(spotlightPool);

--- a/js/fetcher/runner/index.js
+++ b/js/fetcher/runner/index.js
@@ -410,6 +410,36 @@ export const fetcherRunner = (() => {
   }
 
   let fetcherPopoverRelease = null;
+  const FETCHER_SHEET_MQ =
+    '(max-width: 639.98px), (max-height: 480px) and (hover: none)';
+  let fetcherSheetMqWired = false;
+
+  function isFetcherSheetViewport() {
+    return typeof window !== 'undefined'
+      && typeof window.matchMedia === 'function'
+      && window.matchMedia(FETCHER_SHEET_MQ).matches;
+  }
+
+  /** Phone: fullscreen sheet class. Tablet/desktop keep anchored popover math-free CSS. */
+  function syncFetcherPopoverSheetClass(pop = fetcherPopoverEl()) {
+    if (!pop) return;
+    pop.classList.toggle('fetcher-popover--sheet', isFetcherSheetViewport());
+  }
+
+  function ensureFetcherSheetMq() {
+    if (fetcherSheetMqWired || typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+    fetcherSheetMqWired = true;
+    const mq = window.matchMedia(FETCHER_SHEET_MQ);
+    const onChange = () => {
+      const pop = fetcherPopoverEl();
+      if (!pop || pop.hidden) return;
+      syncFetcherPopoverSheetClass(pop);
+    };
+    if (mq.addEventListener) mq.addEventListener('change', onChange);
+    else mq.addListener(onChange);
+  }
 
   function hideFetcherPopover() {
     fetcherPopoverRelease?.();
@@ -418,7 +448,10 @@ export const fetcherRunner = (() => {
     const bd = document.getElementById('fetcherPopoverBackdrop');
     const pill = document.getElementById('fetcherGlobalStatus');
     if (bd) bd.hidden = true;
-    if (pop) pop.hidden = true;
+    if (pop) {
+      pop.hidden = true;
+      pop.classList.remove('fetcher-popover--sheet');
+    }
     if (pill) pill.setAttribute('aria-expanded', 'false');
     // Collapse the log console drawer so reopening the fetcher starts tidy.
     const panel = logPanel();
@@ -436,6 +469,8 @@ export const fetcherRunner = (() => {
     const pop = fetcherPopoverEl();
     const bd = document.getElementById('fetcherPopoverBackdrop');
     if (!pop || !bd) return false;
+    ensureFetcherSheetMq();
+    syncFetcherPopoverSheetClass(pop);
     bd.hidden = false;
     pop.hidden = false;
     const pill = document.getElementById('fetcherGlobalStatus');
@@ -639,7 +674,7 @@ export const fetcherRunner = (() => {
     else expandPanel({ manual });
   }
 
-  const LOG_DESKTOP_MQ = '(min-width: 768px)';
+  const LOG_DESKTOP_MQ = '(min-width: 1024px)';
   let logHeightCardObs = null;
   let logHeightResizeWired = false;
 
@@ -1973,6 +2008,8 @@ export const fetcherRunner = (() => {
     toggleFetcherPopover,
     openFetcherLog,
     isFetcherPopoverOpen,
+    isFetcherSheetViewport,
+    syncFetcherPopoverSheetClass,
     setBarSummary(text) {
       lastBarSummary = text;
     },

--- a/js/header-nav-menu.js
+++ b/js/header-nav-menu.js
@@ -1,0 +1,239 @@
+/**
+ * Main-view hamburger: collapses header tabs into a left sheet when the
+ * tablet ladder matches OR the inline header would wrap (fit check).
+ * Sheet also hosts Report bug + profile; fullscreen is CSS-hidden.
+ */
+import { bindEscapeClose, trapFocus } from './focus-trap.js';
+
+const TABLET_MQ = '(max-width: 1023.98px)';
+const SHEET_CLASS = 'header-nav-sheet';
+
+let releaseTrap = null;
+let releaseEsc = null;
+let fitRaf = 0;
+
+function isTabletMq() {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia(TABLET_MQ).matches;
+}
+
+function isSheetMode() {
+  return document.documentElement.classList.contains(SHEET_CLASS);
+}
+
+function els() {
+  return {
+    toggle: document.getElementById('headerNavToggle'),
+    backdrop: document.getElementById('headerNavBackdrop'),
+    panel: document.getElementById('headerNavPanel'),
+    wrap: document.getElementById('appHeaderNavWrap'),
+    extras: document.getElementById('headerNavSheetExtras'),
+    actions: document.querySelector('.app-header-actions'),
+    row: document.querySelector('.app-header-row'),
+    brand: document.querySelector('.app-header-brand'),
+    nav: document.getElementById('appHeaderNav'),
+    reportBug: document.getElementById('reportBugHeader'),
+    profileWrap: document.getElementById('profileMenuWrap'),
+    fullscreen: document.getElementById('headerFullscreenBtn'),
+  };
+}
+
+/** Put bug + profile back in the header actions (after fullscreen). */
+function parkExtrasInActions() {
+  const { actions, extras, reportBug, profileWrap, fullscreen } = els();
+  if (!actions) return;
+  const anchor = fullscreen?.nextSibling ?? null;
+  if (reportBug && reportBug.parentElement !== actions) {
+    actions.insertBefore(reportBug, anchor);
+  }
+  if (profileWrap && profileWrap.parentElement !== actions) {
+    actions.appendChild(profileWrap);
+  }
+  if (extras) extras.hidden = true;
+}
+
+/** Move bug + profile into the sheet footer. */
+function parkExtrasInSheet() {
+  const { extras, reportBug, profileWrap } = els();
+  if (!extras) return;
+  if (reportBug) extras.appendChild(reportBug);
+  if (profileWrap) extras.appendChild(profileWrap);
+  extras.hidden = false;
+}
+
+export function isHeaderNavMenuOpen() {
+  const { panel } = els();
+  return !!(panel && !panel.hidden && panel.getAttribute('aria-modal') === 'true');
+}
+
+export function closeHeaderNavMenu() {
+  const { toggle, backdrop, panel, wrap } = els();
+  releaseTrap?.();
+  releaseTrap = null;
+  releaseEsc?.();
+  releaseEsc = null;
+  if (backdrop) backdrop.hidden = true;
+  if (panel) {
+    panel.hidden = isSheetMode();
+    panel.removeAttribute('role');
+    panel.removeAttribute('aria-modal');
+    panel.removeAttribute('aria-label');
+  }
+  wrap?.classList.remove('is-open');
+  if (toggle) {
+    toggle.setAttribute('aria-expanded', 'false');
+    toggle.setAttribute('aria-label', 'Open menu');
+    toggle.title = 'Menu';
+  }
+}
+
+export function openHeaderNavMenu() {
+  if (!isSheetMode()) return false;
+  const { toggle, backdrop, panel, wrap } = els();
+  if (!panel || !toggle) return false;
+  if (backdrop) backdrop.hidden = false;
+  panel.hidden = false;
+  panel.setAttribute('role', 'dialog');
+  panel.setAttribute('aria-modal', 'true');
+  panel.setAttribute('aria-label', 'Main menu');
+  wrap?.classList.add('is-open');
+  toggle.setAttribute('aria-expanded', 'true');
+  toggle.setAttribute('aria-label', 'Close menu');
+  toggle.title = 'Close menu';
+  releaseTrap?.();
+  releaseEsc?.();
+  releaseTrap = trapFocus(panel);
+  releaseEsc = bindEscapeClose(panel, closeHeaderNavMenu);
+  const active = panel.querySelector('.view-tab.active') || panel.querySelector('.view-tab');
+  active?.focus({ preventScroll: true });
+  return true;
+}
+
+export function toggleHeaderNavMenu() {
+  if (isHeaderNavMenuOpen()) closeHeaderNavMenu();
+  else openHeaderNavMenu();
+}
+
+/**
+ * Measure whether brand + inline tabs + actions fit on one row.
+ * Temporarily forces inline layout for an accurate width check.
+ */
+function measureNeedsSheet() {
+  if (isTabletMq()) return true;
+  const { row, brand, nav, actions, toggle, panel } = els();
+  if (!row || !brand || !nav || !actions) return isTabletMq();
+
+  const wasOpen = isHeaderNavMenuOpen();
+  if (wasOpen) closeHeaderNavMenu();
+
+  const html = document.documentElement;
+  const wasSheet = html.classList.contains(SHEET_CLASS);
+  parkExtrasInActions();
+  html.classList.remove(SHEET_CLASS);
+
+  const prevToggleHidden = toggle?.hidden;
+  const prevPanelHidden = panel?.hidden;
+  if (toggle) toggle.hidden = true;
+  if (panel) panel.hidden = false;
+
+  void row.offsetWidth;
+  const styles = getComputedStyle(row);
+  const gapX = parseFloat(styles.columnGap || styles.gap || '0') || 0;
+  // Two gaps between three flex children (brand | nav | actions).
+  const need =
+    brand.getBoundingClientRect().width
+    + nav.scrollWidth
+    + actions.getBoundingClientRect().width
+    + gapX * 2;
+  const avail = row.clientWidth;
+
+  if (toggle) toggle.hidden = prevToggleHidden ?? true;
+  if (panel && prevPanelHidden != null) panel.hidden = prevPanelHidden;
+  if (wasSheet) html.classList.add(SHEET_CLASS);
+
+  // Hysteresis so resize does not flap between inline and sheet.
+  if (wasSheet) return need > avail - 24;
+  return need > avail + 1;
+}
+
+function applySheetMode(on) {
+  const html = document.documentElement;
+  const { panel, toggle } = els();
+  const wasOpen = isHeaderNavMenuOpen();
+
+  if (on) {
+    html.classList.add(SHEET_CLASS);
+    parkExtrasInSheet();
+    if (toggle) toggle.hidden = false;
+    if (!wasOpen && panel) {
+      panel.hidden = true;
+      panel.removeAttribute('role');
+      panel.removeAttribute('aria-modal');
+      panel.removeAttribute('aria-label');
+    }
+  } else {
+    if (wasOpen) closeHeaderNavMenu();
+    parkExtrasInActions();
+    html.classList.remove(SHEET_CLASS);
+    if (panel) {
+      panel.hidden = false;
+      panel.removeAttribute('role');
+      panel.removeAttribute('aria-modal');
+      panel.removeAttribute('aria-label');
+    }
+    if (toggle) {
+      toggle.hidden = true;
+      toggle.setAttribute('aria-expanded', 'false');
+      toggle.setAttribute('aria-label', 'Open menu');
+    }
+  }
+}
+
+function syncSheetMode() {
+  applySheetMode(measureNeedsSheet());
+}
+
+function scheduleFitSync() {
+  if (fitRaf) cancelAnimationFrame(fitRaf);
+  fitRaf = requestAnimationFrame(() => {
+    fitRaf = 0;
+    syncSheetMode();
+  });
+}
+
+export function initHeaderNavMenu() {
+  const { toggle, backdrop, panel } = els();
+  if (!toggle || !panel) return;
+
+  toggle.addEventListener('click', (e) => {
+    e.stopPropagation();
+    toggleHeaderNavMenu();
+  });
+  backdrop?.addEventListener('click', () => closeHeaderNavMenu());
+  panel.addEventListener('click', (e) => {
+    if (e.target.closest('.view-tab')) closeHeaderNavMenu();
+  });
+
+  syncSheetMode();
+
+  window.addEventListener('resize', scheduleFitSync, { passive: true });
+  if (typeof ResizeObserver === 'function') {
+    const row = document.querySelector('.app-header-row');
+    if (row) {
+      const ro = new ResizeObserver(() => scheduleFitSync());
+      ro.observe(row);
+    }
+  }
+  if (typeof window.matchMedia === 'function') {
+    const mq = window.matchMedia(TABLET_MQ);
+    const onChange = () => scheduleFitSync();
+    if (mq.addEventListener) mq.addEventListener('change', onChange);
+    else mq.addListener(onChange);
+  }
+}
+
+/** @internal Vitest */
+export function headerNavSheetClassForTest() {
+  return SHEET_CLASS;
+}

--- a/js/notes-dialog.js
+++ b/js/notes-dialog.js
@@ -1,0 +1,119 @@
+/**
+ * Compact notes editor when the Notes table column is density- or phone-hidden.
+ */
+import { findGameByKey } from './game-core.js';
+import { getPersonal, setPersonal } from './personal-storage.js';
+import { isNotesColumnEffectivelyVisible } from './table-density.js';
+import { escapeAttr } from './dom-util.js';
+import { bindEscapeClose, trapFocus } from './focus-trap.js';
+
+const MODAL_ID = 'notesDialogModal';
+let _release = null;
+let _activeKey = null;
+
+function el(id) {
+  return document.getElementById(id);
+}
+
+export function notesAffordanceHtml(key, notesText) {
+  if (isNotesColumnEffectivelyVisible()) {
+    const notes = String(notesText || '').trim();
+    if (!notes) return '';
+    return `<span class="has-notes-dot" data-notes-key="${escapeAttr(key)}" title="${escapeAttr(notes.slice(0, 160))} - click to edit notes" aria-label="Has notes">&#9998; note</span>`;
+  }
+  const notes = String(notesText || '').trim();
+  if (notes) {
+    return `<button type="button" class="has-notes-dot notes-open-btn" data-notes-key="${escapeAttr(key)}" title="${escapeAttr(notes.slice(0, 160))} - edit notes" aria-label="Edit notes">&#9998; note</button>`;
+  }
+  return `<button type="button" class="notes-open-btn notes-open-btn--empty" data-notes-key="${escapeAttr(key)}" title="Add notes" aria-label="Add notes">+ note</button>`;
+}
+
+export function openNotesDialog(key) {
+  const modal = el(MODAL_ID);
+  const input = el('notesDialogInput');
+  const title = el('notesDialogTitle');
+  if (!modal || !input) return;
+  const g = findGameByKey(key);
+  if (!g) return;
+  _activeKey = key;
+  const name = g.name || 'Game';
+  if (title) title.textContent = `Notes - ${name}`;
+  input.value = getPersonal(g).notes || '';
+  modal.classList.remove('hidden');
+  modal.classList.add('flex');
+  _release?.();
+  const dialog = modal.querySelector('[role="dialog"]') || modal;
+  const releaseTrap = trapFocus(dialog);
+  const releaseEsc = bindEscapeClose(dialog, closeNotesDialog);
+  _release = () => {
+    releaseTrap();
+    releaseEsc();
+    _release = null;
+  };
+  input.focus();
+  input.setSelectionRange(input.value.length, input.value.length);
+}
+
+export function closeNotesDialog() {
+  _release?.();
+  const modal = el(MODAL_ID);
+  if (modal) {
+    modal.classList.add('hidden');
+    modal.classList.remove('flex');
+  }
+  _activeKey = null;
+}
+
+function saveAndClose() {
+  const key = _activeKey;
+  const input = el('notesDialogInput');
+  if (!key || !input) {
+    closeNotesDialog();
+    return;
+  }
+  const g = findGameByKey(key);
+  if (g) setPersonal(g, 'notes', input.value);
+  // Refresh affordance / notes cell without a full table rebuild when possible
+  const row = document.querySelector(`tr[data-row-key="${CSS.escape(key)}"]`);
+  const meta = row?.querySelector('.row-meta');
+  if (meta) {
+    meta.querySelectorAll('.has-notes-dot, .notes-open-btn').forEach((n) => n.remove());
+    meta.insertAdjacentHTML('beforeend', notesAffordanceHtml(key, input.value));
+  }
+  const ta = row?.querySelector('.notes-input');
+  if (ta) ta.value = input.value;
+  closeNotesDialog();
+}
+
+export function bindNotesDialog() {
+  el('notesDialogClose')?.addEventListener('click', closeNotesDialog);
+  el('notesDialogCancel')?.addEventListener('click', closeNotesDialog);
+  el('notesDialogSave')?.addEventListener('click', saveAndClose);
+  el(MODAL_ID)?.addEventListener('click', (e) => {
+    if (e.target.id === MODAL_ID) closeNotesDialog();
+  });
+  el('notesDialogInput')?.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault();
+      saveAndClose();
+    }
+  });
+}
+
+/** Click handler for notes chips / + note buttons. */
+export function handleNotesAffordanceClick(target) {
+  const btn = target.closest('[data-notes-key], .has-notes-dot, .notes-open-btn');
+  if (!btn) return false;
+  const key = btn.dataset.notesKey
+    || btn.closest('tr')?.dataset.rowKey;
+  if (!key) return false;
+  if (isNotesColumnEffectivelyVisible()) {
+    const ta = btn.closest('tr')?.querySelector('.notes-input');
+    if (ta) {
+      ta.focus();
+      return true;
+    }
+  }
+  openNotesDialog(key);
+  return true;
+}

--- a/js/store-logos.js
+++ b/js/store-logos.js
@@ -187,3 +187,66 @@ export function storeLogoStripHtml(stores, { size = 'md', max = 12 } = {}) {
   if (!keys.length) return '';
   return `<div class="store-logo-strip store-logo-strip--${size}" role="list" aria-label="Stores in your library">${keys.map(k => `<span role="listitem">${storeGlyphHtml(k, { size, title: storeDisplayName(k) })}</span>`).join('')}</div>`;
 }
+
+/**
+ * Column count that keeps wrapped rows balanced.
+ * e.g. 12 items with max 11/row → 6 (6+6), not 11+1.
+ */
+export function balancedWrapColumns(count, maxPerRow) {
+  const n = Math.max(0, Math.floor(Number(count) || 0));
+  const max = Math.max(0, Math.floor(Number(maxPerRow) || 0));
+  if (n <= 0) return 0;
+  if (max <= 0 || max >= n) return n;
+  const rows = Math.ceil(n / max);
+  return Math.ceil(n / rows);
+}
+
+/** Snap a rendered `.store-logo-strip` to balanced grid columns for its host width. */
+export function snapStoreLogoStrip(strip) {
+  if (!strip) return;
+  const items = strip.querySelectorAll(':scope > [role="listitem"]');
+  const n = items.length;
+  if (n <= 1) {
+    strip.classList.remove('is-balanced-wrap');
+    strip.style.removeProperty('--store-strip-cols');
+    return;
+  }
+  const host = strip.parentElement || strip;
+  const itemW = items[0].getBoundingClientRect().width;
+  if (!(itemW > 0)) {
+    strip.classList.remove('is-balanced-wrap');
+    strip.style.removeProperty('--store-strip-cols');
+    return;
+  }
+  const styles = getComputedStyle(strip);
+  const gap = parseFloat(styles.columnGap || styles.gap) || 0;
+  const avail = host.clientWidth || strip.clientWidth;
+  if (!(avail > 0)) return;
+  const maxPerRow = Math.max(1, Math.floor((avail + gap) / (itemW + gap)));
+  const cols = balancedWrapColumns(n, maxPerRow);
+  if (cols >= n) {
+    strip.classList.remove('is-balanced-wrap');
+    strip.style.removeProperty('--store-strip-cols');
+    return;
+  }
+  strip.style.setProperty('--store-strip-cols', String(cols));
+  strip.classList.add('is-balanced-wrap');
+}
+
+const _heroStoreStripObs = new WeakMap();
+
+/** Observe `.dash-hero-stores` and re-snap the logo strip on resize. */
+export function observeHeroStoreStrip(host) {
+  if (!host) return;
+  const run = () => snapStoreLogoStrip(host.querySelector('.store-logo-strip'));
+  if (typeof ResizeObserver === 'function' && !_heroStoreStripObs.has(host)) {
+    const ro = new ResizeObserver(() => run());
+    _heroStoreStripObs.set(host, ro);
+    ro.observe(host);
+  }
+  if (typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(run);
+  } else {
+    run();
+  }
+}

--- a/js/table-columns.js
+++ b/js/table-columns.js
@@ -1,4 +1,11 @@
 import { state } from './state.js';
+import {
+  densityWouldHide,
+  getDensityTier,
+  clearDensityPins,
+  pinAllDensityColumns,
+  setDensityPinned,
+} from './table-density.js';
 
 export const TABLE_VIEWS = ['library', 'wishlist', 'itch'];
 
@@ -60,22 +67,41 @@ export function setColumnVisible(view, id, on) {
     state.prefs.columns[vk] = {};
   }
   state.prefs.columns[vk][id] = !!on;
+  // Explicit show pins against density; hide clears the pin.
+  setDensityPinned(view, id, !!on);
 }
 
 export function resetColumns(view) {
   ensureColumnsPrefs();
   state.prefs.columns[viewKey(view)] = {};
+  clearDensityPins(view);
 }
 
 export function showAllColumns(view) {
-  for (const col of toggleableColumns()) setColumnVisible(view, col.id, true);
+  for (const col of toggleableColumns()) {
+    ensureColumnsPrefs();
+    const vk = viewKey(view);
+    if (!state.prefs.columns[vk] || typeof state.prefs.columns[vk] !== 'object') {
+      state.prefs.columns[vk] = {};
+    }
+    state.prefs.columns[vk][col.id] = true;
+  }
+  pinAllDensityColumns(view);
 }
 
-export function applyColumnVisibility(view) {
+/**
+ * Apply table-hide-* from prefs + current density tier.
+ * @param {string} view
+ * @param {{ skipDensity?: boolean }} [opts]
+ */
+export function applyColumnVisibility(view, opts = {}) {
   const wrap = document.getElementById('tableWrap');
   if (!wrap) return;
+  const tier = opts.skipDensity ? 0 : getDensityTier();
   for (const col of toggleableColumns()) {
-    wrap.classList.toggle(`table-hide-${col.id}`, !isColumnVisible(view, col.id));
+    const userHide = !isColumnVisible(view, col.id);
+    const densityHide = !opts.skipDensity && densityWouldHide(view, col.id, tier);
+    wrap.classList.toggle(`table-hide-${col.id}`, userHide || densityHide);
   }
 }
 
@@ -83,6 +109,9 @@ export function applyColumnVisibility(view) {
 export function migrateColumnPrefs(merged) {
   if (!merged.columns || typeof merged.columns !== 'object') {
     merged.columns = {};
+  }
+  if (!merged.columnDensityPins || typeof merged.columnDensityPins !== 'object') {
+    merged.columnDensityPins = {};
   }
   const hadScore = merged.showScoreColumn;
   const hadMc = merged.showMetacriticColumn;

--- a/js/table-density.js
+++ b/js/table-density.js
@@ -1,0 +1,191 @@
+/**
+ * Mid-width table density: auto-hide low-priority columns so the library table
+ * fits without #tableWrap overflow-x:auto (which kills sticky thead).
+ */
+import { state } from './state.js';
+
+export const TABLE_DENSITY_VIEWS = ['library', 'wishlist', 'itch'];
+
+/** Hide order: tier N includes all columns from tiers 1..N.
+ *  Aggressive: free room for the Game title before other metrics. */
+export const DENSITY_TIER_COLUMNS = [
+  [],
+  ['notes', 'genres'],
+  ['notes', 'genres', 'lastplayed', 'released'],
+  ['notes', 'genres', 'lastplayed', 'released', 'price', 'mc', 'score'],
+  ['notes', 'genres', 'lastplayed', 'released', 'price', 'mc', 'score', 'steam'],
+  ['notes', 'genres', 'lastplayed', 'released', 'price', 'mc', 'score', 'steam', 'played'],
+  ['notes', 'genres', 'lastplayed', 'released', 'price', 'mc', 'score', 'steam', 'played', 'hltb'],
+];
+
+export const DENSITY_MAX_TIER = DENSITY_TIER_COLUMNS.length - 1;
+
+/** Game title column must stay at least this wide (px) or density bumps. */
+export const GAME_TITLE_MIN_PX = 168;
+
+let _densityTier = 0;
+let _densityObs = null;
+let _densityRaf = 0;
+
+function viewKey(view) {
+  return TABLE_DENSITY_VIEWS.includes(view) ? view : 'library';
+}
+
+export function ensureDensityPinPrefs() {
+  if (!state.prefs.columnDensityPins || typeof state.prefs.columnDensityPins !== 'object') {
+    state.prefs.columnDensityPins = {};
+  }
+}
+
+export function isDensityPinned(view, id) {
+  ensureDensityPinPrefs();
+  return !!state.prefs.columnDensityPins[viewKey(view)]?.[id];
+}
+
+export function setDensityPinned(view, id, on) {
+  ensureDensityPinPrefs();
+  const vk = viewKey(view);
+  if (!state.prefs.columnDensityPins[vk] || typeof state.prefs.columnDensityPins[vk] !== 'object') {
+    state.prefs.columnDensityPins[vk] = {};
+  }
+  if (on) state.prefs.columnDensityPins[vk][id] = true;
+  else delete state.prefs.columnDensityPins[vk][id];
+}
+
+export function clearDensityPins(view) {
+  ensureDensityPinPrefs();
+  state.prefs.columnDensityPins[viewKey(view)] = {};
+}
+
+export function pinAllDensityColumns(view) {
+  ensureDensityPinPrefs();
+  const pins = {};
+  for (const id of [
+    'cover', 'score', 'played', 'hltb', 'steam', 'mc', 'price',
+    'released', 'lastplayed', 'genres', 'notes',
+  ]) {
+    pins[id] = true;
+  }
+  state.prefs.columnDensityPins[viewKey(view)] = pins;
+}
+
+export function getDensityTier() {
+  return _densityTier;
+}
+
+export function setDensityTier(tier) {
+  _densityTier = Math.max(0, Math.min(DENSITY_MAX_TIER, Math.floor(Number(tier) || 0)));
+  return _densityTier;
+}
+
+/** Columns density would hide at the given tier (ignoring pins / prefs). */
+export function densityHideIdsForTier(tier) {
+  const t = Math.max(0, Math.min(DENSITY_MAX_TIER, Math.floor(Number(tier) || 0)));
+  return DENSITY_TIER_COLUMNS[t] || [];
+}
+
+/** True when density tier would hide this id and the user has not pinned it. */
+export function densityWouldHide(view, id, tier = _densityTier) {
+  if (!densityHideIdsForTier(tier).includes(id)) return false;
+  return !isDensityPinned(view, id);
+}
+
+export function applyDensityTierClass(wrap, tier) {
+  if (!wrap) return;
+  const t = setDensityTier(tier);
+  wrap.dataset.density = String(t);
+  for (let i = 1; i <= DENSITY_MAX_TIER; i++) {
+    wrap.classList.toggle(`table-density-${i}`, i === t);
+  }
+  wrap.classList.toggle('table-density', t > 0);
+}
+
+export function measureTableOverflow(wrap) {
+  if (!wrap) return false;
+  return wrap.scrollWidth > wrap.clientWidth + 2;
+}
+
+/** True when the Game title cell is crushed below the readable minimum. */
+export function measureGameTitleTooNarrow(wrap, minPx = GAME_TITLE_MIN_PX) {
+  if (!wrap) return false;
+  const cell = wrap.querySelector(
+    'tbody tr:not(.virtual-spacer):not(.table-empty-state-row):not(.sponsored-table-row) td.game-name-cell, '
+    + 'tbody tr:not(.virtual-spacer) td.col-game',
+  );
+  if (!cell) return false;
+  const w = cell.getBoundingClientRect().width;
+  return w > 0 && w < minPx;
+}
+
+/** Need a denser tier: horizontal overflow OR crushed title. */
+export function measureNeedsMoreDensity(wrap) {
+  return measureTableOverflow(wrap) || measureGameTitleTooNarrow(wrap);
+}
+
+/**
+ * @param {(view: string) => void} applyVisibility - applies table-hide-* for current tier
+ * @param {string} view
+ */
+export function syncTableDensity(applyVisibility, view = state.activeView) {
+  const wrap = document.getElementById('tableWrap');
+  if (!wrap) return 0;
+  if (wrap.classList.contains('table-phone') || !TABLE_DENSITY_VIEWS.includes(view)) {
+    applyDensityTierClass(wrap, 0);
+    applyVisibility?.(view);
+    return 0;
+  }
+
+  let tier = 0;
+  applyDensityTierClass(wrap, tier);
+  applyVisibility?.(view);
+  while (tier < DENSITY_MAX_TIER && measureNeedsMoreDensity(wrap)) {
+    tier += 1;
+    applyDensityTierClass(wrap, tier);
+    applyVisibility?.(view);
+  }
+  while (tier > 0) {
+    applyDensityTierClass(wrap, tier - 1);
+    applyVisibility?.(view);
+    if (measureNeedsMoreDensity(wrap)) {
+      applyDensityTierClass(wrap, tier);
+      applyVisibility?.(view);
+      break;
+    }
+    tier -= 1;
+  }
+  return getDensityTier();
+}
+
+export function scheduleTableDensitySync(applyVisibility, view = state.activeView) {
+  if (_densityRaf) cancelAnimationFrame(_densityRaf);
+  _densityRaf = requestAnimationFrame(() => {
+    _densityRaf = 0;
+    syncTableDensity(applyVisibility, view);
+  });
+}
+
+export function observeTableDensity(applyVisibility, viewGetter) {
+  const wrap = document.getElementById('tableWrap');
+  if (!wrap || typeof ResizeObserver !== 'function') return;
+  if (_densityObs) {
+    _densityObs.disconnect();
+    _densityObs = null;
+  }
+  _densityObs = new ResizeObserver(() => {
+    const view = typeof viewGetter === 'function' ? viewGetter() : state.activeView;
+    scheduleTableDensitySync(applyVisibility, view);
+  });
+  _densityObs.observe(wrap);
+  scheduleTableDensitySync(
+    applyVisibility,
+    typeof viewGetter === 'function' ? viewGetter() : state.activeView,
+  );
+}
+
+export function isNotesColumnEffectivelyVisible(view = state.activeView) {
+  const wrap = document.getElementById('tableWrap');
+  if (!wrap) return true;
+  if (wrap.classList.contains('table-phone')) return false;
+  if (wrap.classList.contains('table-hide-notes')) return false;
+  return true;
+}

--- a/js/table-ui.js
+++ b/js/table-ui.js
@@ -89,6 +89,12 @@ import {
   perfActiveRun,
 } from './table-perf.js';
 import { applyColumnVisibility } from './table-columns.js';
+import {
+  observeTableDensity,
+  scheduleTableDensitySync,
+  syncTableDensity,
+} from './table-density.js';
+import { notesAffordanceHtml } from './notes-dialog.js';
 
 // === Alpha nav + scroll ===
 export function initAlphaNav() {
@@ -446,21 +452,9 @@ export function updateHasNotesIndicatorInPlace(tr, g) {
   if (!tr) return;
   const meta = tr.querySelector(".row-meta");
   if (!meta) return;
-  const notes = String(getPersonal(g).notes || "").trim();
-  const dot = meta.querySelector(".has-notes-dot");
-  if (notes) {
-    const tooltip = `${notes.slice(0, 160)} - click to edit notes`;
-    if (dot) {
-      dot.title = tooltip;
-    } else {
-      meta.insertAdjacentHTML(
-        "beforeend",
-        `<span class="has-notes-dot" title="${escapeAttr(tooltip)}" aria-label="Has notes">&#9998; note</span>`,
-      );
-    }
-  } else if (dot) {
-    dot.remove();
-  }
+  const key = gameKey(g);
+  meta.querySelectorAll(".has-notes-dot, .notes-open-btn").forEach((n) => n.remove());
+  meta.insertAdjacentHTML("beforeend", notesAffordanceHtml(key, getPersonal(g).notes));
 }
 
 export function updateRowInPlace(tr, g) {
@@ -617,6 +611,11 @@ export function consumePendingScrollTarget(list = state._visibleList) {
   }
 
   if (t.kind === "row") {
+    // Cross-view drills: wait for picks/summary chrome like toolbar drills.
+    if (t.hideOverlay && !isToolbarScrollReady()) {
+      scheduleScrollAfterChromeSettled();
+      return false;
+    }
     const key = t.key;
     if (!key || !Array.isArray(list) || !list.length) {
       t.consumed = true;
@@ -637,7 +636,14 @@ export function consumePendingScrollTarget(list = state._visibleList) {
     setRowAdAnchor(idx);
 
     const row = ensureRowPaintedForScroll(list, idx, key);
-    if (usesVirtualScroll(list)) {
+    const phone = isTablePhoneLayout();
+    if (phone && row) {
+      // Variable-height card rows: live rect beats idx * rh spacer math.
+      markFocusedRow(key);
+      refreshMeasuredRowHeight(row.parentElement);
+      scrollRowToCenter(row, { smooth: !!t.smooth });
+      if (_pendingFlashKeys.has(key)) applyRowFlash(key);
+    } else if (usesVirtualScroll(list)) {
       // Virtual lists: position by deterministic index math (top-spacer height +
       // measured row height) instead of the freshly-painted row's rect. The giant
       // top spacer isn't always laid out when we measure two rAF after paint, so a
@@ -652,7 +658,7 @@ export function consumePendingScrollTarget(list = state._visibleList) {
       if (_pendingFlashKeys.has(key)) applyRowFlash(key);
     }
 
-    _lastConsumeWasSmooth = !!t.smooth && !!row && !usesVirtualScroll(list);
+    _lastConsumeWasSmooth = !!t.smooth && !!row && (phone || !usesVirtualScroll(list));
     t.consumed = true;
     _pendingScrollTarget = null;
     completeDrillOverlayIfNeeded(t.hideOverlay);
@@ -672,10 +678,10 @@ export function scheduleScrollAfterLayoutSettled() {
   });
 }
 
-/** Category drill-ins: wait for summary/picks chrome to stop resizing before scrolling. */
+/** Category / cross-view drills: wait for summary/picks chrome before scrolling. */
 export function scheduleScrollAfterChromeSettled() {
   const t = _pendingScrollTarget;
-  if (!t || t.consumed || t.kind !== 'toolbar') {
+  if (!t || t.consumed || (t.kind !== 'toolbar' && t.kind !== 'row')) {
     scheduleScrollAfterLayoutSettled();
     return;
   }
@@ -963,11 +969,51 @@ let _renderTableGen = 0;
 
 const TABLE_PHONE_MQ = '(max-width: 639.98px)';
 
+export function isTablePhoneLayout() {
+  const wrap = document.getElementById('tableWrap');
+  return !!wrap?.classList.contains('table-phone');
+}
+
+function syncTablePhoneStickyChrome() {
+  const bar = document.getElementById('tablePhoneSticky');
+  if (!bar) return;
+  const phone = isTablePhoneLayout();
+  const tableView = state.activeView === 'library'
+    || state.activeView === 'wishlist'
+    || state.activeView === 'itch';
+  bar.hidden = !(phone && tableView);
+  if (!phone || !tableView) return;
+  const label = document.getElementById('tablePhoneStickyLabel');
+  const count = document.getElementById('tablePhoneStickyCount');
+  if (label) {
+    label.textContent = state.activeView === 'wishlist'
+      ? 'Wishlist'
+      : state.activeView === 'itch'
+        ? 'itch.io'
+        : 'Library';
+  }
+  if (count) {
+    const n = state._visibleList?.length ?? 0;
+    count.textContent = n ? `${n}` : '';
+  }
+}
+
 function syncTablePhoneLayout() {
   const wrap = document.getElementById('tableWrap');
   if (!wrap) return;
+  const wasPhone = wrap.classList.contains('table-phone');
   const phone = typeof matchMedia === 'function' && matchMedia(TABLE_PHONE_MQ).matches;
   wrap.classList.toggle('table-phone', phone);
+  syncTablePhoneStickyChrome();
+  if (wasPhone !== phone) {
+    _rowHeightPx = ROW_HEIGHT;
+    _virtualWindow = { start: -1, end: -1 };
+    _virtualWindowList = null;
+    scheduleTableDensitySync((v) => applyColumnVisibility(v), state.activeView);
+    if (_virtualList && usesVirtualScroll(_virtualList)) {
+      scheduleVirtualScrollUpdate();
+    }
+  }
 }
 
 /** Toggle card-style library rows on narrow viewports. */
@@ -978,6 +1024,14 @@ export function initTablePhoneLayout() {
   const onChange = () => syncTablePhoneLayout();
   if (mq.addEventListener) mq.addEventListener('change', onChange);
   else mq.addListener(onChange);
+}
+
+/** Wire density ResizeObserver (call once at boot). */
+export function initTableDensity() {
+  observeTableDensity(
+    (v) => applyColumnVisibility(v),
+    () => state.activeView,
+  );
 }
 let _paintGen = 0;
 const FIRST_CHUNK = 50;
@@ -1068,12 +1122,29 @@ function getRow0DocY() {
   const shell = document.getElementById("tableShell");
   const thead = document.querySelector(".games-table thead");
   if (!shell) return 0;
-  return shell.offsetTop + (thead?.offsetHeight ?? 48);
+  // Phone hides thead (display:none → offsetHeight 0); do not invent 48px.
+  const headH = thead && getComputedStyle(thead).display !== 'none'
+    ? (thead.offsetHeight || 0)
+    : 0;
+  const phoneBar = document.getElementById('tablePhoneSticky');
+  const barH = phoneBar && !phoneBar.hidden ? (phoneBar.offsetHeight || 0) : 0;
+  return shell.offsetTop + headH + barH;
+}
+
+/** Extra Y from a sponsored row inserted at slot when slot < idx. */
+function sponsoredExtraBeforeIndex(idx) {
+  if (!_virtualList?.length || idx <= 0) return 0;
+  const slot = resolveSponsoredTableSlot(_virtualList.length);
+  if (slot < 0 || slot >= idx) return 0;
+  const ad = document.querySelector('#tbody tr.sponsored-table-row');
+  const h = ad?.getBoundingClientRect().height;
+  return h > 0 ? h : rowHeightPx();
 }
 
 function scrollTopForRowCenter(idx) {
   const rh = rowHeightPx();
-  const rowCenterY = getRow0DocY() + idx * rh + rh / 2;
+  const extra = sponsoredExtraBeforeIndex(idx);
+  const rowCenterY = getRow0DocY() + extra + idx * rh + rh / 2;
   return Math.max(0, rowCenterY - window.innerHeight * 0.42);
 }
 
@@ -1336,6 +1407,8 @@ function tableRowHtml(g, idx, { isWish }) {
             <div class="flex items-center gap-1.5 min-w-0">
               ${storeLinkHtml(g, "text-sky-400 hover:underline font-medium game-name truncate min-w-0", escapeHtml(g.name))}
               ${ownedWish ? '<span class="text-amber-400 text-xs shrink-0" title="You already own this (matched by title)">owned</span>' : ""}
+              ${earlyAccessPillHtml(g)}
+              ${hiddenGem ? '<span class="text-purple-400 shrink-0" style="cursor: default" title="Hidden gem: 90%+ rated and unplayed">✦</span>' : ""}
             </div>
             <div class="row-meta mt-1 flex items-center gap-1.5 flex-wrap">
               ${state.activeView === "wishlist" ? wishlistBadgeHtml(g) : storeBadgeHtml(g)}
@@ -1344,13 +1417,9 @@ function tableRowHtml(g, idx, { isWish }) {
               ${coopPillsHtml(g)}
               ${state.activeView === "wishlist" ? "" : trophyProgressPillHtml(g)}
               ${state.activeView === "wishlist" ? "" : platinumBadgeHtml(g)}
-              ${String(p.notes || "").trim() ? `<span class="has-notes-dot" title="${escapeAttr(String(p.notes).slice(0, 160))} - click to edit notes" aria-label="Has notes">&#9998; note</span>` : ""}
+              ${notesAffordanceHtml(key, p.notes)}
             </div>
-            ${lowConf && g.hltb_name ? `<div class="text-xs text-amber-400" title="Uncertain HowLongToBeat match - Shift+click HLTB to override">HLTB match: ${escapeHtml(g.hltb_name)}</div>` : ""}
-          </div>
-          <div class="flex items-center gap-1.5 shrink-0">
-            ${earlyAccessPillHtml(g)}
-            ${hiddenGem ? '<span class="text-purple-400 shrink-0" style="cursor: default" title="Hidden gem: 90%+ rated and unplayed">✦</span>' : ""}
+            ${lowConf && g.hltb_name ? `<div class="hltb-match-hint text-xs text-amber-400" title="Uncertain HowLongToBeat match - Shift+click HLTB to override">HLTB match: ${escapeHtml(g.hltb_name)}</div>` : ""}
           </div>
         </div>
       </td>
@@ -1434,7 +1503,14 @@ function paintTableBody(list, opts = {}) {
   const { start, end } = computeVirtualRange(list.length, anchorIdx >= 0 ? anchorIdx : null);
   paintVirtualSlice(start, end);
   if (anchorIdx >= 0 && !hasPendingScrollTarget()) {
-    scrollToVirtualRowIndex(anchorIdx, { behavior: "auto" });
+    if (isTablePhoneLayout()) {
+      const key = gameKey(list[anchorIdx]);
+      const row = document.querySelector(`tr[data-row-key="${CSS.escape(key)}"]`);
+      if (row) scrollRowToCenter(row, { smooth: false });
+      else scrollToVirtualRowIndex(anchorIdx, { behavior: "auto" });
+    } else {
+      scrollToVirtualRowIndex(anchorIdx, { behavior: "auto" });
+    }
   }
   if (run) {
     perfMeasure(run, 'paint:total', 'paint:start', {
@@ -1652,7 +1728,8 @@ export async function renderTable(opts) {
   perfMark(perfRun, 'chrome:start');
   const isWish = state.activeView === "wishlist";
   syncTablePhoneLayout();
-  applyColumnVisibility(state.activeView);
+  syncTableDensity((v) => applyColumnVisibility(v), state.activeView);
+  syncTablePhoneStickyChrome();
   const statusHdr = document.getElementById("statusHeader");
   if (statusHdr) {
     const label = isWish ? "Tracking" : "Status";

--- a/js/update-check.js
+++ b/js/update-check.js
@@ -457,7 +457,7 @@ export function showUpdateModal(parsed, handlers = {}) {
     modal = document.createElement("div");
     modal.id = UPDATE_MODAL_ID;
     modal.className =
-      "fixed inset-0 z-50 hidden flex items-center justify-center bg-black/60";
+      "app-modal fixed inset-0 z-50 hidden flex items-center justify-center bg-black/60";
     modal.tabIndex = -1;
     document.body.appendChild(modal);
   }
@@ -495,7 +495,7 @@ export function confirmInstallUpdate() {
       modal = document.createElement("div");
       modal.id = UPDATE_INSTALL_MODAL_ID;
       modal.className =
-        "fixed inset-0 z-[60] hidden flex items-center justify-center bg-black/60";
+        "app-modal fixed inset-0 z-[60] hidden flex items-center justify-center bg-black/60";
       modal.tabIndex = -1;
       document.body.appendChild(modal);
     }

--- a/landing/index.html
+++ b/landing/index.html
@@ -1129,6 +1129,10 @@
           <p class="foot-tagline"><strong>baklog.app</strong>. One honest backlog across every store.</p>
           <p class="foot-pricing">Free forever to import &middot; Support BAKLOG optional &middot; Invite-only early access. Invites go out in small waves.</p>
           <div class="foot-social" role="group" aria-label="Follow BAKLOG">
+            <!-- Discord: keep in sync with shared/community.json discord_invite -->
+            <a href="https://discord.gg/VFvxN5nCCB" target="_blank" rel="noopener noreferrer" aria-label="BAKLOG on Discord" title="Discord (community)">
+              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.331c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
+            </a>
             <a href="https://www.instagram.com/baklog.app/" target="_blank" rel="noopener noreferrer" aria-label="BAKLOG on Instagram" title="Instagram (@baklog.app)">
               <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zM12 0C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.741 0 12c0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.668.014 15.259 0 12 0zm0 5.838a6.162 6.162 0 1 0 0 12.324 6.162 6.162 0 0 0 0-12.324zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm6.406-11.845a1.44 1.44 0 1 0 0 2.881 1.44 1.44 0 0 0 0-2.881z"/></svg>
             </a>
@@ -1146,8 +1150,9 @@
         <nav class="foot-links" aria-label="Footer">
           <div class="foot-col">
             <h4>Community</h4>
-            <!-- GitHub: keep in sync with shared/community.json -->
+            <!-- Discord + GitHub: keep in sync with shared/community.json -->
             <a href="#waitlist">Request an invite</a>
+            <a href="https://discord.gg/VFvxN5nCCB" target="_blank" rel="noopener noreferrer">Discord</a>
             <a href="https://github.com/Ogrods/BAKLOG" target="_blank" rel="noopener noreferrer">GitHub</a>
             <a href="https://github.com/Ogrods/BAKLOG/blob/main/SECURITY.md" target="_blank" rel="noopener noreferrer">Security model</a>
             <a href="https://github.com/Ogrods/BAKLOG/blob/main/PRIVACY.md" target="_blank" rel="noopener noreferrer">Privacy</a>

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "check:dist-integrity": "node scripts/check-dist-integrity.mjs",
     "check:perf": "npm run test:perf",
     "perf:audit": "node scripts/perf-audit.mjs",
+    "test:responsive": "node scripts/responsive-overflow-audit.mjs",
     "perf:profile": "node scripts/generate-perf-profile.mjs",
     "audit:header": "node scripts/audit-header-rule.mjs",
     "audit:tab-curtain": "node scripts/audit-tab-curtain.mjs",

--- a/scripts/responsive-overflow-audit.mjs
+++ b/scripts/responsive-overflow-audit.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+/**
+ * Responsive overflow audit against a live BAKLOG server.
+ * Usage: node scripts/responsive-overflow-audit.mjs [baseUrl]
+ *
+ * Opt-in (not CI-gated). Needs a local server on 8765. Prefer the same gate as
+ * perf audit so the auth overlay does not block boot:
+ *   BAKLOG_PROFILE=perf BAKLOG_AUTH_DISABLED=1 BAKLOG_ADMIN=0
+ * (see scripts/start-perf-server.ps1).
+ *
+ * Matrix: tracker RESPONSIVE_TEST_MATRIX (1024 / 768 / 390 / 360) plus a phone
+ * landscape cell (844×390). Settled views + one library overlay smoke
+ * (Columns modal + Filters drawer open/close).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const BASE = process.argv[2] || 'http://127.0.0.1:8765';
+
+const VIEWPORTS = [
+  { width: 1024, height: 768, label: '1024' },
+  { width: 768, height: 1024, label: '768' },
+  { width: 390, height: 844, label: '390' },
+  { width: 360, height: 740, label: '360' },
+  { width: 844, height: 390, label: '844x390' },
+];
+
+const VIEWS = ['dashboard', 'library', 'wishlist', 'connections', 'pro'];
+
+/** Allow 1px subpixel fudge (common on fractional DPR). */
+const SCROLL_FUDGE_PX = 1;
+
+async function clickViewTab(page, view) {
+  await page.evaluate((v) => {
+    const tab = document.querySelector(`.view-tab[data-view="${v}"]`);
+    if (tab) {
+      tab.click();
+      return;
+    }
+    document.querySelector(`#headerNavSheet .view-tab[data-view="${v}"]`)?.click();
+  }, view);
+}
+
+async function waitBootCurtainLift(page, timeoutMs = 25000) {
+  const authBlocking = await page.evaluate(() => {
+    const gate = document.getElementById('authGateOverlay');
+    if (!gate || gate.hasAttribute('hidden')) return false;
+    return true;
+  }).catch(() => false);
+  if (authBlocking) {
+    throw new Error(
+      'auth gate is visible - restart server with BAKLOG_AUTH_DISABLED=1 (and preferably BAKLOG_PROFILE=perf)',
+    );
+  }
+  await page.waitForFunction(
+    () => !document.documentElement.hasAttribute('data-boot-loading'),
+    null,
+    { timeout: timeoutMs },
+  );
+}
+
+async function waitViewSettled(page, view, timeoutMs = 12000) {
+  await page.waitForFunction(
+    (v) => {
+      const overlay = !!document
+        .getElementById('viewLoadingOverlay')
+        ?.classList.contains('show');
+      const active = document.documentElement.getAttribute('data-init-view');
+      return !overlay && active === v;
+    },
+    view,
+    { timeout: timeoutMs },
+  );
+}
+
+async function measureOverflow(page) {
+  return page.evaluate((fudge) => {
+    const rootEl = document.documentElement;
+    const body = document.body;
+    const scrollW = Math.max(rootEl.scrollWidth, body?.scrollWidth || 0);
+    const clientW = rootEl.clientWidth || window.innerWidth;
+    const overflowPx = Math.max(0, scrollW - clientW);
+    return {
+      scrollWidth: scrollW,
+      clientWidth: clientW,
+      overflowPx,
+      ok: overflowPx <= fudge,
+    };
+  }, SCROLL_FUDGE_PX);
+}
+
+function pushResult(report, row) {
+  report.results.push(row);
+  if (!row.ok) {
+    report.failures.push(
+      `${row.viewport}/${row.view}: overflow ${row.overflowPx}px (scrollWidth=${row.scrollWidth}, clientWidth=${row.clientWidth})`,
+    );
+  }
+}
+
+/** Open Columns + Filters on library, measure, then close. */
+async function smokeLibraryOverlays(page, vp, report) {
+  const label = `${vp.label}/library-overlays`;
+  try {
+    await clickViewTab(page, 'library');
+    await waitViewSettled(page, 'library');
+
+    await page.evaluate(() => {
+      document.getElementById('openColumnsBtn')?.click();
+    });
+    await page.waitForTimeout(150);
+    let m = await measureOverflow(page);
+    pushResult(report, { viewport: vp.label, width: vp.width, view: 'library-columns', ...m });
+
+    await page.evaluate(() => {
+      document.getElementById('closeColumnsBtn')?.click();
+      document.querySelector('#columnsModal [aria-label="Close"]')?.click();
+      const modal = document.getElementById('columnsModal');
+      if (modal && !modal.classList.contains('hidden')) modal.classList.add('hidden');
+    });
+    await page.waitForTimeout(100);
+
+    await page.evaluate(() => {
+      document.getElementById('openFiltersBtn')?.click();
+    });
+    await page.waitForTimeout(150);
+    m = await measureOverflow(page);
+    pushResult(report, { viewport: vp.label, width: vp.width, view: 'library-filters', ...m });
+
+    await page.evaluate(() => {
+      document.getElementById('closeFiltersBtn')?.click();
+      const drawer = document.getElementById('filterDrawer');
+      drawer?.classList.remove('open');
+      document.getElementById('filterDrawerBackdrop')?.classList.remove('open');
+    });
+  } catch (err) {
+    report.failures.push(`${label}: ${err.message || err}`);
+  }
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const report = {
+    capturedAt: new Date().toISOString(),
+    baseUrl: BASE,
+    fudgePx: SCROLL_FUDGE_PX,
+    results: [],
+    failures: [],
+  };
+
+  try {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    for (const vp of VIEWPORTS) {
+      await page.setViewportSize({ width: vp.width, height: vp.height });
+      try {
+        await page.goto(`${BASE}/`, { waitUntil: 'domcontentloaded', timeout: 25000 });
+        await waitBootCurtainLift(page);
+      } catch (err) {
+        report.failures.push(
+          `${vp.label}: boot failed (${err.message || err})`,
+        );
+        continue;
+      }
+
+      for (const view of VIEWS) {
+        try {
+          await clickViewTab(page, view);
+          await waitViewSettled(page, view);
+          await page.waitForTimeout(200);
+          const m = await measureOverflow(page);
+          pushResult(report, {
+            viewport: vp.label,
+            width: vp.width,
+            view,
+            ...m,
+          });
+        } catch (err) {
+          report.failures.push(
+            `${vp.label}/${view}: ${err.message || err}`,
+          );
+        }
+      }
+
+      await smokeLibraryOverlays(page, vp, report);
+    }
+  } finally {
+    await browser.close();
+  }
+
+  const outPath = path.join(root, 'scripts', 'responsive-overflow-last-run.json');
+  fs.writeFileSync(outPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+
+  const passCount = report.results.filter((r) => r.ok).length;
+  console.log(
+    `Responsive overflow: ${passCount}/${report.results.length} cells ok ` +
+      `(${VIEWPORTS.length} viewports × ${VIEWS.length} views + overlays)`,
+  );
+  if (report.failures.length) {
+    console.error('Failures:');
+    for (const f of report.failures) console.error(`  - ${f}`);
+    console.error(`Report: ${path.relative(root, outPath)}`);
+    process.exit(1);
+  }
+  console.log(`Passed. Report: ${path.relative(root, outPath)}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/shared/community.json
+++ b/shared/community.json
@@ -1,4 +1,4 @@
 {
-  "discord_invite": "https://discord.gg/baklog",
+  "discord_invite": "https://discord.gg/VFvxN5nCCB",
   "github_repo": "https://github.com/Ogrods/BAKLOG"
 }

--- a/size-budget.json
+++ b/size-budget.json
@@ -1,6 +1,6 @@
 {
   "note": "Critical-path dist/ ceilings (entry js/app.js + CSS). Lazy chunks excluded. Refresh: npm run build && node scripts/check-bundle-size.mjs --write",
-  "capturedAt": "2026-06-26",
-  "maxEntryJsKb": 75,
-  "maxCssKb": 264
+  "capturedAt": "2026-08-05",
+  "maxEntryJsKb": 82,
+  "maxCssKb": 286
 }

--- a/tests/drill-anchor.test.js
+++ b/tests/drill-anchor.test.js
@@ -297,4 +297,43 @@ describe("virtual drill anchor scroll", () => {
     expect(maxTop).toBeGreaterThan(0);
     expect(document.querySelector('tr[data-row-key="steam:60"]')).toBeTruthy();
   });
+
+  it("phone layout row drill prefers painted-row scroll after focusGame", async () => {
+    const { state } = await import("../js/state.js");
+    const {
+      setPendingScrollTarget,
+      consumePendingScrollTarget,
+    } = await import("../js/table-ui.js");
+    state.activeView = "library";
+    state.prefs = state.prefs || {};
+    document.getElementById("tableWrap")?.classList.add("table-phone");
+
+    const list = Array.from({ length: 80 }, (_, i) => ({
+      store: "steam",
+      id: i,
+      name: `Game ${String(i).padStart(3, "0")}`,
+    }));
+    state._visibleList = list;
+
+    const tbody = document.getElementById("tbody");
+    tbody.innerHTML = `<tr data-row-key="steam:40" data-row-index="40" style="height:90px"><td>Game 040</td></tr>`;
+    const row = tbody.querySelector("tr");
+    Object.defineProperty(row, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({ top: 500, bottom: 590, height: 90, left: 0, right: 100, width: 100 }),
+    });
+    Object.defineProperty(win, "scrollY", { configurable: true, value: 0 });
+    Object.defineProperty(win, "innerHeight", { configurable: true, value: 700 });
+
+    scrollToSpy.mockClear();
+    setPendingScrollTarget({ kind: "row", key: "steam:40", smooth: false });
+    const ok = consumePendingScrollTarget(list);
+    expect(ok).toBe(true);
+    expect(scrollToSpy).toHaveBeenCalled();
+    const top = scrollToSpy.mock.calls[0][0]?.top;
+    expect(typeof top).toBe("number");
+    // Rect path: rowCenter ~545, target ~545 - 0.42*700 ≈ 251
+    expect(top).toBeGreaterThan(100);
+    expect(top).toBeLessThan(400);
+  });
 });

--- a/tests/fetcher-health.test.js
+++ b/tests/fetcher-health.test.js
@@ -1054,7 +1054,7 @@ describe('syncLogHeightToCard', () => {
     const card = document.getElementById('dashboardFetcherHealth');
     Object.defineProperty(card, 'offsetHeight', { configurable: true, value: 120 });
     vi.stubGlobal('matchMedia', (query) => ({
-      matches: query.includes('768px') ? matchMediaDesktop : false,
+      matches: query.includes('1024px') ? matchMediaDesktop : false,
       media: query,
     }));
   });
@@ -1504,6 +1504,47 @@ describe('fetcher header popover', () => {
   afterEach(() => {
     document.body.innerHTML = '';
     fetcherRunner.hideFetcherPopover?.();
+  });
+
+  it('showFetcherPopover toggles fetcher-popover--sheet on phone viewport', () => {
+    const mqList = {
+      matches: true,
+      media: '(max-width: 639.98px), (max-height: 480px) and (hover: none)',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    };
+    const mm = vi.spyOn(window, 'matchMedia').mockImplementation((query) => {
+      if (String(query).includes('639.98')) return mqList;
+      return {
+        matches: false,
+        media: String(query),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+      };
+    });
+    fetcherRunner.showFetcherPopover({ focusPanel: false });
+    expect(document.getElementById('fetcherPopover').classList.contains('fetcher-popover--sheet')).toBe(true);
+    fetcherRunner.hideFetcherPopover();
+    expect(document.getElementById('fetcherPopover').classList.contains('fetcher-popover--sheet')).toBe(false);
+    mm.mockRestore();
+  });
+
+  it('showFetcherPopover skips sheet class on desktop viewport', () => {
+    const mm = vi.spyOn(window, 'matchMedia').mockImplementation((query) => ({
+      matches: false,
+      media: String(query),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    }));
+    fetcherRunner.showFetcherPopover({ focusPanel: false });
+    expect(document.getElementById('fetcherPopover').classList.contains('fetcher-popover--sheet')).toBe(false);
+    mm.mockRestore();
   });
 
   it('showFetcherPopover opens dialog without dashboard switch', () => {

--- a/tests/header-nav-menu.test.js
+++ b/tests/header-nav-menu.test.js
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  closeHeaderNavMenu,
+  headerNavSheetClassForTest,
+  initHeaderNavMenu,
+  isHeaderNavMenuOpen,
+  openHeaderNavMenu,
+} from '../js/header-nav-menu.js';
+
+function mount() {
+  document.documentElement.classList.remove(headerNavSheetClassForTest());
+  document.body.innerHTML = `
+    <div class="app-header-row" style="width:400px">
+      <div class="app-header-brand" style="width:80px">BAKLOG</div>
+      <div id="appHeaderNavWrap">
+        <div id="headerNavBackdrop" hidden></div>
+        <div id="headerNavPanel">
+          <nav id="appHeaderNav" class="app-header-nav" style="width:600px">
+            <button type="button" class="view-tab" data-view="dashboard">Dashboard</button>
+            <button type="button" class="view-tab active" data-view="library">Library</button>
+          </nav>
+          <div id="headerNavSheetExtras" class="header-nav-sheet-extras" hidden></div>
+        </div>
+      </div>
+      <div class="app-header-actions" style="width:120px">
+        <button type="button" id="headerNavToggle" aria-expanded="false">Menu</button>
+        <button type="button" id="headerFullscreenBtn">FS</button>
+        <button type="button" id="reportBugHeader">Bug<span class="header-nav-sheet-action-label">Report bug</span></button>
+        <div id="profileMenuWrap"><button type="button" id="profileMenuTrigger">Default</button></div>
+      </div>
+    </div>`;
+}
+
+describe('header nav hamburger menu', () => {
+  beforeEach(() => {
+    mount();
+  });
+
+  afterEach(() => {
+    closeHeaderNavMenu();
+    document.documentElement.classList.remove(headerNavSheetClassForTest());
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('opens as dialog sheet when tablet mq / sheet class is active', () => {
+    vi.spyOn(window, 'matchMedia').mockImplementation((query) => ({
+      matches: String(query).includes('1023.98'),
+      media: String(query),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    }));
+    initHeaderNavMenu();
+
+    expect(document.documentElement.classList.contains(headerNavSheetClassForTest())).toBe(true);
+    expect(openHeaderNavMenu()).toBe(true);
+    const panel = document.getElementById('headerNavPanel');
+    expect(panel.hidden).toBe(false);
+    expect(panel.getAttribute('aria-modal')).toBe('true');
+    expect(document.getElementById('appHeaderNavWrap').classList.contains('is-open')).toBe(true);
+    expect(document.getElementById('headerNavToggle').getAttribute('aria-expanded')).toBe('true');
+    expect(isHeaderNavMenuOpen()).toBe(true);
+    // Bug + profile parked in sheet extras
+    expect(document.getElementById('headerNavSheetExtras').contains(document.getElementById('reportBugHeader'))).toBe(true);
+    expect(document.getElementById('headerNavSheetExtras').contains(document.getElementById('profileMenuWrap'))).toBe(true);
+  });
+
+  it('closes on view-tab click and clears dialog attrs', () => {
+    vi.spyOn(window, 'matchMedia').mockImplementation((query) => ({
+      matches: String(query).includes('1023.98'),
+      media: String(query),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    }));
+    initHeaderNavMenu();
+    openHeaderNavMenu();
+
+    document.querySelector('.view-tab[data-view="library"]').click();
+    const panel = document.getElementById('headerNavPanel');
+    expect(panel.hidden).toBe(true);
+    expect(panel.hasAttribute('aria-modal')).toBe(false);
+    expect(isHeaderNavMenuOpen()).toBe(false);
+  });
+
+  it('stays inline on wide desktop when content fits', () => {
+    vi.spyOn(window, 'matchMedia').mockImplementation((query) => ({
+      matches: false,
+      media: String(query),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    }));
+    // Make row wide enough for brand + nav + actions in the mocked layout.
+    const row = document.querySelector('.app-header-row');
+    row.style.width = '1200px';
+    document.getElementById('appHeaderNav').style.width = '200px';
+    Object.defineProperty(row, 'clientWidth', { configurable: true, get: () => 1200 });
+    Object.defineProperty(document.querySelector('.app-header-brand'), 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ width: 100 }),
+    });
+    Object.defineProperty(document.querySelector('.app-header-actions'), 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ width: 150 }),
+    });
+    Object.defineProperty(document.getElementById('appHeaderNav'), 'scrollWidth', {
+      configurable: true,
+      get: () => 200,
+    });
+
+    initHeaderNavMenu();
+    expect(document.documentElement.classList.contains(headerNavSheetClassForTest())).toBe(false);
+    expect(openHeaderNavMenu()).toBe(false);
+    expect(document.querySelector('.app-header-actions').contains(document.getElementById('reportBugHeader'))).toBe(true);
+  });
+});

--- a/tests/notes-dialog.test.js
+++ b/tests/notes-dialog.test.js
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Window } from 'happy-dom';
+
+describe('notes dialog affordance', () => {
+  beforeEach(async () => {
+    const win = new Window({ url: 'http://127.0.0.1:8765/' });
+    global.window = win;
+    global.document = win.document;
+    global.CSS = { escape: (s) => String(s) };
+    document.body.innerHTML = `
+      <div id="tableWrap" class="table-hide-notes"></div>
+      <div id="notesDialogModal" class="hidden">
+        <div role="dialog">
+          <h3 id="notesDialogTitle"></h3>
+          <textarea id="notesDialogInput"></textarea>
+          <button id="notesDialogClose"></button>
+          <button id="notesDialogCancel"></button>
+          <button id="notesDialogSave"></button>
+        </div>
+      </div>
+    `;
+    vi.resetModules();
+    vi.doMock('../js/game-core.js', () => ({
+      findGameByKey: (key) => (key === 'steam:1' ? { store: 'steam', id: 1, name: 'Test' } : null),
+      gameKey: (g) => `${g.store}:${g.id}`,
+    }));
+    vi.doMock('../js/personal-storage.js', () => ({
+      getPersonal: () => ({ notes: 'hello' }),
+      setPersonal: vi.fn(),
+    }));
+    vi.doMock('../js/focus-trap.js', () => ({
+      trapFocus: () => () => {},
+      bindEscapeClose: () => () => {},
+    }));
+  });
+
+  it('notesAffordanceHtml shows open button when notes column hidden', async () => {
+    const { notesAffordanceHtml } = await import('../js/notes-dialog.js');
+    const html = notesAffordanceHtml('steam:1', 'hello');
+    expect(html).toContain('notes-open-btn');
+    expect(html).toContain('data-notes-key="steam:1"');
+  });
+
+  it('notesAffordanceHtml shows + note when empty and column hidden', async () => {
+    const { notesAffordanceHtml } = await import('../js/notes-dialog.js');
+    const html = notesAffordanceHtml('steam:1', '');
+    expect(html).toContain('notes-open-btn--empty');
+    expect(html).toContain('+ note');
+  });
+
+  it('openNotesDialog populates textarea', async () => {
+    const { openNotesDialog } = await import('../js/notes-dialog.js');
+    openNotesDialog('steam:1');
+    const modal = document.getElementById('notesDialogModal');
+    expect(modal.classList.contains('flex')).toBe(true);
+    expect(document.getElementById('notesDialogInput').value).toBe('hello');
+    expect(document.getElementById('notesDialogTitle').textContent).toContain('Test');
+  });
+});

--- a/tests/spotlight-lowres.test.js
+++ b/tests/spotlight-lowres.test.js
@@ -73,5 +73,27 @@ describe("spotlight low-res art", () => {
     expect(spot.classList.contains("has-portrait-art")).toBe(true);
     expect(spot.classList.contains("is-lowres-art")).toBe(false);
     expect(img.style.objectFit).toBe("contain");
+    expect(img.style.objectPosition).toBe("center");
+  });
+
+  it("parks portrait and low-res covers at ~2/3 when spotlight is stacked", () => {
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: String(query).includes("1023.98px"),
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    }));
+
+    const portraitSpot = mountSpotlight();
+    const portraitImg = stubArtDimensions(portraitSpot, 300, 450);
+    expect(portraitSpot.classList.contains("has-portrait-art")).toBe(true);
+    expect(portraitImg.style.objectPosition).toBe("66% 40%");
+
+    const lowresSpot = mountSpotlight();
+    const lowresImg = stubArtDimensions(lowresSpot, 460, 215);
+    expect(lowresSpot.classList.contains("is-lowres-art")).toBe(true);
+    expect(lowresImg.style.objectPosition).toBe("66% 40%");
   });
 });

--- a/tests/store-logos.test.js
+++ b/tests/store-logos.test.js
@@ -3,7 +3,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { storeLogoHtml, storeLogoStripHtml, storeGlyphHtml, storeDisplayName, storeLetter, STORE_BADGE_LETTERS, STORE_RAIL_GLYPH_OFFSET } from '../js/store-logos.js';
+import { storeLogoHtml, storeLogoStripHtml, storeGlyphHtml, storeDisplayName, storeLetter, STORE_BADGE_LETTERS, STORE_RAIL_GLYPH_OFFSET, balancedWrapColumns } from '../js/store-logos.js';
 
 describe('storeLetter', () => {
   it('maps known store keys to canonical letters', () => {
@@ -147,6 +147,24 @@ describe('storeLogoStripHtml', () => {
     expect(html).toContain("url('assets/store-logos/steam.svg')");
     expect(html).toContain("url('assets/store-logos/epic.svg')");
     expect(html).not.toContain("url('assets/store-logos/gog.svg')");
+  });
+});
+
+describe('balancedWrapColumns', () => {
+  it('keeps a single row when everything fits', () => {
+    expect(balancedWrapColumns(12, 12)).toBe(12);
+    expect(balancedWrapColumns(5, 8)).toBe(5);
+  });
+
+  it('splits evenly instead of leaving a lonely last row', () => {
+    expect(balancedWrapColumns(12, 11)).toBe(6);
+    expect(balancedWrapColumns(12, 7)).toBe(6);
+    expect(balancedWrapColumns(10, 9)).toBe(5);
+  });
+
+  it('balances across three rows when needed', () => {
+    expect(balancedWrapColumns(12, 5)).toBe(4);
+    expect(balancedWrapColumns(11, 5)).toBe(4);
   });
 });
 

--- a/tests/table-density.test.js
+++ b/tests/table-density.test.js
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Window } from 'happy-dom';
+
+describe('table density', () => {
+  beforeEach(async () => {
+    const win = new Window({ url: 'http://127.0.0.1:8765/' });
+    global.window = win;
+    global.document = win.document;
+    global.ResizeObserver = class {
+      observe() {}
+      disconnect() {}
+    };
+    global.requestAnimationFrame = (cb) => {
+      cb(0);
+      return 1;
+    };
+    global.cancelAnimationFrame = () => {};
+    document.body.innerHTML = `<div id="tableWrap" style="width:400px"><table class="games-table" style="width:900px"><tr><td>x</td></tr></table></div>`;
+    const wrap = document.getElementById('tableWrap');
+    Object.defineProperty(wrap, 'clientWidth', { configurable: true, get: () => 400 });
+    Object.defineProperty(wrap, 'scrollWidth', { configurable: true, get: () => {
+      const tier = Number(wrap.dataset.density || 0);
+      // Simulate wider table until density hides enough columns
+      return tier >= 2 ? 380 : 900;
+    }});
+    vi.resetModules();
+  });
+
+  it('densityHideIdsForTier grows by tier', async () => {
+    const { densityHideIdsForTier, DENSITY_MAX_TIER } = await import('../js/table-density.js');
+    expect(densityHideIdsForTier(0)).toEqual([]);
+    expect(densityHideIdsForTier(1)).toEqual(['notes', 'genres']);
+    expect(densityHideIdsForTier(2)).toContain('released');
+    expect(densityHideIdsForTier(2)).toContain('lastplayed');
+    expect(densityHideIdsForTier(3)).toContain('price');
+    expect(densityHideIdsForTier(4)).toContain('steam');
+    expect(densityHideIdsForTier(5)).toContain('played');
+    expect(densityHideIdsForTier(6)).toContain('hltb');
+    expect(densityHideIdsForTier(99).length).toBe(densityHideIdsForTier(DENSITY_MAX_TIER).length);
+  });
+
+  it('pins prevent densityWouldHide', async () => {
+    const { state } = await import('../js/state.js');
+    state.prefs = { columnDensityPins: {} };
+    const {
+      densityWouldHide,
+      setDensityPinned,
+      setDensityTier,
+    } = await import('../js/table-density.js');
+    setDensityTier(2);
+    expect(densityWouldHide('library', 'notes')).toBe(true);
+    setDensityPinned('library', 'notes', true);
+    expect(densityWouldHide('library', 'notes')).toBe(false);
+  });
+
+  it('syncTableDensity raises tier until overflow clears', async () => {
+    const { syncTableDensity, getDensityTier } = await import('../js/table-density.js');
+    const apply = vi.fn();
+    const tier = syncTableDensity(apply, 'library');
+    expect(tier).toBe(2);
+    expect(getDensityTier()).toBe(2);
+    expect(apply).toHaveBeenCalled();
+  });
+
+  it('bumps density when game title cell is crushed', async () => {
+    const wrap = document.getElementById('tableWrap');
+    Object.defineProperty(wrap, 'scrollWidth', { configurable: true, get: () => 400 });
+    wrap.innerHTML = `<table class="games-table"><tbody><tr>
+      <td class="game-name-cell">Title</td>
+    </tr></tbody></table>`;
+    const cell = wrap.querySelector('.game-name-cell');
+    Object.defineProperty(cell, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ width: 80, height: 20, top: 0, left: 0, right: 80, bottom: 20 }),
+    });
+    const { measureNeedsMoreDensity, measureGameTitleTooNarrow } = await import('../js/table-density.js');
+    expect(measureGameTitleTooNarrow(wrap)).toBe(true);
+    expect(measureNeedsMoreDensity(wrap)).toBe(true);
+  });
+
+  it('applyColumnVisibility composes prefs + density', async () => {
+    const { state } = await import('../js/state.js');
+    state.prefs = { columns: {}, columnDensityPins: {} };
+    const { setDensityTier } = await import('../js/table-density.js');
+    const { applyColumnVisibility } = await import('../js/table-columns.js');
+    setDensityTier(1);
+    applyColumnVisibility('library');
+    const wrap = document.getElementById('tableWrap');
+    expect(wrap.classList.contains('table-hide-notes')).toBe(true);
+    expect(wrap.classList.contains('table-hide-genres')).toBe(true);
+    expect(wrap.classList.contains('table-hide-price')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Close the local-app responsive train (Phase 0–R5): hamburger/sheets, library density + phone cards, hero/chart polish, Connections sticky panes, modal sheets, type tokens + reduced-motion, and leftover CSS breakpoint ladder rename onto 1023.98 / 639.98 / 400.
- Opt-in `npm run test:responsive` overflow matrix; permanent Discord invite wiring.
- No version bump / no release tag (ships in next patch).

## Test plan
- [ ] `npm test` (or CI Vitest)
- [ ] CI pytest / lint / size budgets green
- [ ] Optional: `BAKLOG_PROFILE=perf` + `BAKLOG_AUTH_DISABLED=1` then `npm run test:responsive`
- [ ] Spot-check 390 / 768 / 1024: header sheet, library cards, dashboard insight wrap, OS reduced-motion