### PR TITLE
feat: auto-download Chrome for Testing when Chrome/Edge is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [Unreleased]
 
+### Added
+
+- When Chrome/Edge is missing, Connections (and other CDP launches) download a pinned Chrome for Testing build once into the data-dir cache (`shared/chromium_runtime.py`, pin `shared/chromium_cft_pin.json`). System browsers and `BAKLOG_CHROME_PATH` still win; `BAKLOG_NO_CHROMIUM_DOWNLOAD=1` disables the fallback.
+
 ### Fixed
 
 - Responsive outside scan: `TABLE_PHONE_MQ` (+ phone chrome / A–Z dock) aligns with sheet landscape MQ so 844×390 uses library cards; `test:responsive` covers itch + outside overlays (notes/bug/update/kebab/profile/claimables/header nav/pro-compare) and `--auth-gate` mode.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The app itself (dashboard, `server.py`, secret storage, browser sign-in) is OS-a
 
 Credentials are stored via your OS **keyring** (Windows Credential Manager, macOS Keychain, Linux Secret Service) with an AES-GCM file fallback — not DPAPI. See [`auth/secrets.py`](auth/secrets.py).
 
-**Requirements (all platforms):** Python 3.11+, Google Chrome or Chromium for the Connect sign-in flow (override with `BAKLOG_CHROME_PATH`), then `pip install -r requirements.txt` and `python server.py`. Developers/CI: `pip install -e ".[dev]"` (or `requirements-dev.txt`).
+**Requirements (all platforms):** Python 3.11+, Google Chrome or Chromium preferred for Connect (override with `BAKLOG_CHROME_PATH`; if missing, first Connect downloads a one-time browser ~150 MB), then `pip install -r requirements.txt` and `python server.py`. Developers/CI: `pip install -e ".[dev]"` (or `requirements-dev.txt`).
 
 ### System tray (optional)
 
