### PR TITLE
Gate ITAD deal UI; PSN connect diagnostics

### DIFF
--- a/auth/cdp_browser.py
+++ b/auth/cdp_browser.py
@@ -1681,6 +1681,14 @@ def launch_persistent_profile(
     profile = Path(user_data_dir)
     profile.mkdir(parents=True, exist_ok=True)
     _ensure_persistent_session_prefs(profile)
+    launch_t0 = time.time()
+    from auth.connect_log import connect_log
+
+    connect_log(
+        "cdp",
+        f"launch start exe={Path(exe).name} profile={profile.name} port={port}",
+        key="launch",
+    )
 
     args = [
         str(exe),
@@ -1939,6 +1947,12 @@ def launch_persistent_profile(
                 page.goto(initial_url, wait_until="domcontentloaded", timeout=25_000)
             except Exception:
                 pass
+
+    connect_log(
+        "cdp",
+        f"attached ms={int((time.time() - launch_t0) * 1000)} pages={len(context.pages)}",
+        key="attached",
+    )
 
     return context
 

--- a/auth/connect_log.py
+++ b/auth/connect_log.py
@@ -57,3 +57,22 @@ def reset_connect_log_for_tests() -> None:
     """Clear cached paths / dedupe state (unit tests only)."""
     _last_log_by_key.clear()
     _log_paths.clear()
+
+
+def connect_log_tails(*, max_lines: int = 40) -> dict[str, list[str]]:
+    """Return tails of ``connect-*.log`` files under the data dir."""
+    from shared.server_support import tail_text_file
+
+    try:
+        from shared.install_paths import data_root
+
+        root = data_root()
+    except Exception:  # noqa: BLE001
+        return {}
+    out: dict[str, list[str]] = {}
+    try:
+        for path in sorted(root.glob("connect-*.log")):
+            out[path.name] = tail_text_file(path, max_lines=max_lines)
+    except Exception:  # noqa: BLE001
+        pass
+    return out

--- a/auth/runner.py
+++ b/auth/runner.py
@@ -8,6 +8,7 @@ import re
 import threading
 import time
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
@@ -610,34 +611,43 @@ def _fetch_npsso_background(page, context) -> tuple[str, str]:
 
 def _extract_psn(page, context, session: AuthSession | None = None) -> dict[str, str]:
     """Wait for sign-in on the PlayStation Store, then capture a valid npsso."""
-    deadline = time.time() + SUCCESS_WAIT_SEC
-    last_ssocookie = 0.0
+    from auth.cdp_browser import abort_if_browser_closed
+    from auth.connect_log import connect_log
+    from auth.connect_loop import run_connect_poll
+
+    connect_log("psn", "connect poll start", key="enter")
+
     tried_cookie: set[str] = set()
-    last_msg = 0.0
-    while time.time() < deadline:
+    last_ssocookie = [0.0]
+    last_blocked_nav = [0.0]
+
+    def _check() -> dict[str, str] | None:
         abort_if_browser_closed(context)
         url = page.url or ""
-
-        # Always re-check by fetching from ssocookie endpoint first; that's
-        # the source of truth, not the stale cookie that may be in the jar.
         now = time.time()
-        if now - last_ssocookie >= PSN_SSOCOOKIE_INTERVAL_SEC:
-            last_ssocookie = now
-            fresh, _source = _fetch_npsso_background(page, context)
+        if now - last_ssocookie[0] >= PSN_SSOCOOKIE_INTERVAL_SEC:
+            last_ssocookie[0] = now
+            fresh, source = _fetch_npsso_background(page, context)
+            connect_log(
+                "psn",
+                f"ssocookie poll source={source or 'none'} has_token={'yes' if fresh else 'no'}",
+                key="ssocookie",
+            )
             if fresh and fresh not in tried_cookie:
                 result = _check_npsso(fresh)
+                connect_log("psn", f"npsso probe={result}", key=f"npsso-{result}")
                 if result == PSN_CHECK_VALID:
+                    connect_log("psn", "session ready", key="ready")
                     return {"PSN_NPSSO": fresh}
-                # Only blacklist a token PSN positively rejected — an
-                # "unreachable" result is a network blip, so keep retrying it.
                 if result == PSN_CHECK_INVALID:
                     tried_cookie.add(fresh)
 
-        # Also try the cookie directly (cheap)
         cookie_val = _psn_cookie(context)
         if cookie_val and cookie_val not in tried_cookie:
             result = _check_npsso(cookie_val)
+            connect_log("psn", f"cookie jar probe={result}", key=f"jar-{result}")
             if result == PSN_CHECK_VALID:
+                connect_log("psn", "session ready via cookie jar", key="ready-jar")
                 return {"PSN_NPSSO": cookie_val}
             if result == PSN_CHECK_INVALID:
                 tried_cookie.add(cookie_val)
@@ -648,38 +658,35 @@ def _extract_psn(page, context, session: AuthSession | None = None) -> dict[str,
             body = ""
 
         if _psn_on_blocked_account_page(url, body):
-            if session and now - last_msg > 6:
-                last_msg = now
-                session.emit(
-                    "waiting_for_user",
-                    {"message": "Use Sign In on the PlayStation Store (top-right) to continue"},
-                )
-            try:
-                page.goto(PSN_STORE_URL, wait_until="domcontentloaded", timeout=20000)
-            except Exception:
-                pass
-            page.wait_for_timeout(1500)
-            continue
+            connect_log("psn", f"blocked account page url={(url or '')[:120]}", key="blocked")
+            if now - last_blocked_nav[0] > 6:
+                last_blocked_nav[0] = now
+                try:
+                    page.goto(PSN_STORE_URL, wait_until="domcontentloaded", timeout=20000)
+                except Exception:
+                    pass
+        return None
 
-        if session and now - last_msg > 6:
-            last_msg = now
-            session.emit(
-                "waiting_for_user",
-                {
-                    "message": (
-                        "Signed in to PlayStation? Click anything on the page so Sony "
-                        "issues a fresh session cookie."
-                    )
-                    if "store.playstation.com" in url.lower()
-                    else "Sign in on the PlayStation Store (Sign In, top-right)."
-                },
+    def _hint() -> str:
+        url = (page.url or "").lower()
+        if "store.playstation.com" in url:
+            return (
+                "Signed in to PlayStation? Click anything on the page so Sony "
+                "issues a fresh session cookie."
             )
+        return "Sign in on the PlayStation Store (Sign In, top-right)."
 
-        page.wait_for_timeout(int(POLL_SEC * 1000))
-
-    raise RuntimeError(
-        "Could not capture a PSN session — sign in on the PlayStation Store (Sign In, top-right) "
-        "and keep this window open until it closes."
+    return run_connect_poll(
+        context=context,
+        session=session,
+        deadline=time.time() + SUCCESS_WAIT_SEC,
+        poll_sec=POLL_SEC,
+        check=_check,
+        hint=_hint,
+        timeout_message=(
+            "Could not capture a PSN session — sign in on the PlayStation Store (Sign In, top-right) "
+            "and keep this window open until it closes."
+        ),
     )
 
 
@@ -1860,8 +1867,10 @@ def run_browser_auth(provider: str, session: AuthSession) -> dict[str, str] | No
     session.emit("waiting_for_user", {"message": connect_hint})
 
     from auth.cdp_browser import release_chromium_profile_lock
+    from auth.connect_log import connect_log
 
     release_chromium_profile_lock(user_data)
+    connect_log(provider, f"launching browser profile={Path(user_data).name}", key="launch")
 
     with launch_persistent_profile(
         user_data,

--- a/guide/connecting-stores.md
+++ b/guide/connecting-stores.md
@@ -239,6 +239,8 @@ python fetch_itad.py                        # IsThereAnyDeal prices → itad_pri
 
 **Display currency / FX:** set `ITAD_COUNTRY` (e.g. `GB`) before `fetch_itad.py`. ITAD and wishlist rows use that region's currency. The script caches daily exchange rates from [Frankfurter](https://www.frankfurter.app/) and writes comparable `price_amount` fields on wishlist JSON while keeping `price_native` / `currency_native` for the store's real price. Re-run ITAD after wishlist fetches to refresh conversions.
 
+**Wishlist deal UI:** Cross-store deal prices on the Wishlist tab and Dashboard require **ITAD** connected in Connections (validated API key) plus a run of `fetch_itad.py` from Fetcher health.
+
 ---
 
 ## Platform availability

--- a/guide/troubleshooting.md
+++ b/guide/troubleshooting.md
@@ -224,6 +224,20 @@ We skip paid signing for now; future releases may add certificates. Verify SHA-2
 
 Dashboard JavaScript errors can be reported via the sticky toast or **Report a bug…** menu. Fetcher failures are separate - check **Fetcher health**, exit codes, and `profiles/<id>/cache/runs/*.jsonl`. See [Getting help](getting-help.md).
 
+## Connect window closes immediately
+
+**Symptom:** Battle.net, PSN, or another store Connect opens a browser window that closes within a few seconds.
+
+**Fix:**
+
+1. Confirm you are on **v0.8.47 or newer** (⋮ menu version, or `GET /api/diagnostics`).
+2. Run BAKLOG from a permanent folder, not a temp zip extract (`running_from_temp: true` in diagnostics blocks in-app updates and can break profile writes).
+3. Open your data folder (Settings or diagnostics `data_dir_path`) and check `connect-battlenet.log`, `connect-psn.log`, or `connect-cdp.log` after a failed attempt.
+4. If the first Connect needs a one-time browser download, wait for the **Downloading BAKLOG browser** progress message before the window opens.
+5. Use **Reconnect** and complete sign-in without closing the window early.
+
+Include the relevant `connect-*.log` tail when reporting a bug (**Report a bug…** copies diagnostics automatically on recent builds).
+
 ## Still stuck?
 
 - [FAQ](faq.md)

--- a/index.html
+++ b/index.html
@@ -1459,6 +1459,15 @@
         </section>
 
         <div
+          id="wishlistItadCta"
+          class="hidden mb-3 rounded-lg border border-slate-600 bg-slate-800/80 px-3 py-2 text-sm text-slate-300"
+          role="note"
+        >
+          Connect ITAD in Connections, then run the deal price fetcher to see
+          wishlist deals and price tracking here.
+        </div>
+
+        <div
           id="wishlistDealRadar"
           class="dash-wishlist-stats-target hidden grid grid-cols-1 lg:grid-cols-3 gap-4 mb-4"
         ></div>

--- a/js/active-filters.js
+++ b/js/active-filters.js
@@ -4,6 +4,7 @@
  */
 
 import { state, STATUS_FILTER_LABELS } from './state.js';
+import { isItadDealsAvailable } from './itad-deal-gate.js';
 import { WISHLIST_STATUS_LABELS } from './row-templates.js';
 import { getCoopFilterMode, COOP_FILTER_LABELS } from './prefs.js';
 import { formatMoney, displayCurrency } from './currency.js';
@@ -58,7 +59,7 @@ export function collectActiveFilters() {
   if (state.cleanupModeActive && state.activeView === "library") pills.push({ kind: "cleanup", value: "1", label: "Cleanup mode" });
   if (state.activeView === "itch" && state.sessionPrefs.itchHideNonGames) pills.push({ kind: "itchHideNonGames", value: "1", label: "Hide tools, soundtracks, etc." });
   if (state.sessionPrefs.crossStoreDedup && state.allGames.length > 0) pills.push({ kind: "dedup", value: "1", label: "Hide duplicates" });
-  if (state.activeView === "wishlist") {
+  if (state.activeView === "wishlist" && isItadDealsAvailable()) {
     if (state.prefs.dealOnSaleOnly) pills.push({ kind: "dealOnSale", value: "1", label: "On sale only" });
     if (state.prefs.dealHistoricalLowOnly) pills.push({ kind: "dealLow", value: "1", label: "Historical low only" });
     if (state.prefs.dealHideOwned) pills.push({ kind: "dealHideOwned", value: "1", label: "Hide owned" });

--- a/js/app.js
+++ b/js/app.js
@@ -106,6 +106,7 @@ import {
 } from "./dashboard-charts.js";
 import { prewarmTableQueryForView, tableFingerprint } from "./table-ui.js";
 import { applyColumnVisibility } from "./table-columns.js";
+import { isItadDealsAvailable, syncItadDealSurfaces } from "./itad-deal-gate.js";
 import { initBugReportDialog } from "./bug-report.js";
 import { refreshAdsForPlanChange } from "./sponsored-deals.js";
 import {
@@ -214,6 +215,9 @@ async function bootstrap() {
   syncViewTabAria(state.activeView);
   savePrefs();
   bindEvents();
+  document.addEventListener("baklog:auth-status", () => {
+    syncItadDealSurfaces();
+  });
   wireProView();
   onPlanChange(() => {
     applyProTabVisibility();
@@ -257,6 +261,7 @@ async function bootstrap() {
   syncFilterDomFromState();
   updateCleanupBtnState();
   updateViewChrome();
+  syncItadDealSurfaces({ rerender: false });
   if (
     state.activeView === "library" &&
     state.prefs.picksTab === "wishlistDeals"
@@ -266,6 +271,7 @@ async function bootstrap() {
   }
   if (
     state.activeView === "wishlist" &&
+    isItadDealsAvailable() &&
     state.prefs.picksTab !== "wishlistDeals"
   ) {
     state.prefs.picksTab = "wishlistDeals";

--- a/js/column-picker.js
+++ b/js/column-picker.js
@@ -4,6 +4,7 @@ import { bindEscapeClose, trapFocus } from './focus-trap.js';
 import { escapeHtml } from './dom-util.js';
 import {
   toggleableColumns,
+  columnsForPicker,
   isColumnVisible,
   setColumnVisible,
   resetColumns,
@@ -36,7 +37,7 @@ function render() {
   const list = el(LIST_ID);
   if (!list) return;
   const view = currentView();
-  const cols = toggleableColumns();
+  const cols = columnsForPicker(view);
   list.innerHTML = cols.map(c => rowHtml(c, view)).join('');
 }
 

--- a/js/connections-status.js
+++ b/js/connections-status.js
@@ -49,6 +49,11 @@ export function isProviderConnected(provider) {
   return authStatus.some(p => p.key === provider && p.status === 'connected');
 }
 
+/** ITAD deal/pricing UI is meaningful only after a validated API key is saved. */
+export function isItadDealsAvailable() {
+  return isProviderConnected('itad');
+}
+
 /** Number of auth providers with status === 'connected'. */
 export function connectedProviderCount() {
   return authStatus.filter(p => p.status === 'connected').length;

--- a/js/connections.js
+++ b/js/connections.js
@@ -46,6 +46,7 @@ export {
   providerForFetcher,
   providerStatus,
 };
+export { isItadDealsAvailable } from "./itad-deal-gate.js";
 export {
   displayStatus,
   groupRepFor,
@@ -1805,7 +1806,7 @@ async function startBrowserConnect(provider) {
     // On frozen builds, the server console stderr may contain the actual
     // error details (e.g. a traceback from the connect callback).
     if (_serverFrozen && log) {
-      log.textContent += " Check the BAKLOG server console for error details.";
+      log.textContent += " Check connect-*.log in your BAKLOG data folder (see Settings > Data folder).";
     }
 
     connectUiFinished = true;

--- a/js/creative-metrics.js
+++ b/js/creative-metrics.js
@@ -15,6 +15,7 @@ import {
 import { gameGenresCanonical } from "./genres.js";
 import { getPersonal } from "./personal-storage.js";
 import { getDealInfo, dealScore } from "./deals.js";
+import { isItadDealsAvailable } from "./itad-deal-gate.js";
 import { formatMoney, displayCurrency } from "./currency.js";
 import { hoardRate, oldestWishlist } from "./sabermetrics.js";
 
@@ -365,20 +366,22 @@ export function computeCreativeMetrics(games, snap) {
   }
 
   const wl = state.wishlistGames || [];
-  const atLow = wl.filter((g) => {
-    const d = getDealInfo(g);
-    return d && d.isHistoricalLow;
-  });
-  if (atLow.length) out.patiencePays = atLow.length;
+  if (isItadDealsAvailable()) {
+    const atLow = wl.filter((g) => {
+      const d = getDealInfo(g);
+      return d && d.isHistoricalLow;
+    });
+    if (atLow.length) out.patiencePays = atLow.length;
 
-  const onSaleWl = wl.filter((g) => {
-    const d = getDealInfo(g);
-    return d && (d.cut || 0) > 0;
-  });
-  if (onSaleWl.length) {
-    const top = [...onSaleWl].sort((a, b) => dealScore(b) - dealScore(a))[0];
-    const cut = getDealInfo(top)?.cut || 0;
-    out.gotAway = { name: top.name, cut };
+    const onSaleWl = wl.filter((g) => {
+      const d = getDealInfo(g);
+      return d && (d.cut || 0) > 0;
+    });
+    if (onSaleWl.length) {
+      const top = [...onSaleWl].sort((a, b) => dealScore(b) - dealScore(a))[0];
+      const cut = getDealInfo(top)?.cut || 0;
+      out.gotAway = { name: top.name, cut };
+    }
   }
 
   const wlOldest = oldestWishlist(wl);

--- a/js/dashboard-cards.js
+++ b/js/dashboard-cards.js
@@ -9,6 +9,7 @@ import { freeItchCount, paidItchCount, itchSpendTotal } from './sabermetrics.js'
 import { gameGenresCanonical } from './genres.js';
 import { getPersonal } from './personal-storage.js';
 import { wishlistGamesWithDeals, dealHeroCardHtml, dealHeroEmptyHtml, dealSaleScoreboardCardHtml, dealStealsCardHtml, getDealInfo, dealScore, effectiveDiscountPercent, isStealDeal } from './deals.js';
+import { isItadDealsAvailable } from './itad-deal-gate.js';
 import {
   sponsoredDealCardHtml,
   getAdsForLocation,
@@ -379,6 +380,7 @@ export function renderDashboardHouseSlot() {
 }
 
 export function buildWishlistStatsHtml(slot = 'wishlist') {
+  if (!isItadDealsAvailable()) return '';
   const wl = state.wishlistGames;
   if (!wl.length) {
     const cards = [
@@ -450,6 +452,7 @@ export function buildWishlistStatsHtml(slot = 'wishlist') {
 }
 
 export function renderDashboardWishlistStats() {
+  if (!isItadDealsAvailable()) return;
   // Re-used by both the dashboard mega-grid and the standalone wishlist deal
   // radar shown above the table on the Wishlist view. The three organic deal
   // cards share one builder; only the 4th ad slot varies per target.

--- a/js/dashboard-insights.js
+++ b/js/dashboard-insights.js
@@ -23,6 +23,7 @@ import {
   isStealDeal,
   cutBucketClass,
 } from "./deals.js";
+import { isItadDealsAvailable } from "./itad-deal-gate.js";
 import { formatMoney, displayCurrency } from "./currency.js";
 import { registerPausable } from "./visibility.js";
 export {
@@ -418,10 +419,12 @@ export function buildInsightPool(games, snapIn, ctxIn) {
     );
   }
 
-  const deals = state.wishlistGames.filter((g) => {
-    const d = getDealInfo(g);
-    return d && (d.cut || 0) > 0;
-  });
+  const deals = isItadDealsAvailable()
+    ? state.wishlistGames.filter((g) => {
+        const d = getDealInfo(g);
+        return d && (d.cut || 0) > 0;
+      })
+    : [];
   if (deals.length) {
     const top = [...deals].sort((a, b) => dealScore(b) - dealScore(a))[0];
     const cut = getDealInfo(top)?.cut || 0;
@@ -471,7 +474,7 @@ export function buildInsightPool(games, snapIn, ctxIn) {
   ).length;
   if (hiddenGems) add(`Hidden gems: <strong>${formatNum(hiddenGems)}</strong>`);
 
-  const clutch = backlog.filter((g) => isLeveragePick(g));
+  const clutch = isItadDealsAvailable() ? backlog.filter((g) => isLeveragePick(g)) : [];
   if (clutch[0])
     add(`Clutch pick: <strong>${escapeHtml(clutch[0].name)}</strong>`);
 
@@ -1016,7 +1019,9 @@ export function buildMarqueeItems(games, snapIn, ctxIn) {
     push("^", "is-rose", formatNum(cleanup), "cleanup candidates", null, {
       weight: W.friendly,
     });
-  const clutchCount = backlog.filter((g) => isLeveragePick(g)).length;
+  const clutchCount = isItadDealsAvailable()
+    ? backlog.filter((g) => isLeveragePick(g)).length
+    : 0;
   if (clutchCount)
     push("*", "is-violet", formatNum(clutchCount), "clutch picks", null, {
       weight: W.friendly,
@@ -1203,70 +1208,72 @@ export function buildMarqueeItems(games, snapIn, ctxIn) {
     );
   }
 
-  const stealsCount = wl.filter(isStealDeal).length;
-  if (stealsCount)
-    push("+", "is-emerald", formatNum(stealsCount), "steal-tier deals");
-  if (onSale.length)
-    push("+", "is-emerald", formatNum(onSale.length), "on sale now");
-  if (onSale.length) {
-    const top = [...onSale].sort((a, b) => dealScore(b) - dealScore(a))[0];
-    const cut = getDealInfo(top)?.cut || 0;
-    push(
-      "+",
-      "is-emerald",
-      "",
-      "top deal",
-      `${escapeHtml(top.name)} ${coloredCutHtml(cut, { className: "dash-marquee-cut" })}`,
-    );
-    const cuts = onSale
-      .map((g) => getDealInfo(g)?.cut || 0)
-      .filter((x) => x > 0);
-    if (cuts.length) {
-      const avgCut = Math.round(
-        cuts.reduce((s, c2) => s + c2, 0) / cuts.length,
-      );
+  if (isItadDealsAvailable()) {
+    const stealsCount = wl.filter(isStealDeal).length;
+    if (stealsCount)
+      push("+", "is-emerald", formatNum(stealsCount), "steal-tier deals");
+    if (onSale.length)
+      push("+", "is-emerald", formatNum(onSale.length), "on sale now");
+    if (onSale.length) {
+      const top = [...onSale].sort((a, b) => dealScore(b) - dealScore(a))[0];
+      const cut = getDealInfo(top)?.cut || 0;
       push(
         "+",
         "is-emerald",
         "",
-        "avg discount",
-        coloredCutHtml(avgCut, {
-          signed: false,
-          className: "dash-marquee-cut",
-        }),
+        "top deal",
+        `${escapeHtml(top.name)} ${coloredCutHtml(cut, { className: "dash-marquee-cut" })}`,
       );
-      const steepest = Math.max(...cuts);
+      const cuts = onSale
+        .map((g) => getDealInfo(g)?.cut || 0)
+        .filter((x) => x > 0);
+      if (cuts.length) {
+        const avgCut = Math.round(
+          cuts.reduce((s, c2) => s + c2, 0) / cuts.length,
+        );
+        push(
+          "+",
+          "is-emerald",
+          "",
+          "avg discount",
+          coloredCutHtml(avgCut, {
+            signed: false,
+            className: "dash-marquee-cut",
+          }),
+        );
+        const steepest = Math.max(...cuts);
+        push(
+          "+",
+          "is-emerald",
+          "",
+          "steepest cut",
+          coloredCutHtml(steepest, { className: "dash-marquee-cut" }),
+        );
+      }
+    }
+
+    let wishlistValue = 0;
+    let wishlistSaleNow = 0;
+    for (const g of wl) {
+      const d = getDealInfo(g);
+      if (d?.regular != null) wishlistValue += d.regular;
+      if (d?.price != null) wishlistSaleNow += d.price;
+    }
+    if (wishlistValue > 0)
       push(
-        "+",
-        "is-emerald",
-        "",
-        "steepest cut",
-        coloredCutHtml(steepest, { className: "dash-marquee-cut" }),
+        "#",
+        "is-violet",
+        formatDollarMarquee(wishlistValue),
+        "wishlist value",
+      );
+    if (wishlistSaleNow > 0 && wishlistSaleNow < wishlistValue) {
+      push(
+        "#",
+        "is-violet",
+        formatDollarMarquee(wishlistValue - wishlistSaleNow),
+        "savings if bought now",
       );
     }
-  }
-
-  let wishlistValue = 0;
-  let wishlistSaleNow = 0;
-  for (const g of wl) {
-    const d = getDealInfo(g);
-    if (d?.regular != null) wishlistValue += d.regular;
-    if (d?.price != null) wishlistSaleNow += d.price;
-  }
-  if (wishlistValue > 0)
-    push(
-      "#",
-      "is-violet",
-      formatDollarMarquee(wishlistValue),
-      "wishlist value",
-    );
-  if (wishlistSaleNow > 0 && wishlistSaleNow < wishlistValue) {
-    push(
-      "#",
-      "is-violet",
-      formatDollarMarquee(wishlistValue - wishlistSaleNow),
-      "savings if bought now",
-    );
   }
 
   const parseReleaseYear = (d) => {

--- a/js/dashboard-spotlight.js
+++ b/js/dashboard-spotlight.js
@@ -20,6 +20,7 @@ import { storeLogoHtml, storeDisplayName } from "./store-logos.js";
 import { getPersonal, filterOutHidden } from "./personal-storage.js";
 import { spotlightRecentKeysStorageKey } from "./profiles.js";
 import { getDealInfo, cutBucketClass } from "./deals.js";
+import { isItadDealsAvailable } from "./itad-deal-gate.js";
 import {
   isBarrel,
   isLeveragePick,
@@ -614,7 +615,7 @@ export function gameSpotlightReason(g, recentKeys) {
   if (status === "next" && rating >= 70) {
     return { eyebrow: "Up next", score: rating + 10 };
   }
-  if (isLeveragePick(g)) {
+  if (isItadDealsAvailable() && isLeveragePick(g)) {
     return { eyebrow: "Clutch deal", score: rating + 12, isLeverage: true };
   }
   // "Supposedly perfect" — a flawless 100% score on a thin sample (<50 reviews),
@@ -722,36 +723,38 @@ export function pickSpotlightGames(games, snapIn) {
   // games you want but don't own yet. Mirrors the visible-wishlist filter used by
   // the deal radar (cross-store-hidden + user-hidden excluded).
   const wlHidden = state.wishlistCrossStoreHiddenKeys || new Set();
-  const wishlistOnSale = filterOutHidden(
-    (state.wishlistGames || []).filter((g) => !wlHidden.has(gameKey(g))),
-  )
-    .filter(hasArt)
-    .filter((g) => isOnSale(g) && ratingValue(g) >= 70)
-    .map((g) => {
-      const deal = getDealInfo(g);
-      const cut = deal?.cut || 0;
-      const rating = ratingValue(g);
-      const metaParts = [`<strong>${rating}%</strong> review`];
-      if (cut > 0) {
-        metaParts.push(
-          `<strong class="dash-spotlight-cut ${cutBucketClass(cut)}">-${cut}%</strong> off`,
-        );
-      }
-      if (deal?.price != null) {
-        metaParts.push(
-          `<strong class="dash-spotlight-price ${cutBucketClass(cut)}">${escapeHtml(formatDollar(deal.price))}</strong>`,
-        );
-      }
-      return {
-        g,
-        reason: {
-          eyebrow: "On sale now",
-          score: rating + 9,
-          isWishlistSale: true,
-          metaParts,
-        },
-      };
-    });
+  const wishlistOnSale = isItadDealsAvailable()
+    ? filterOutHidden(
+        (state.wishlistGames || []).filter((g) => !wlHidden.has(gameKey(g))),
+      )
+        .filter(hasArt)
+        .filter((g) => isOnSale(g) && ratingValue(g) >= 70)
+        .map((g) => {
+          const deal = getDealInfo(g);
+          const cut = deal?.cut || 0;
+          const rating = ratingValue(g);
+          const metaParts = [`<strong>${rating}%</strong> review`];
+          if (cut > 0) {
+            metaParts.push(
+              `<strong class="dash-spotlight-cut ${cutBucketClass(cut)}">-${cut}%</strong> off`,
+            );
+          }
+          if (deal?.price != null) {
+            metaParts.push(
+              `<strong class="dash-spotlight-price ${cutBucketClass(cut)}">${escapeHtml(formatDollar(deal.price))}</strong>`,
+            );
+          }
+          return {
+            g,
+            reason: {
+              eyebrow: "On sale now",
+              score: rating + 9,
+              isWishlistSale: true,
+              metaParts,
+            },
+          };
+        })
+    : [];
   tagged.push(...wishlistOnSale);
 
   const snap = snapIn || getLibrarySnapshot(games);

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -24,6 +24,7 @@ import {
 } from './game-core.js';
 import { getPersonal } from './personal-storage.js';
 import { getDealInfo } from './deals.js';
+import { isItadDealsAvailable } from './itad-deal-gate.js';
 import { ensureChartJs } from './chart-loader.js';
 import { animateCount, countUpDurationForDelta, dashboardLibraryGames, sortStoresByDisplayOrder } from './dashboard-shared.js';
 import { isSurfaceAnimating } from './library-count-animation.js';
@@ -168,6 +169,13 @@ function buildMegaArtifacts(games, snap) {
   };
   _megaArtifactsKey = key;
   return _megaArtifactsCache;
+}
+
+function megaHeroDealsTaglineHtml(stats) {
+  if (!isItadDealsAvailable()) {
+    return '<span title="Connect ITAD in Connections for wishlist deal tracking">Connect ITAD for deals</span>';
+  }
+  return `<span title="Wishlist items with an active discount right now"><strong>${escapeHtml(formatNum(stats.wlDeals))}</strong> deals live</span>`;
 }
 
 function computeMegaHeroStats(games, snap, agg) {
@@ -320,7 +328,7 @@ function updateDashboardMegaInPlace(games, stats, spotlight, spotlightPool, marq
         <span class="sep">·</span>
         <span id="dashHeroYearsClear" title="${escapeAttr(stats.yearsClearTitle)}"><strong>${stats.years}</strong> yrs to clear at 2h/day</span>
         <span class="sep">·</span>
-        <span title="Wishlist items with an active discount right now"><strong>${escapeHtml(formatNum(stats.wlDeals))}</strong> deals live</span>`;
+        ${megaHeroDealsTaglineHtml(stats)}`;
   }
   applyMegaHeroCounters(stats);
   const marqueeKey = marqueeItems.map(it => `${it.glyph}|${it.label}|${it.valueHtml}`).join("\n");
@@ -380,7 +388,7 @@ function renderDashboardMega(games, snap, agg) {
         <span class="sep">·</span>
         <span id="dashHeroYearsClear" title="${escapeAttr(stats.yearsClearTitle)}"><strong>${stats.years}</strong> yrs to clear at 2h/day</span>
         <span class="sep">·</span>
-        <span title="Wishlist items with an active discount right now"><strong>${escapeHtml(formatNum(stats.wlDeals))}</strong> deals live</span>
+        ${megaHeroDealsTaglineHtml(stats)}
       </div>
       <div class="dash-hero-pillars">
         <div class="dash-hero-pillar" title="Sum of playtime across all games, in hours">

--- a/js/error-boundary.js
+++ b/js/error-boundary.js
@@ -446,6 +446,7 @@ export async function fetchBugBundleServerContext() {
       apply_started: data.apply_started ?? null,
       applying_lock_age_sec: data.applying_lock_age_sec ?? null,
       apply_log_tail: data.apply_log_tail ?? null,
+      connect_log_tails: data.connect_log_tails ?? null,
       install_source: data.install_source ?? null,
       arp_version: data.arp_version ?? null,
     };

--- a/js/filters-ui.js
+++ b/js/filters-ui.js
@@ -89,6 +89,7 @@ import {
   authStatusLoaded,
 } from './connections.js';
 import { visibleItchGames } from './connections-status.js';
+import { isItadDealsAvailable } from './itad-deal-gate.js';
 import { collectActiveFilters } from './active-filters.js';
 
 export { collectActiveFilters } from './active-filters.js';
@@ -466,9 +467,12 @@ export function scheduleTableRerender() {
 
 export function updateWishlistDrawerVisibility(options = {}) {
   const deferRadar = !!options?.deferTableChrome;
+  const itadDeals = isItadDealsAvailable();
   const section = document.getElementById("wishlistDealsSection");
-  if (section) section.classList.toggle("hidden", state.activeView !== "wishlist");
-  const showWishlistDeals = state.activeView === "wishlist" && state.dashboardDataReady;
+  if (section) {
+    section.classList.toggle("hidden", state.activeView !== "wishlist" || !itadDeals);
+  }
+  const showWishlistDeals = state.activeView === "wishlist" && state.dashboardDataReady && itadDeals;
   const radar = document.getElementById("wishlistDealRadar");
   if (radar) {
     // Wait for the library/wishlist data to land before showing the radar so
@@ -508,6 +512,7 @@ export function updateViewChrome(options) {
   document.documentElement.setAttribute("data-init-view", state.activeView);
   applyItchTabVisibility();
   updateWishlistDrawerVisibility({ deferTableChrome: deferChrome });
+  void import('./itad-deal-gate.js').then((m) => m.syncItadDealSurfaces({ rerender: false }));
   updatePickTabsVisibility();
   // Picks chrome is synchronous here — async renderViewHouseSlot raced category
   // drill-ins and re-painted the house stripe after toolbar scroll (68px jump).
@@ -571,6 +576,9 @@ export function updatePickTabsVisibility() {
     if (customMatch) {
       const idx = Number(customMatch[1]);
       hidden = hidden || !shouldShowCustomListTab(lists[idx], idx);
+    }
+    if (btn.dataset.tab === 'wishlistDeals') {
+      hidden = hidden || !isItadDealsAvailable();
     }
     btn.classList.toggle("hidden", hidden);
   });
@@ -783,15 +791,24 @@ export function renderSummary() {
       if (s) sourceSet.add(s);
     }
     const sourcesList = [...sourceSet].map(s => s.toUpperCase()).sort().join(", ");
-    const onSale = wl.filter(g => { const d = getDealInfo(g); return d && (d.cut || 0) > 0; });
-    const lows = wl.filter(g => { const d = getDealInfo(g); return d && d.isHistoricalLow; });
-    const owned = wl.filter(g => isOwnedByTitle(g.name)).length;
+    const itadDeals = isItadDealsAvailable();
+    const onSale = itadDeals
+      ? wl.filter(g => { const d = getDealInfo(g); return d && (d.cut || 0) > 0; })
+      : [];
+    const lows = itadDeals
+      ? wl.filter(g => { const d = getDealInfo(g); return d && d.isHistoricalLow; })
+      : [];
+    const owned = itadDeals
+      ? wl.filter(g => isOwnedByTitle(g.name)).length
+      : 0;
     // 100%-off (free-to-claim) deals skew the averages (0 price, max discount),
     // so they're excluded from Avg discount / Avg price.
     const isFullyFree = g => effectiveDiscountPercent(g) >= 100;
-    const cuts = onSale.map(g => effectiveDiscountPercent(g)).filter(c => c > 0 && c < 100);
+    const cuts = itadDeals ? onSale.map(g => effectiveDiscountPercent(g)).filter(c => c > 0 && c < 100) : [];
     const avgDisc = cuts.length ? Math.round(cuts.reduce((s, c) => s + c, 0) / cuts.length) : null;
-    const prices = wl.filter(g => !isFullyFree(g)).map(g => effectiveSortPrice(g)).filter(p => p != null);
+    const prices = itadDeals
+      ? wl.filter(g => !isFullyFree(g)).map(g => effectiveSortPrice(g)).filter(p => p != null)
+      : [];
     const avgPrice = prices.length ? (prices.reduce((s, p) => s + p, 0) / prices.length).toFixed(2) : null;
     const onSaleActive = !!state.prefs.dealOnSaleOnly;
     const lowOnlyActive = !!state.prefs.dealHistoricalLowOnly;
@@ -810,10 +827,14 @@ export function renderSummary() {
     const sourcesChip = sourceSet.size
       ? `<div class="summary-stat-chip" data-stat="sources" title="Wishlist sources: ${escapeAttr(sourcesList)}">Sources <span class="text-slate-100 font-semibold ml-1">${sourceSet.size}</span></div>`
       : "";
+    const itadCta = !itadDeals
+      ? `<div class="summary-stat-chip text-slate-400" data-stat="itad-cta" title="Connect ITAD in Connections for cross-store deal prices">Connect ITAD in Connections for deal prices</div>`
+      : "";
     el.innerHTML = `
       <div class="w-full flex flex-wrap gap-2">
         ${resetChip}
         ${sourcesChip}
+        ${itadCta}
         ${avgDisc != null ? `<div class="summary-stat-chip" data-stat="avg-discount" title="Average discount % across on-sale wishlist items">Avg discount <span class="text-slate-100 font-semibold ml-1">${avgDisc}%</span></div>` : ""}
         ${avgPrice != null ? `<div class="summary-stat-chip" data-stat="avg-price" title="Average current deal price (USD) on wishlist">Avg price <span class="text-slate-100 font-semibold ml-1">$${avgPrice}</span></div>` : ""}
         ${onSaleChip}

--- a/js/itad-deal-gate.js
+++ b/js/itad-deal-gate.js
@@ -1,0 +1,87 @@
+/**
+ * Hide wishlist/dashboard deal surfaces until ITAD is connected (validated API key).
+ */
+import { isItadDealsAvailable } from './connections-status.js';
+import { state } from './state.js';
+import { savePrefs } from './prefs.js';
+import { applyColumnVisibility } from './table-columns.js';
+
+export { isItadDealsAvailable };
+
+let _lastItadAvailable = null;
+
+/** Clear deal filters/sort prefs that only apply when ITAD pricing is active. */
+export function clearItadDealPrefs() {
+  let changed = false;
+  if (state.prefs.dealOnSaleOnly) {
+    state.prefs.dealOnSaleOnly = false;
+    changed = true;
+  }
+  if (state.prefs.dealHistoricalLowOnly) {
+    state.prefs.dealHistoricalLowOnly = false;
+    changed = true;
+  }
+  if (state.prefs.dealHideOwned) {
+    state.prefs.dealHideOwned = false;
+    changed = true;
+  }
+  if (+state.prefs.dealMinDiscount > 0) {
+    state.prefs.dealMinDiscount = 0;
+    changed = true;
+  }
+  if (+state.prefs.dealMaxPrice < 100) {
+    state.prefs.dealMaxPrice = 100;
+    changed = true;
+  }
+  const wishlistSort = state.prefs.sort?.wishlist;
+  if (wishlistSort?.key === 'deal_price') {
+    state.prefs.sort.wishlist = { key: 'steam', dir: -1 };
+    changed = true;
+  }
+  if (changed) savePrefs();
+  return changed;
+}
+
+/** True when the price column should render on the wishlist table. */
+export function isWishlistPriceColumnAvailable() {
+  return isItadDealsAvailable();
+}
+
+/**
+ * Reconcile DOM + prefs when ITAD connect state changes.
+ * @param {{ rerender?: boolean }} [options]
+ */
+export function syncItadDealSurfaces(options = {}) {
+  const available = isItadDealsAvailable();
+  const prev = _lastItadAvailable;
+  _lastItadAvailable = available;
+
+  if (typeof document !== 'undefined') {
+    document.documentElement.dataset.itadDeals = available ? '1' : '0';
+    document.getElementById('dashboardWishlistStats')?.classList.toggle('hidden', !available);
+    document.querySelector('[data-tab="wishlistDeals"]')?.classList.toggle('hidden', !available);
+    document.getElementById('wishlistItadCta')?.classList.toggle('hidden', available);
+  }
+
+  if (!available && prev !== false) {
+    clearItadDealPrefs();
+  }
+
+  applyColumnVisibility(state.activeView);
+
+  if (options.rerender === false) return;
+
+  if (typeof document === 'undefined') return;
+
+  if (state.activeView === 'wishlist') {
+    void import('./filters-ui.js').then((m) => {
+      m.renderSummary();
+      m.updateWishlistDrawerVisibility();
+      m.updatePickTabsVisibility();
+    });
+    void import('./picks-ui.js').then((m) => m.renderPicks());
+    void import('./table-ui.js').then((m) => m.renderTable?.());
+  } else if (state.activeView === 'dashboard') {
+    void import('./dashboard.js').then((m) => m.scheduleDashboardRender?.());
+  }
+}

--- a/js/library-load.js
+++ b/js/library-load.js
@@ -23,6 +23,7 @@ import {
   slimItadSnapshot,
   buildOwnedNormNames,
 } from "./deals.js";
+import { isItadDealsAvailable } from "./itad-deal-gate.js";
 import {
   loadManualGames,
   saveLibraryFirstSeen,
@@ -104,6 +105,12 @@ let _prevRowCountLibrary = null;
 let _prevRowCountWishlist = null;
 
 export async function loadItadPrices() {
+  if (!isItadDealsAvailable()) {
+    state.libraryMeta.itad = null;
+    state.itadByKey = {};
+    state.itadPriceDroppedKeys = new Set();
+    return;
+  }
   let prevByKey = {};
   try {
     const raw = localStorage.getItem(itadSnapshotStorageKey());
@@ -132,6 +139,7 @@ export async function loadItadPrices() {
 }
 
 export function showItadAlertBanner({ newSales, newHistoricalLows }) {
+  if (!isItadDealsAvailable()) return;
   const el = document.getElementById("itadAlertBanner");
   if (!el) return;
   const parts = [];

--- a/js/picks-ui.js
+++ b/js/picks-ui.js
@@ -20,6 +20,7 @@ import {
   dealDroppedBadgeHtml,
   isOwnedByTitle,
 } from './deals.js';
+import { isItadDealsAvailable } from './itad-deal-gate.js';
 import { getPersonal, filterOutHidden } from './personal-storage.js';
 import { getPicksLimitForView, setPicksLimitForView } from './prefs.js';
 import { syncCoverFits } from './covers.js';
@@ -143,7 +144,10 @@ export function applyPicksCollapsedState() {
 /** Picks tab for the active view — never show library tabs on wishlist. */
 export function effectivePicksTab() {
   const view = state.activeView;
-  if (view === "wishlist") return "wishlistDeals";
+  if (view === "wishlist") {
+    if (!isItadDealsAvailable()) return "topRated";
+    return "wishlistDeals";
+  }
   if (view === "itch") {
     const t = state.prefs.itchPicksTab || state.prefs.picksTab;
     if (t === "wishlistDeals" || isCustomListTab(t)) return state.prefs.itchPicksTab || "topRated";
@@ -203,6 +207,8 @@ export function renderPicks() {
     default:
       if (customIdx >= 0 && pickView === "library") {
         data = resolveCustomListGames(getCustomLists()[customIdx]);
+      } else if (pickView === "wishlist" && !isItadDealsAvailable()) {
+        data = [];
       } else {
         data = pickView === "wishlist" ? wishlistDeals : backlogRated;
       }
@@ -229,9 +235,13 @@ export function renderPicks() {
   const emptyMsg = isCustomTab
     ? 'Select games in the table, then use Add to list in the bulk bar.'
     : tab === "wishlistDeals"
-    ? (state.wishlistGames.length === 0
+    ? (!isItadDealsAvailable()
+      ? "Connect ITAD in Connections, then run the deal price fetcher to see wishlist deals here."
+      : state.wishlistGames.length === 0
       ? "No deals on your wishlist yet. Connect a store and run the wishlist and deal price fetchers from Fetcher health."
       : "No wishlist deals on sale right now. Refresh prices from Fetcher health, or check back after the next sale.")
+    : pickView === "wishlist" && !isItadDealsAvailable()
+    ? "Connect ITAD in Connections, then run the deal price fetcher to see wishlist deals here."
     : pickView === "itch"
       ? "No rated itch.io backlog games yet. Most indie titles won't have Steam review scores."
       : "No games match this tab yet.";

--- a/js/table-columns.js
+++ b/js/table-columns.js
@@ -6,6 +6,7 @@ import {
   pinAllDensityColumns,
   setDensityPinned,
 } from './table-density.js';
+import { isWishlistPriceColumnAvailable } from './itad-deal-gate.js';
 
 export const TABLE_VIEWS = ['library', 'wishlist', 'itch'];
 
@@ -51,11 +52,24 @@ export function isColumnVisible(view, id) {
   const col = TABLE_COLUMNS.find(c => c.id === id);
   if (!col) return true;
   if (col.locked) return true;
+  if (viewKey(view) === 'wishlist' && id === 'price' && !isWishlistPriceColumnAvailable()) {
+    return false;
+  }
   ensureColumnsPrefs();
   const vk = viewKey(view);
   const stored = state.prefs.columns[vk];
   if (stored && typeof stored[id] === 'boolean') return stored[id];
   return defaultVisibleFor(col, vk);
+}
+
+/** Column picker: omit ITAD-gated columns for the active view. */
+export function columnsForPicker(view) {
+  return toggleableColumns().filter((col) => {
+    if (viewKey(view) === 'wishlist' && col.id === 'price' && !isWishlistPriceColumnAvailable()) {
+      return false;
+    }
+    return true;
+  });
 }
 
 export function setColumnVisible(view, id, on) {
@@ -102,6 +116,11 @@ export function applyColumnVisibility(view, opts = {}) {
     const userHide = !isColumnVisible(view, col.id);
     const densityHide = !opts.skipDensity && densityWouldHide(view, col.id, tier);
     wrap.classList.toggle(`table-hide-${col.id}`, userHide || densityHide);
+  }
+  const priceHeader = document.getElementById('priceHeader');
+  if (priceHeader) {
+    const hidePrice = viewKey(view) === 'wishlist' && !isWishlistPriceColumnAvailable();
+    priceHeader.classList.toggle('hidden', hidePrice);
   }
 }
 

--- a/shared/server_support.py
+++ b/shared/server_support.py
@@ -344,5 +344,15 @@ def build_diagnostics_payload(
         "apply_started": apply_started,
         "applying_lock_age_sec": applying_lock_age_sec(work_root),
         "apply_log_tail": apply_log_tail(work_root),
+        "connect_log_tails": _connect_log_tails(data_root),
         **install_visibility_fields(version),
     }
+
+
+def _connect_log_tails(data_root: Path) -> dict[str, list[str]]:
+    from auth.connect_log import connect_log_tails
+
+    try:
+        return connect_log_tails(max_lines=40)
+    except Exception:  # noqa: BLE001
+        return {}

--- a/tests/dashboard-empty.test.js
+++ b/tests/dashboard-empty.test.js
@@ -5,9 +5,11 @@
 import { describe, expect, it, beforeEach } from 'vitest';
 import { state } from '../js/state.js';
 import { buildWishlistStatsHtml } from '../js/dashboard-cards.js';
+import { setAuthStatusSnapshot } from '../js/connections-status.js';
 
 beforeEach(() => {
   state.wishlistGames = [];
+  setAuthStatusSnapshot([{ key: 'itad', status: 'connected' }]);
 });
 
 describe('buildWishlistStatsHtml empty wishlist', () => {
@@ -26,5 +28,10 @@ describe('buildWishlistStatsHtml empty wishlist', () => {
     const html = buildWishlistStatsHtml();
     expect(html).toContain('wishlist fetcher');
     expect(html).toContain('Connect a store');
+  });
+
+  it('returns empty html when ITAD is not connected', () => {
+    setAuthStatusSnapshot([]);
+    expect(buildWishlistStatsHtml()).toBe('');
   });
 });

--- a/tests/itad-deal-gate.test.js
+++ b/tests/itad-deal-gate.test.js
@@ -1,0 +1,86 @@
+/**
+ * ITAD deal surface gating — wishlist/dashboard UI hidden until ITAD connected.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { state } from '../js/state.js';
+import {
+  isItadDealsAvailable,
+  clearItadDealPrefs,
+  syncItadDealSurfaces,
+} from '../js/itad-deal-gate.js';
+import { setAuthStatusSnapshot } from '../js/connections-status.js';
+import { buildWishlistStatsHtml } from '../js/dashboard-cards.js';
+
+beforeEach(() => {
+  setAuthStatusSnapshot([]);
+  state.prefs = {
+    dealOnSaleOnly: true,
+    dealHistoricalLowOnly: true,
+    dealHideOwned: true,
+    dealMinDiscount: 25,
+    dealMaxPrice: 10,
+    sort: { wishlist: { key: 'deal_price', dir: -1 } },
+    picksTab: 'wishlistDeals',
+  };
+  state.activeView = 'wishlist';
+  state.wishlistGames = [];
+  document.body.innerHTML = `
+    <div id="dashboardWishlistStats"></div>
+    <button class="pick-tab" data-tab="wishlistDeals" data-pick-view="wishlist"></button>
+    <div id="wishlistItadCta" class="hidden"></div>
+    <div id="wishlistDealRadar"></div>
+    <th id="priceHeader"></th>
+  `;
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  document.documentElement.removeAttribute('data-itad-deals');
+});
+
+describe('isItadDealsAvailable', () => {
+  it('is false when ITAD is disconnected', () => {
+    setAuthStatusSnapshot([{ key: 'itad', status: 'disconnected' }]);
+    expect(isItadDealsAvailable()).toBe(false);
+  });
+
+  it('is false when ITAD is unverified', () => {
+    setAuthStatusSnapshot([{ key: 'itad', status: 'unverified' }]);
+    expect(isItadDealsAvailable()).toBe(false);
+  });
+
+  it('is true when ITAD is connected', () => {
+    setAuthStatusSnapshot([{ key: 'itad', status: 'connected' }]);
+    expect(isItadDealsAvailable()).toBe(true);
+  });
+});
+
+describe('clearItadDealPrefs', () => {
+  it('resets deal filters and wishlist deal_price sort when gated', () => {
+    const changed = clearItadDealPrefs();
+    expect(changed).toBe(true);
+    expect(state.prefs.dealOnSaleOnly).toBe(false);
+    expect(state.prefs.sort.wishlist.key).toBe('steam');
+  });
+});
+
+describe('syncItadDealSurfaces', () => {
+  it('hides deal radar targets and shows ITAD CTA when disconnected', () => {
+    syncItadDealSurfaces({ rerender: false });
+    expect(document.documentElement.dataset.itadDeals).toBe('0');
+    expect(document.getElementById('dashboardWishlistStats').classList.contains('hidden')).toBe(true);
+    expect(document.querySelector('[data-tab="wishlistDeals"]').classList.contains('hidden')).toBe(true);
+    expect(document.getElementById('wishlistItadCta').classList.contains('hidden')).toBe(false);
+    expect(buildWishlistStatsHtml()).toBe('');
+  });
+
+  it('shows deal surfaces when ITAD is connected', () => {
+    setAuthStatusSnapshot([{ key: 'itad', status: 'connected' }]);
+    syncItadDealSurfaces({ rerender: false });
+    expect(document.documentElement.dataset.itadDeals).toBe('1');
+    expect(document.getElementById('dashboardWishlistStats').classList.contains('hidden')).toBe(false);
+    expect(document.querySelector('[data-tab="wishlistDeals"]').classList.contains('hidden')).toBe(false);
+    expect(document.getElementById('wishlistItadCta').classList.contains('hidden')).toBe(true);
+  });
+});

--- a/tests/picks-empty.test.js
+++ b/tests/picks-empty.test.js
@@ -4,7 +4,8 @@
 
 import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { state } from '../js/state.js';
-import { renderPicks } from '../js/picks-ui.js';
+import { renderPicks, effectivePicksTab } from '../js/picks-ui.js';
+import { setAuthStatusSnapshot } from '../js/connections-status.js';
 
 function setupPicksDom() {
   document.body.innerHTML = `
@@ -48,6 +49,7 @@ describe('renderPicks empty library', () => {
   });
 
   it('wishlist deals tab uses Fetcher health wording when wishlist is empty', () => {
+    setAuthStatusSnapshot([{ key: 'itad', status: 'connected' }]);
     state.activeView = 'wishlist';
     state.prefs.picksTab = 'wishlistDeals';
     renderPicks();
@@ -55,5 +57,15 @@ describe('renderPicks empty library', () => {
     expect(grid?.innerHTML).toContain('Fetcher health');
     expect(grid?.innerHTML).toContain('Connect a store');
     expect(grid?.innerHTML).not.toMatch(/fetch_.*\.py/);
+  });
+
+  it('falls back from wishlist deals tab when ITAD is disconnected', () => {
+    setAuthStatusSnapshot([]);
+    state.activeView = 'wishlist';
+    state.prefs.picksTab = 'wishlistDeals';
+    expect(effectivePicksTab()).toBe('topRated');
+    renderPicks();
+    const grid = document.getElementById('picksGrid');
+    expect(grid?.innerHTML).toContain('Connect ITAD in Connections');
   });
 });

--- a/tests/picks-sponsored-slot.test.js
+++ b/tests/picks-sponsored-slot.test.js
@@ -5,6 +5,7 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { state } from '../js/state.js';
 import { renderPicks } from '../js/picks-ui.js';
+import { setAuthStatusSnapshot } from '../js/connections-status.js';
 import { dismissSponsoredDeal, __resetDismissedSponsorsForTest, __setSponsorsForTest } from '../js/sponsored-deals.js';
 import * as authGate from '../js/auth-gate.js';
 
@@ -34,6 +35,7 @@ function wishlistDeal(name, price = 9.99, cut = 50) {
 
 beforeEach(() => {
   __resetDismissedSponsorsForTest();
+  setAuthStatusSnapshot([{ key: 'itad', status: 'connected' }]);
   vi.spyOn(authGate, 'isPro').mockReturnValue(false);
   state.allGames = [];
   state.itchGames = [];

--- a/tests/sponsored-deals.test.js
+++ b/tests/sponsored-deals.test.js
@@ -53,6 +53,7 @@ import * as authGate from '../js/auth-gate.js';
 import * as anonMetrics from '../js/anon-metrics.js';
 import * as apiClient from '../js/api-client.js';
 import { state } from '../js/state.js';
+import { setAuthStatusSnapshot } from '../js/connections-status.js';
 
 function sponsor(overrides = {}) {
   const { id, ...rest } = {
@@ -896,6 +897,7 @@ describe('buildWishlistStatsHtml ad slot variants', () => {
   });
 
   it('uses wish-deal-hero sponsor in the wishlist deal rail when assigned', () => {
+    setAuthStatusSnapshot([{ key: 'itad', status: 'connected' }]);
     state.wishlistGames = [];
     __setSponsorsForTest(v2Doc(
       { hero: sponsor({ id: 'hero', title: 'Hero Deal', kind: 'sponsor' }) },

--- a/tests/spotlight-replay.test.js
+++ b/tests/spotlight-replay.test.js
@@ -198,6 +198,8 @@ describe("spotlight expanded categories", () => {
     state.libraryFirstSeenByKey = {};
     state.wishlistGames = [];
     state.wishlistCrossStoreHiddenKeys = new Set();
+    const { setAuthStatusSnapshot } = await import("../js/connections-status.js");
+    setAuthStatusSnapshot([{ key: "itad", status: "connected" }]);
     win._dataVersion = (win._dataVersion || 0) + 1;
     let setStinkerChanceForTest;
     let setScoreJitterForTest;

--- a/tests/test_psn_connect.py
+++ b/tests/test_psn_connect.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import time
 from unittest.mock import MagicMock
 
-from auth.runner import _fetch_npsso_background
+import pytest
+
+from auth.connect_loop import run_connect_poll
+from auth.runner import PSN_CHECK_VALID, _fetch_npsso_background
 
 
 def test_ssocookie_api_used_when_cookie_jar_empty() -> None:
@@ -38,3 +42,33 @@ def test_cookie_jar_used_when_ssocookie_empty() -> None:
     token, source = _fetch_npsso_background(page, context)
     assert source == "cookie"
     assert token == "jar-only-token"
+
+
+def test_psn_run_connect_poll_survives_check_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Check exceptions should not kill the browser session (Battle.net parity)."""
+    monkeypatch.setattr(
+        "auth.connect_loop.abort_if_browser_closed",
+        lambda _context: None,
+    )
+    context = MagicMock()
+    context.pages = []
+    calls = {"n": 0}
+
+    def _check():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("transient DOM glitch")
+        return {"PSN_NPSSO": "ok-token"}
+
+    creds = run_connect_poll(
+        context=context,
+        session=None,
+        deadline=time.time() + 5,
+        poll_sec=0.01,
+        check=_check,
+        timeout_message="timeout",
+    )
+    assert creds == {"PSN_NPSSO": "ok-token"}
+    assert calls["n"] >= 2

--- a/tests/test_psn_connect.py
+++ b/tests/test_psn_connect.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from auth.connect_loop import run_connect_poll
-from auth.runner import PSN_CHECK_VALID, _fetch_npsso_background
+from auth.runner import _fetch_npsso_background
 
 
 def test_ssocookie_api_used_when_cookie_jar_empty() -> None:


### PR DESCRIPTION
## Summary
- Hide wishlist and dashboard ITAD deal surfaces until ITAD is connected with a validated API key (isItadDealsAvailable + syncItadDealSurfaces).
- Refactor PSN Connect onto un_connect_poll with connect-psn.log parity, CDP launch logging, and connect_log_tails in diagnostics/bug bundles.
- Add troubleshooting guide for Connect windows that close immediately; fix tracker Architecture wishlist SVG overflow (internal repo).

## Test plan
- [x] 
pm test (1644 tests)
- [x] pytest tests/test_psn_connect.py tests/test_connect_loop.py tests/test_battlenet_connect_loop.py
- [ ] CI green on PR
- [ ] Manual: ITAD disconnected hides deal radar/picks/price col; connected restores surfaces

Made with [Cursor](https://cursor.com)