@@ -225,7 +225,7 @@ If you have not created a venv yet, run the [Setup](#setup) steps first (`python
 
 Windows shortcut: `.\scripts\start-server.ps1` (uses the project venv; run `pip install -e ".[dev]"` once if that script reports a missing venv).
 
-Requires **Google Chrome** or **Microsoft Edge** installed (Edge ships with Windows). Connections opens a headed browser window for cookie/OAuth sign-in. Override the browser path with `BAKLOG_CHROME_PATH` if needed.
+Requires **Google Chrome** or **Microsoft Edge** when available (Edge ships with Windows). If neither is installed, Connections downloads a one-time Chrome for Testing build (~150 MB) on first Connect. Override the browser path with `BAKLOG_CHROME_PATH` if needed.
 
 On Windows, always use the project venv (not the Microsoft Store `python.exe` stub). Fetcher subprocesses launched from the stub can hang `subprocess.Popen` and wedge the run queue. `server.py` auto-picks `.venv` when present.
 

--- a/auth/cdp_browser.py
+++ b/auth/cdp_browser.py
@@ -1,7 +1,8 @@
-"""Launch the user's Chrome/Edge and drive it over Chrome DevTools Protocol (CDP).
+"""Launch Chrome/Edge (or a managed Chrome for Testing build) over CDP.
 
 Replaces Playwright for Connections sign-in and headless wishlist fetches.
-Requires Google Chrome or Microsoft Edge installed locally.
+Prefers a system Google Chrome or Microsoft Edge install; when none is found,
+``ensure_chromium_executable`` downloads a pinned Chrome for Testing build.
 """
 
 from __future__ import annotations
@@ -364,7 +365,7 @@ STEALTH_INIT_SCRIPT = r"""
 
 _BROWSER_LAUNCH_HINT = (
     "Install Google Chrome or Microsoft Edge, set BAKLOG_CHROME_PATH to the browser "
-    "executable, or try the other installed browser."
+    "executable, or let BAKLOG download a one-time browser (~150 MB) on Connect."
 )
 
 
@@ -487,7 +488,10 @@ def _chromium_executable_candidates() -> list[Path]:
 
 
 def find_chromium_executable() -> Path:
-    """Return path to Chrome or Edge, or raise with install instructions."""
+    """Return path to Chrome/Edge or a previously downloaded managed build.
+
+    Does not download. Soft probes (``/api/config``) use this so boot stays offline.
+    """
     override = os.getenv("BAKLOG_CHROME_PATH", "").strip()
     if override:
         p = Path(override)
@@ -506,10 +510,39 @@ def find_chromium_executable() -> Path:
             if p.is_file():
                 return p
 
+    try:
+        from shared.chromium_runtime import find_managed_chromium
+
+        managed = find_managed_chromium()
+        if managed is not None:
+            return managed
+    except Exception:
+        pass
+
     raise RuntimeError(
         "No Chrome or Edge browser found. Install Google Chrome or Microsoft Edge, "
-        "or set BAKLOG_CHROME_PATH to your browser executable."
+        "set BAKLOG_CHROME_PATH, or Connect once online so BAKLOG can download a browser."
     )
+
+
+def ensure_chromium_executable(
+    *,
+    on_progress: Callable[[int, int | None], None] | None = None,
+) -> Path:
+    """Like ``find_chromium_executable``, but download managed CfT when missing."""
+    try:
+        return find_chromium_executable()
+    except RuntimeError:
+        override = os.getenv("BAKLOG_CHROME_PATH", "").strip()
+        if override:
+            # Honor explicit override failures; never replace with a download.
+            raise
+        from shared.chromium_runtime import ChromiumRuntimeError, ensure_chromium
+
+        try:
+            return ensure_chromium(on_progress=on_progress)
+        except ChromiumRuntimeError as exc:
+            raise RuntimeError(f"{exc} {_BROWSER_LAUNCH_HINT}") from exc
 
 
 def _free_port() -> int:
@@ -1643,7 +1676,7 @@ def launch_persistent_profile(
     When ``initial_url`` is set, the first connect page navigates there after CDP attach
     (used by EA Connect to open the login page immediately).
     """
-    exe = find_chromium_executable()
+    exe = ensure_chromium_executable()
     port = _free_port()
     profile = Path(user_data_dir)
     profile.mkdir(parents=True, exist_ok=True)

--- a/auth/manager.py
+++ b/auth/manager.py
@@ -745,6 +745,31 @@ def start_browser_auth(provider: str, *, fresh: bool = False) -> str:
 
     def _worker() -> None:
         try:
+            # Prefetch managed Chrome for Testing before the Connect window opens so
+            # progress can stream over SSE (wishlist/headless paths still ensure in
+            # launch_persistent_profile).
+            from auth.cdp_browser import ensure_chromium_executable
+
+            last_emit = [0.0]
+
+            def _on_chromium_progress(done: int, total: int | None) -> None:
+                now = time.time()
+                if done and total and done < total and (now - last_emit[0]) < 0.4:
+                    return
+                last_emit[0] = now
+                if total and total > 0:
+                    pct = min(100, int(100 * done / total))
+                    msg = f"Downloading BAKLOG browser… {pct}% (~150 MB one-time)"
+                else:
+                    mb = max(1, done // (1024 * 1024)) if done else 0
+                    msg = f"Downloading BAKLOG browser… {mb} MB (~150 MB one-time)"
+                session.emit(
+                    "status",
+                    {"message": msg, "bytes": done, "total": total},
+                )
+
+            ensure_chromium_executable(on_progress=_on_chromium_progress)
+
             creds = run_browser_auth(provider, session)
             if not creds:
                 # Window closed without a completed sign-in. Reset to a clean,

--- a/guide/connecting-stores.md
+++ b/guide/connecting-stores.md
@@ -2,7 +2,7 @@
 
 Connect each store from the **Connections** tab in the dashboard, then run fetchers from the **Fetcher health** row or from the terminal.
 
-**Recommended flow:** run `python server.py`, open **Connections**, click **Connect** for each store. A headed Chrome/Edge window opens for cookie or OAuth sign-in. Credentials stay local in encrypted per-profile storage (`cache/auth/`). After connecting, click the matching chip in **Fetcher health** or run the script below.
+**Recommended flow:** run `python server.py`, open **Connections**, click **Connect** for each store. A headed Chrome/Edge window opens for cookie or OAuth sign-in (if neither is installed, BAKLOG downloads a one-time browser on first Connect). Credentials stay local in encrypted per-profile storage (`cache/auth/`). After connecting, click the matching chip in **Fetcher health** or run the script below.
 
 BAKLOG supports **19 store connections** across **12 libraries** and **8 wishlists** (27 fetcher jobs). Wishlist JSON files are optional per store - the **Fetcher health** row marks any file not yet fetched as *missing*; that is normal until you run the matching script.
 

--- a/guide/getting-started.md
+++ b/guide/getting-started.md
@@ -7,7 +7,7 @@ Install BAKLOG, run the local server, and open the dashboard in your browser.
 | Requirement | Notes |
 |-------------|-------|
 | **Python 3.11+** | Use a virtual environment (recommended) |
-| **Google Chrome or Chromium** | Required for the Connections sign-in flow. Microsoft Edge also works on Windows. Override with `BAKLOG_CHROME_PATH` if needed |
+| **Google Chrome or Chromium** | Preferred for Connections sign-in (Microsoft Edge also works). If none is installed, BAKLOG downloads a one-time browser (~150 MB) on first Connect. Override with `BAKLOG_CHROME_PATH` if needed |
 | **OS** | Windows 10/11 (primary), macOS, or Linux - see [FAQ](faq.md#supported-platforms) for store limits |
 
 On Windows, use the project `.venv` Python - not the Microsoft Store `python.exe` stub. Fetcher subprocesses launched from the stub can hang and wedge the run queue. `server.py` auto-picks `.venv` when present.

--- a/guide/profiles-and-moving-machines.md
+++ b/guide/profiles-and-moving-machines.md
@@ -41,7 +41,7 @@ Profile switch cancels in-flight fetchers, resets secrets cache, rebinds run pat
 
 1. **Old machine:** **Connections** → ⋮ → **Portable bundle…** → **Export bundle…**. Choose a passphrase and save the downloaded `baklog-secrets-*.bundle` somewhere safe (USB, cloud folder, etc.).
 
-2. **New machine:** Install BAKLOG (`pip install -r requirements.txt`, `python server.py`). Chrome or Edge must be installed for Connections sign-in.
+2. **New machine:** Install BAKLOG (`pip install -r requirements.txt`, `python server.py`). Chrome or Edge is preferred for Connections; if missing, first Connect downloads a one-time browser (~150 MB).
 
 3. **New machine:** **Connections** → ⋮ → **Portable bundle…** → **Import bundle…**, pick the file, enter the same passphrase. The page reloads with every provider restored - including browser cookie profiles.
 

--- a/guide/troubleshooting.md
+++ b/guide/troubleshooting.md
@@ -64,12 +64,14 @@ Sessions expire on different schedules per store. Epic wishlist, Nintendo, and c
 
 ## Chrome / Edge not found
 
-**Symptom:** Connections sign-in fails to open a browser.
+**Symptom:** Connections shows a browser warning, or sign-in fails to open a browser.
 
 **Fix:**
 
-1. Install Google Chrome or Microsoft Edge.
-2. Set `BAKLOG_CHROME_PATH` to the full path of your browser executable.
+1. Click **Connect** once while online - BAKLOG downloads a one-time browser (~150 MB) into its data folder when Chrome/Edge is missing.
+2. Or install Google Chrome or Microsoft Edge.
+3. Or set `BAKLOG_CHROME_PATH` to the full path of your browser executable.
+4. Offline / air-gapped: install Chrome or Edge (or set `BAKLOG_CHROME_PATH`). `BAKLOG_NO_CHROMIUM_DOWNLOAD=1` disables the auto-download.
 
 ## Battle.net cookie issues (Windows)
 

--- a/js/connections.js
+++ b/js/connections.js
@@ -1774,6 +1774,15 @@ async function startBrowserConnect(provider) {
         msg.message || "Complete sign-in in the browser window…";
   });
 
+  es.addEventListener("status", (ev) => {
+    try {
+      const msg = JSON.parse(ev.data);
+      if (log && msg.message) log.textContent = msg.message;
+    } catch {
+      /* ignore malformed status */
+    }
+  });
+
   es.addEventListener("signed_in", () => {
     if (log) log.textContent = "Signed in - extracting credentials…";
   });
@@ -1838,7 +1847,7 @@ function renderBrowserWarn() {
   el.hidden = false;
   el.innerHTML = `
     <div class="migration-banner-body">
-      <span class="text-amber-400">Google Chrome or Microsoft Edge is required for store sign-in. Install one, then click Connect.</span>
+      <span class="text-amber-400">No Chrome or Edge found. On first Connect, BAKLOG downloads a one-time browser (~150 MB), or install Google Chrome / Microsoft Edge.</span>
     </div>`;
 }
 

--- a/packaging/BETA-README.txt
+++ b/packaging/BETA-README.txt
@@ -11,7 +11,8 @@ Recommended: run BAKLOG-Setup.exe from your invite link.
 3. Launch BAKLOG from the Start Menu (or the optional desktop shortcut).
    A tray icon appears. Your browser opens to http://127.0.0.1:8765/
 4. Open the Connections tab and click Connect on each store you use.
-   Sign-in requires Google Chrome or Microsoft Edge.
+   Prefer Google Chrome or Microsoft Edge. If neither is installed,
+   Connect downloads a one-time BAKLOG browser (~150 MB) automatically.
 5. After connecting, fetcher chips import your libraries automatically.
 
 Your library data (profiles, games, connections) is stored separately at
@@ -33,7 +34,8 @@ Your data stays on this PC. Nothing is uploaded to our servers.
 
 If your invite build uses account sign-in (Supabase), you will see a sign-in
 screen before the dashboard. Create a free account on that screen, or sign in
-if you already have one. Store Connect still requires Chrome or Edge.
+if you already have one. Store Connect prefers Chrome or Edge; otherwise
+BAKLOG downloads a one-time browser (~150 MB) on first Connect.
 
 Bug reports: use the app menu (Report a bug…) or Discord #bug-reports.
 Version: see the About line in the app or BAKLOG-*.sha256 next to the zip.

--- a/packaging/baklog.spec
+++ b/packaging/baklog.spec
@@ -26,6 +26,7 @@ datas = [
     (str(root / "vendor"), "vendor"),
     (str(root / "curated"), "curated"),
     (str(root / "fetchers" / "manifest.json"), "fetchers"),
+    (str(root / "shared" / "chromium_cft_pin.json"), "shared"),
     (str(root / "pyproject.toml"), "."),
 ]
 

--- a/scripts/bump_chromium_pin.py
+++ b/scripts/bump_chromium_pin.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Refresh shared/chromium_cft_pin.json from Chrome for Testing Stable.
+
+Downloads each platform zip once, records SHA-256, and writes the pin file.
+Run when CDP breaks on an old CfT build:
+
+  .\\.venv\\Scripts\\python.exe scripts\\bump_chromium_pin.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PIN_PATH = ROOT / "shared" / "chromium_cft_pin.json"
+LKG_URL = (
+    "https://googlechromelabs.github.io/chrome-for-testing/"
+    "last-known-good-versions-with-downloads.json"
+)
+PLATFORMS = ("win64", "mac-arm64", "mac-x64", "linux64")
+USER_AGENT = "BAKLOG-bump-chromium-pin"
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main() -> int:
+    req = urllib.request.Request(LKG_URL, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        payload = json.loads(resp.read().decode("utf-8"))
+    stable = (payload.get("channels") or {}).get("Stable") or {}
+    version = str(stable.get("version") or "").strip()
+    chrome_downloads = (stable.get("downloads") or {}).get("chrome") or []
+    by_plat = {
+        str(item.get("platform")): str(item.get("url") or "").strip()
+        for item in chrome_downloads
+        if isinstance(item, dict)
+    }
+    if not version:
+        print("Stable channel missing version", file=sys.stderr)
+        return 1
+
+    platforms: dict[str, dict[str, str]] = {}
+    with tempfile.TemporaryDirectory(prefix="baklog-cft-pin-") as tmp:
+        tmp_path = Path(tmp)
+        for plat in PLATFORMS:
+            url = by_plat.get(plat)
+            if not url:
+                print(f"missing download for {plat}", file=sys.stderr)
+                return 1
+            print(f"Downloading {plat}…")
+            dest = tmp_path / f"{plat}.zip"
+            req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+            with urllib.request.urlopen(req, timeout=300) as resp, dest.open("wb") as out:
+                while True:
+                    chunk = resp.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    out.write(chunk)
+            sha = _sha256_file(dest)
+            print(f"  {plat}: {sha} ({dest.stat().st_size} bytes)")
+            platforms[plat] = {"url": url, "sha256": sha}
+
+    pin = {
+        "version": version,
+        "channel": "Stable",
+        "source": LKG_URL,
+        "platforms": platforms,
+    }
+    PIN_PATH.write_text(json.dumps(pin, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote {PIN_PATH} (CfT {version})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/shared/chromium_cft_pin.json
+++ b/shared/chromium_cft_pin.json
@@ -1,0 +1,23 @@
+{
+  "version": "151.0.7922.76",
+  "channel": "Stable",
+  "source": "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json",
+  "platforms": {
+    "win64": {
+      "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7922.76/win64/chrome-win64.zip",
+      "sha256": "19e700a206718b59ad2d208a37112b7543aead4b2da34b9539a3d6950341a866"
+    },
+    "mac-arm64": {
+      "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7922.76/mac-arm64/chrome-mac-arm64.zip",
+      "sha256": "4d727601939c51719d2b5ff7d2cd57c44fab6d2529f9f1d2e5769939b86590bf"
+    },
+    "mac-x64": {
+      "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7922.76/mac-x64/chrome-mac-x64.zip",
+      "sha256": "856f41d1ce82dd618c9e9317d48608286ba85d67be0e3870d64d305fe058b121"
+    },
+    "linux64": {
+      "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7922.76/linux64/chrome-linux64.zip",
+      "sha256": "d9e4c5916f77e737f22056cab47cd8abb7d39ebec559500ffc2d6f3e02106a7e"
+    }
+  }
+}

--- a/shared/chromium_runtime.py
+++ b/shared/chromium_runtime.py
@@ -1,0 +1,397 @@
+"""Download and cache a pinned Chrome for Testing build for CDP when no system browser exists."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import shutil
+import sys
+import tempfile
+import threading
+import time
+import zipfile
+from collections.abc import Callable
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+from shared.install_paths import bundle_root, data_root
+
+MARKER_NAME = "BAKLOG-chromium.json"
+PIN_NAME = "chromium_cft_pin.json"
+MAX_DOWNLOAD_BYTES = 250 * 1024 * 1024  # 250 MiB
+_ALLOWED_HOST = "storage.googleapis.com"
+_ALLOWED_PATH_PREFIX = "/chrome-for-testing-public/"
+_USER_AGENT = "BAKLOG-chromium-runtime"
+
+_download_lock = threading.Lock()
+
+ProgressCallback = Callable[[int, int | None], None]
+
+
+class ChromiumRuntimeError(RuntimeError):
+    """Managed Chromium download or install failed."""
+
+
+def platform_key() -> str:
+    """Return CfT platform id: win64 | mac-arm64 | mac-x64 | linux64."""
+    if sys.platform == "win32":
+        return "win64"
+    machine = (platform.machine() or "").lower()
+    if sys.platform == "darwin":
+        if machine in ("arm64", "aarch64"):
+            return "mac-arm64"
+        return "mac-x64"
+    return "linux64"
+
+
+def _pin_path() -> Path:
+    candidates = (
+        Path(__file__).resolve().parent / PIN_NAME,
+        bundle_root() / "shared" / PIN_NAME,
+    )
+    for path in candidates:
+        if path.is_file():
+            return path
+    raise ChromiumRuntimeError(
+        f"Missing Chromium pin file ({PIN_NAME}). Reinstall BAKLOG or restore shared/{PIN_NAME}."
+    )
+
+
+def load_pin() -> dict[str, Any]:
+    raw = json.loads(_pin_path().read_text(encoding="utf-8"))
+    if not isinstance(raw, dict) or not raw.get("version") or not isinstance(raw.get("platforms"), dict):
+        raise ChromiumRuntimeError(f"Invalid Chromium pin file: {_pin_path()}")
+    return raw
+
+
+def chromium_cache_root() -> Path:
+    return data_root() / "cache" / "chromium"
+
+
+def managed_chromium_dir(*, version: str | None = None, plat: str | None = None) -> Path:
+    pin = load_pin()
+    ver = version or str(pin["version"])
+    key = plat or platform_key()
+    return chromium_cache_root() / ver / key
+
+
+def _relative_exe(plat: str) -> Path:
+    if plat == "win64":
+        return Path("chrome-win64") / "chrome.exe"
+    if plat == "mac-arm64":
+        return (
+            Path("chrome-mac-arm64")
+            / "Google Chrome for Testing.app"
+            / "Contents"
+            / "MacOS"
+            / "Google Chrome for Testing"
+        )
+    if plat == "mac-x64":
+        return (
+            Path("chrome-mac-x64")
+            / "Google Chrome for Testing.app"
+            / "Contents"
+            / "MacOS"
+            / "Google Chrome for Testing"
+        )
+    if plat == "linux64":
+        return Path("chrome-linux64") / "chrome"
+    raise ChromiumRuntimeError(f"Unsupported Chromium platform: {plat}")
+
+
+def managed_chromium_exe(*, version: str | None = None, plat: str | None = None) -> Path:
+    key = plat or platform_key()
+    return managed_chromium_dir(version=version, plat=key) / _relative_exe(key)
+
+
+def _read_marker(dest_dir: Path) -> dict[str, Any] | None:
+    marker = dest_dir / MARKER_NAME
+    if not marker.is_file():
+        return None
+    try:
+        data = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def find_managed_chromium() -> Path | None:
+    """Return managed Chrome exe if the pinned install is present and valid."""
+    try:
+        pin = load_pin()
+    except ChromiumRuntimeError:
+        return None
+    plat = platform_key()
+    platforms = pin.get("platforms") or {}
+    entry = platforms.get(plat)
+    if not isinstance(entry, dict):
+        return None
+    dest = managed_chromium_dir(version=str(pin["version"]), plat=plat)
+    exe = managed_chromium_exe(version=str(pin["version"]), plat=plat)
+    marker = _read_marker(dest)
+    if marker is None:
+        return None
+    if str(marker.get("version") or "") != str(pin["version"]):
+        return None
+    if str(marker.get("platform") or "") != plat:
+        return None
+    if str(marker.get("sha256") or "").lower() != str(entry.get("sha256") or "").lower():
+        return None
+    if not exe.is_file():
+        return None
+    return exe
+
+
+def downloads_disabled() -> bool:
+    return os.environ.get("BAKLOG_NO_CHROMIUM_DOWNLOAD", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def is_allowed_cft_url(url: str) -> bool:
+    try:
+        parsed = urlparse(url.strip())
+    except ValueError:
+        return False
+    if parsed.scheme != "https":
+        return False
+    host = (parsed.hostname or "").lower()
+    if host != _ALLOWED_HOST:
+        return False
+    path = parsed.path or ""
+    return path.lower().startswith(_ALLOWED_PATH_PREFIX)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _zip_member_is_safe(member_name: str) -> bool:
+    normalized = member_name.replace("\\", "/")
+    if normalized.startswith("/") or ".." in PurePosixPath(normalized).parts:
+        return False
+    return True
+
+
+def safe_extract_cft_zip(zip_path: Path, dest_dir: Path) -> None:
+    """Extract a CfT zip with path-traversal guards."""
+    dest_resolved = dest_dir.resolve()
+    dest_resolved.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path) as archive:
+        for info in archive.infolist():
+            if not _zip_member_is_safe(info.filename):
+                raise ChromiumRuntimeError(f"unsafe zip member: {info.filename}")
+            target = (dest_resolved / info.filename).resolve()
+            if dest_resolved not in target.parents and target != dest_resolved:
+                raise ChromiumRuntimeError(f"zip member escapes target dir: {info.filename}")
+        archive.extractall(dest_resolved)
+
+
+def clear_macos_quarantine(app_bundle: Path) -> None:
+    """Clear Gatekeeper quarantine on a macOS .app (best-effort)."""
+    if sys.platform != "darwin":
+        return
+    if not app_bundle.exists():
+        return
+    import subprocess
+
+    try:
+        subprocess.run(
+            ["xattr", "-cr", str(app_bundle)],
+            check=False,
+            capture_output=True,
+            timeout=60,
+        )
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+
+def _chmod_exe(exe: Path) -> None:
+    if sys.platform == "win32":
+        return
+    try:
+        mode = exe.stat().st_mode
+        exe.chmod(mode | 0o111)
+    except OSError:
+        pass
+
+
+def _download_to_file(
+    url: str,
+    dest: Path,
+    *,
+    on_progress: ProgressCallback | None = None,
+    max_bytes: int = MAX_DOWNLOAD_BYTES,
+) -> int:
+    if not is_allowed_cft_url(url):
+        raise ChromiumRuntimeError("Chromium download URL is not allowlisted")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    req = Request(url, headers={"User-Agent": _USER_AGENT})
+    total = 0
+    total_hint: int | None = None
+    try:
+        with urlopen(req, timeout=120) as resp, dest.open("wb") as handle:
+            length = resp.headers.get("Content-Length")
+            if length:
+                try:
+                    total_hint = int(length)
+                except ValueError:
+                    total_hint = None
+            if on_progress:
+                on_progress(0, total_hint)
+            while True:
+                chunk = resp.read(1024 * 1024)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > max_bytes:
+                    raise ChromiumRuntimeError("Chromium download exceeds size cap")
+                handle.write(chunk)
+                if on_progress:
+                    on_progress(total, total_hint)
+    except ChromiumRuntimeError:
+        if dest.is_file():
+            dest.unlink(missing_ok=True)
+        raise
+    except OSError as exc:
+        if dest.is_file():
+            dest.unlink(missing_ok=True)
+        raise ChromiumRuntimeError(f"Chromium download failed: {exc}") from exc
+    except Exception as exc:  # noqa: BLE001 - surface network failures clearly
+        if dest.is_file():
+            dest.unlink(missing_ok=True)
+        raise ChromiumRuntimeError(f"Chromium download failed: {exc}") from exc
+    return total
+
+
+def _write_marker(dest_dir: Path, *, version: str, plat: str, sha256: str, url: str) -> None:
+    payload = {
+        "version": version,
+        "platform": plat,
+        "sha256": sha256,
+        "url": url,
+        "downloaded_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    marker = dest_dir / MARKER_NAME
+    tmp = dest_dir / f".{MARKER_NAME}.tmp"
+    tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    tmp.replace(marker)
+
+
+def _prune_old_versions(keep_version: str) -> None:
+    root = chromium_cache_root()
+    if not root.is_dir():
+        return
+    for child in root.iterdir():
+        if not child.is_dir():
+            continue
+        if child.name in {keep_version, ".tmp"}:
+            continue
+        try:
+            shutil.rmtree(child, ignore_errors=True)
+        except OSError:
+            pass
+
+
+def _mac_app_bundle(plat: str, dest_dir: Path) -> Path | None:
+    if plat == "mac-arm64":
+        return dest_dir / "chrome-mac-arm64" / "Google Chrome for Testing.app"
+    if plat == "mac-x64":
+        return dest_dir / "chrome-mac-x64" / "Google Chrome for Testing.app"
+    return None
+
+
+def ensure_chromium(*, on_progress: ProgressCallback | None = None) -> Path:
+    """Return a usable Chromium exe, downloading the pinned CfT build if needed."""
+    existing = find_managed_chromium()
+    if existing is not None:
+        return existing
+
+    if downloads_disabled():
+        raise ChromiumRuntimeError(
+            "No Chrome or Edge browser found, and BAKLOG_NO_CHROMIUM_DOWNLOAD is set. "
+            "Install Google Chrome or Microsoft Edge, or set BAKLOG_CHROME_PATH, "
+            "or unset BAKLOG_NO_CHROMIUM_DOWNLOAD and go online once."
+        )
+
+    pin = load_pin()
+    plat = platform_key()
+    entry = (pin.get("platforms") or {}).get(plat)
+    if not isinstance(entry, dict):
+        raise ChromiumRuntimeError(f"Chromium pin has no entry for platform {plat}")
+    url = str(entry.get("url") or "").strip()
+    expected_sha = str(entry.get("sha256") or "").strip().lower()
+    if not url or not expected_sha or len(expected_sha) != 64:
+        raise ChromiumRuntimeError(f"Chromium pin entry for {plat} is incomplete")
+    if not is_allowed_cft_url(url):
+        raise ChromiumRuntimeError("Chromium pin URL is not allowlisted")
+
+    version = str(pin["version"])
+    final_dir = managed_chromium_dir(version=version, plat=plat)
+    final_exe = managed_chromium_exe(version=version, plat=plat)
+
+    with _download_lock:
+        existing = find_managed_chromium()
+        if existing is not None:
+            return existing
+
+        tmp_root = chromium_cache_root() / ".tmp"
+        tmp_root.mkdir(parents=True, exist_ok=True)
+        work = Path(tempfile.mkdtemp(prefix=f"cft-{plat}-", dir=tmp_root))
+        zip_path = work / "chrome.zip"
+        extract_dir = work / "extract"
+        extract_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            _download_to_file(url, zip_path, on_progress=on_progress)
+            actual_sha = _sha256_file(zip_path)
+            if actual_sha.lower() != expected_sha:
+                raise ChromiumRuntimeError(
+                    "Chromium download failed integrity check (SHA-256 mismatch). "
+                    "Delete cache/chromium and try again, or install Chrome/Edge."
+                )
+            safe_extract_cft_zip(zip_path, extract_dir)
+            staged_exe = extract_dir / _relative_exe(plat)
+            if not staged_exe.is_file():
+                raise ChromiumRuntimeError(
+                    f"Chromium archive missing expected executable: {_relative_exe(plat)}"
+                )
+            app = _mac_app_bundle(plat, extract_dir)
+            if app is not None:
+                clear_macos_quarantine(app)
+            _chmod_exe(staged_exe)
+
+            if final_dir.exists():
+                shutil.rmtree(final_dir, ignore_errors=True)
+            final_dir.parent.mkdir(parents=True, exist_ok=True)
+            # Move extracted tree into the versioned cache dir.
+            extract_dir.replace(final_dir)
+            _write_marker(
+                final_dir,
+                version=version,
+                plat=plat,
+                sha256=expected_sha,
+                url=url,
+            )
+            if not final_exe.is_file():
+                raise ChromiumRuntimeError("Chromium install finished but executable is missing")
+            _prune_old_versions(version)
+            return final_exe
+        except Exception:
+            if final_dir.exists() and not final_exe.is_file():
+                shutil.rmtree(final_dir, ignore_errors=True)
+            raise
+        finally:
+            shutil.rmtree(work, ignore_errors=True)

--- a/tests/test_chromium_runtime.py
+++ b/tests/test_chromium_runtime.py
@@ -1,0 +1,278 @@
+"""Unit tests for managed Chrome for Testing download/cache."""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import shared.chromium_runtime as crt
+
+
+def _make_chrome_zip(plat: str, payload: bytes = b"fake-chrome") -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        if plat == "win64":
+            zf.writestr("chrome-win64/chrome.exe", payload)
+        elif plat == "linux64":
+            zf.writestr("chrome-linux64/chrome", payload)
+        elif plat == "mac-arm64":
+            zf.writestr(
+                "chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/"
+                "Google Chrome for Testing",
+                payload,
+            )
+        elif plat == "mac-x64":
+            zf.writestr(
+                "chrome-mac-x64/Google Chrome for Testing.app/Contents/MacOS/"
+                "Google Chrome for Testing",
+                payload,
+            )
+        else:
+            raise AssertionError(plat)
+    return buf.getvalue()
+
+
+def _pin_for(plat: str, url: str, sha256: str, version: str = "1.0.0") -> dict[str, Any]:
+    return {
+        "version": version,
+        "channel": "Stable",
+        "platforms": {plat: {"url": url, "sha256": sha256}},
+    }
+
+
+@pytest.fixture()
+def data_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    monkeypatch.setenv("BAKLOG_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.delenv("BAKLOG_NO_CHROMIUM_DOWNLOAD", raising=False)
+    return tmp_path / "data"
+
+
+def test_platform_key_win(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(crt.sys, "platform", "win32")
+    assert crt.platform_key() == "win64"
+
+
+def test_is_allowed_cft_url() -> None:
+    assert crt.is_allowed_cft_url(
+        "https://storage.googleapis.com/chrome-for-testing-public/1/win64/chrome-win64.zip"
+    )
+    assert not crt.is_allowed_cft_url("https://evil.example/chrome.zip")
+    assert not crt.is_allowed_cft_url("http://storage.googleapis.com/chrome-for-testing-public/x")
+
+
+def test_safe_extract_rejects_zip_slip(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.zip"
+    with zipfile.ZipFile(bad, "w") as zf:
+        zf.writestr("../evil.exe", b"x")
+    with pytest.raises(crt.ChromiumRuntimeError, match="unsafe"):
+        crt.safe_extract_cft_zip(bad, tmp_path / "out")
+
+
+def test_find_managed_requires_marker_and_exe(
+    monkeypatch: pytest.MonkeyPatch, data_dir: Path
+) -> None:
+    plat = "win64"
+    url = (
+        "https://storage.googleapis.com/chrome-for-testing-public/"
+        "1.0.0/win64/chrome-win64.zip"
+    )
+    sha = "a" * 64
+    pin = _pin_for(plat, url, sha)
+    monkeypatch.setattr(crt, "load_pin", lambda: pin)
+    monkeypatch.setattr(crt, "platform_key", lambda: plat)
+    assert crt.find_managed_chromium() is None
+
+    dest = crt.managed_chromium_dir(version="1.0.0", plat=plat)
+    exe = crt.managed_chromium_exe(version="1.0.0", plat=plat)
+    exe.parent.mkdir(parents=True)
+    exe.write_bytes(b"chrome")
+    crt._write_marker(dest, version="1.0.0", plat=plat, sha256=sha, url=url)
+    assert crt.find_managed_chromium() == exe
+
+
+def test_ensure_downloads_when_missing(
+    monkeypatch: pytest.MonkeyPatch, data_dir: Path
+) -> None:
+    plat = "win64"
+    raw = _make_chrome_zip(plat)
+    import hashlib
+
+    sha = hashlib.sha256(raw).hexdigest()
+    url = (
+        "https://storage.googleapis.com/chrome-for-testing-public/"
+        "9.9.9/win64/chrome-win64.zip"
+    )
+    pin = _pin_for(plat, url, sha, version="9.9.9")
+    monkeypatch.setattr(crt, "load_pin", lambda: pin)
+    monkeypatch.setattr(crt, "platform_key", lambda: plat)
+
+    progress: list[tuple[int, int | None]] = []
+
+    def fake_download(url_arg: str, dest: Path, *, on_progress=None, max_bytes=0):  # noqa: ANN001
+        assert url_arg == url
+        dest.write_bytes(raw)
+        if on_progress:
+            on_progress(len(raw), len(raw))
+            progress.append((len(raw), len(raw)))
+        return len(raw)
+
+    monkeypatch.setattr(crt, "_download_to_file", fake_download)
+    exe = crt.ensure_chromium(on_progress=lambda n, t: progress.append((n, t)))
+    assert exe.is_file()
+    assert exe.name == "chrome.exe"
+    assert crt.find_managed_chromium() == exe
+    assert progress
+
+
+def test_ensure_sha_mismatch_cleans_up(
+    monkeypatch: pytest.MonkeyPatch, data_dir: Path
+) -> None:
+    plat = "win64"
+    raw = _make_chrome_zip(plat)
+    url = (
+        "https://storage.googleapis.com/chrome-for-testing-public/"
+        "9.9.9/win64/chrome-win64.zip"
+    )
+    pin = _pin_for(plat, url, "b" * 64, version="9.9.9")
+    monkeypatch.setattr(crt, "load_pin", lambda: pin)
+    monkeypatch.setattr(crt, "platform_key", lambda: plat)
+
+    def fake_download(url_arg: str, dest: Path, *, on_progress=None, max_bytes=0):  # noqa: ANN001
+        dest.write_bytes(raw)
+        return len(raw)
+
+    monkeypatch.setattr(crt, "_download_to_file", fake_download)
+    with pytest.raises(crt.ChromiumRuntimeError, match="integrity"):
+        crt.ensure_chromium()
+    final = crt.managed_chromium_dir(version="9.9.9", plat=plat)
+    assert not final.exists() or not crt.managed_chromium_exe(version="9.9.9", plat=plat).is_file()
+
+
+def test_no_download_env(
+    monkeypatch: pytest.MonkeyPatch, data_dir: Path
+) -> None:
+    monkeypatch.setenv("BAKLOG_NO_CHROMIUM_DOWNLOAD", "1")
+    monkeypatch.setattr(crt, "find_managed_chromium", lambda: None)
+    with pytest.raises(crt.ChromiumRuntimeError, match="BAKLOG_NO_CHROMIUM_DOWNLOAD"):
+        crt.ensure_chromium()
+
+
+def test_clear_macos_quarantine_invoked(
+    monkeypatch: pytest.MonkeyPatch, data_dir: Path, tmp_path: Path
+) -> None:
+    plat = "mac-arm64"
+    raw = _make_chrome_zip(plat)
+    import hashlib
+
+    sha = hashlib.sha256(raw).hexdigest()
+    url = (
+        "https://storage.googleapis.com/chrome-for-testing-public/"
+        "9.9.9/mac-arm64/chrome-mac-arm64.zip"
+    )
+    pin = _pin_for(plat, url, sha, version="9.9.9")
+    monkeypatch.setattr(crt, "load_pin", lambda: pin)
+    monkeypatch.setattr(crt, "platform_key", lambda: plat)
+    monkeypatch.setattr(crt.sys, "platform", "darwin")
+
+    calls: list[Path] = []
+
+    def fake_clear(app: Path) -> None:
+        calls.append(app)
+
+    monkeypatch.setattr(crt, "clear_macos_quarantine", fake_clear)
+
+    def fake_download(url_arg: str, dest: Path, *, on_progress=None, max_bytes=0):  # noqa: ANN001
+        dest.write_bytes(raw)
+        return len(raw)
+
+    monkeypatch.setattr(crt, "_download_to_file", fake_download)
+    exe = crt.ensure_chromium()
+    assert exe.is_file()
+    assert calls
+    assert calls[0].name.endswith(".app")
+
+
+def test_pin_file_committed() -> None:
+    pin = crt.load_pin()
+    assert pin["version"]
+    for key in ("win64", "mac-arm64", "mac-x64", "linux64"):
+        entry = pin["platforms"][key]
+        assert crt.is_allowed_cft_url(entry["url"])
+        assert len(entry["sha256"]) == 64
+
+
+def test_cdp_find_uses_managed(
+    monkeypatch: pytest.MonkeyPatch, data_dir: Path, tmp_path: Path
+) -> None:
+    import auth.cdp_browser as cdp
+
+    monkeypatch.delenv("BAKLOG_CHROME_PATH", raising=False)
+    monkeypatch.setattr(cdp, "_chromium_executable_candidates", lambda: [])
+    monkeypatch.setattr(cdp.shutil, "which", lambda _name: None)
+
+    managed = tmp_path / "managed" / "chrome.exe"
+    managed.parent.mkdir(parents=True)
+    managed.write_bytes(b"x")
+    monkeypatch.setattr(
+        "shared.chromium_runtime.find_managed_chromium",
+        lambda: managed,
+    )
+    assert cdp.find_chromium_executable() == managed
+
+
+def test_cdp_ensure_downloads_when_find_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import auth.cdp_browser as cdp
+
+    monkeypatch.delenv("BAKLOG_CHROME_PATH", raising=False)
+    managed = tmp_path / "dl" / "chrome.exe"
+    managed.parent.mkdir(parents=True)
+    managed.write_bytes(b"x")
+
+    def boom() -> Path:
+        raise RuntimeError("No Chrome or Edge browser found")
+
+    monkeypatch.setattr(cdp, "find_chromium_executable", boom)
+    monkeypatch.setattr(
+        "shared.chromium_runtime.ensure_chromium",
+        lambda *, on_progress=None: managed,
+    )
+    assert cdp.ensure_chromium_executable() == managed
+
+
+def test_cdp_ensure_does_not_download_for_bad_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import auth.cdp_browser as cdp
+
+    monkeypatch.setenv("BAKLOG_CHROME_PATH", "/no/such/browser.exe")
+    called = {"n": 0}
+
+    def fake_ensure(*, on_progress=None):  # noqa: ANN001
+        called["n"] += 1
+        raise AssertionError("should not download")
+
+    monkeypatch.setattr("shared.chromium_runtime.ensure_chromium", fake_ensure)
+    with pytest.raises(RuntimeError, match="BAKLOG_CHROME_PATH"):
+        cdp.ensure_chromium_executable()
+    assert called["n"] == 0
+
+
+def test_launch_uses_ensure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import auth.cdp_browser as cdp
+
+    calls: list[str] = []
+
+    def fake_ensure(*, on_progress=None):  # noqa: ANN001
+        calls.append("ensure")
+        raise RuntimeError("stop before Popen")
+
+    monkeypatch.setattr(cdp, "ensure_chromium_executable", fake_ensure)
+    with pytest.raises(RuntimeError, match="stop before Popen"):
+        cdp.launch_persistent_profile(tmp_path / "profile")
+    assert calls == ["ensure"]

--- a/tests/test_packaging_manifest.py
+++ b/tests/test_packaging_manifest.py
@@ -102,6 +102,14 @@ def test_pyinstaller_datas_include_curated_feeds() -> None:
     ), "packaging/baklog.spec datas must bundle curated/ (free_claims.fallback.json offline)"
 
 
+def test_pyinstaller_datas_include_chromium_cft_pin() -> None:
+    text = SPEC.read_text(encoding="utf-8")
+    assert 'chromium_cft_pin.json' in text, (
+        "packaging/baklog.spec datas must bundle shared/chromium_cft_pin.json"
+    )
+    assert (ROOT / "shared" / "chromium_cft_pin.json").is_file()
+
+
 def test_inno_installer_branding_assets() -> None:
     """Inno Setup wizard/icon files must exist with expected dimensions."""
     packaging = ROOT / "packaging"


### PR DESCRIPTION
## Summary
- Download a pinned Chrome for Testing build into `data_root()/cache/chromium/` on first CDP launch when system Chrome/Edge is missing
- Keep CDP launch path unchanged; `BAKLOG_CHROME_PATH` and system browsers still win; `BAKLOG_NO_CHROMIUM_DOWNLOAD=1` disables fallback
- Connections SSE progress + banner/docs; pin JSON bundled in PyInstaller datas

## Test plan
- [x] `pytest tests/test_chromium_runtime.py` (mocked download / SHA / zip-slip / precedence)
- [ ] Connect on a machine without Chrome/Edge (or with candidates stubbed) and confirm one-time download + sign-in window
- [ ] With Chrome/Edge installed, confirm no download
- [ ] With `BAKLOG_CHROME_PATH` set to a missing path, confirm no silent download