### PR TITLE
chore: v0.9.00 audit remediations (no release)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,9 @@ assets/milestones/
 assets/social/
 
 # Local scratch run output, audits, review artifacts (never commit)
+.connect-*.log
+connect-*.log
+/update-dismiss.json
 .build-windows.log
 EVENT_AUDIT.json
 EVENT_AUDIT.md
@@ -103,6 +106,7 @@ review-feed-rows.csv
 review-findings.yaml
 review-handoff.md
 review-report.json
+.audit/
 scripts/_diag_personal.py
 scripts/perf-last-run.json
 scripts/responsive-overflow-last-run.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Refresh bundle budget after intentional growth: `npm run build && node scripts/c
 
 ## Auth gating (layers)
 
-- **CSRF** — `X-BAKLOG-Local: 1` or valid localhost Origin/Referer for mutating requests.
+- **CSRF** — mutating requests require `X-BAKLOG-Local: 1` (the app and admin console send it). When Supabase auth is on, a valid bearer may also authorize mutations; Origin/Referer alone is not enough.
 - **Supabase JWT** — when `BAKLOG_SUPABASE_URL` + anon key set; all `/api/*` except `/api/config` require bearer token.
 - **BAKLOG_ADMIN** — exposes `/admin/` and `/api/internal/*` without Supabase.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Fixed
 
+- Wishlist and dashboard ITAD deal UI stays gated until ITAD is connected (validated API key); hide price column, deal radar, picks Deals tab, and related deal chips when disconnected.
+- Battle.net / PSN Connect quick-close diagnostics: PSN uses `run_connect_poll`, CDP launch logging (`connect-cdp.log` / `connect-psn.log`), tails in diagnostics and bug bundles, and troubleshooting for "Connect window closes immediately".
 - Responsive outside scan: `TABLE_PHONE_MQ` (+ phone chrome / A–Z dock) aligns with sheet landscape MQ so 844×390 uses library cards; `test:responsive` covers itch + outside overlays (notes/bug/update/kebab/profile/claimables/header nav/pro-compare) and `--auth-gate` mode.
 - Responsive re-litigation: sheet modals get `overflow-y: auto` + flex `min-height: 0` under the landscape sheet MQ (notes/update no longer clip); phone library cards gain touch targets, hide dual cover EA ribbon, priority-hide COUCH when ONLINE coop is present, full-width sponsored house strip, and phone virtual-row height remeasure; `#summary` h-scroll aligns with sheet MQ and chip `min-height` uses `--touch-min`; wishlist/dash radar Tailwind `sm:grid-cols-3` → `lg:grid-cols-3` to match the 1024 CSS ladder.
 - R5 responsive closeout: type tokens for ribbon/insight/score digits; tablet insight wrap; reduced-motion for error toast + pick/coop hover lifts; year-chart Chart.js duration gated; short-landscape chart/ribbon height trim; leftover app.css media (`640`/`760`/`767`/`768`/`520`/`420`) onto `1023.98`/`639.98`/`400`; fetcher `LOG_DESKTOP_MQ` `768`→`1024`.
@@ -71,9 +73,12 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Changed
 
+- Soft-sell Pro / Support BAKLOG copy across house creatives, Pro tab, tips, and landing FAQ; in-house Pro upgrade banners stay hidden (`HOUSE_PRO_BANNERS_ENABLED=false`) until the funnel review flips the flag.
+- In-app updates stay explicit: boot check and tray notify only; no silent background download or apply-on-quit (Phase 6 silent update permanently deferred).
 - Permanent Discord invite is `https://discord.gg/VFvxN5nCCB` (`shared/community.json`); linked from app kebab + footer socials, landing footer icons + Community column, README, and guide/getting-help.
 - Fetcher health on phone opens as a fullscreen overlay sheet with sticky titled head; tablet keeps the anchored popover (dvh-capped).
 - Main view tabs collapse to a hamburger sheet at tablet and below (replaces the phone horizontal scroll strip), and also when the inline header would wrap; sheet mode hides fullscreen and moves Report bug + profile into the overlay.
+
 ## [0.8.47] - 2026-08-02
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,9 +92,10 @@ Never move or re-point a published tag. Cut a new patch tag instead.
 
 ## Local API note
 
-Mutating requests to the local server require the `X-BAKLOG-Local: 1` header (or
-a valid localhost Origin/Referer). The app and admin console send this
-automatically.
+Mutating requests to the local server require the `X-BAKLOG-Local: 1` header.
+The app and admin console send this automatically. A localhost Origin/Referer
+alone is not enough. When Supabase auth is enabled, a valid bearer token may
+also authorize mutations.
 
 ## Reporting security issues
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -2,7 +2,7 @@
 
 BAKLOG is a **local-first** desktop tool. It does not ship telemetry or
 analytics **by default**. Optional anonymous aggregate metrics are **opt-in**
-(Connections / Settings: share anonymous stats). The "server" referenced in the
+(Connections: share anonymous stats). The "server" referenced in the
 README is a `http://127.0.0.1` Python process that serves files to your own
 browser tab. Game libraries, personal notes, and store credentials stay on your
 machine. On frozen Windows beta installs, the default data root is
@@ -30,7 +30,7 @@ These are optional and separate from the local dashboard:
 | Bug report (`/api/report`) | Whitelisted diagnostic bundle you paste/send | You click **Send report** in the app |
 | Free claims feed (`free-claims.json`) | Public curated giveaway metadata (no personal data) | App polls when you open Claimable Now |
 | Sponsored deals feed (`sponsors.json`) | Public house/paid ad metadata (no personal data) | App fetches when online (profile override → hosted → bundled) |
-| Metrics (`/api/metrics`) | Anonymous session/impression counts | **Opt-in only** (`shareAnonStats` in Settings; default off) |
+| Metrics (`/api/metrics`) | Anonymous session/impression counts | **Opt-in only** (`shareAnonStats` in Connections; default off) |
 
 The local app does **not** upload your library or credentials to these endpoints.
 
@@ -254,9 +254,9 @@ inline Add-game flow hits `store.steampowered.com/api/storesearch/`.
 
 ## What does *not* happen
 
-- No telemetry or analytics **by default** — optional anonymous aggregate
+- No telemetry or analytics **by default** - optional anonymous aggregate
   metrics (`shareAnonStats`) send counts to `baklog.app` only when you enable
-  them in Settings.
+  them in Connections.
 - No silent crash uploads — the error log stays in your browser until *you*
   copy it or explicitly send it via **Send report** in the consent dialog.
 - No third-party ad/affiliate **scripts** — outbound links may carry an

--- a/README.md
+++ b/README.md
@@ -329,4 +329,4 @@ pytest tests/test_cdp_browser.py -m integration
 
 On GitHub, use **Actions → CDP smoke (manual) → Run workflow** after a suspected Chrome/Edge regression.
 
-Phase 0 is **local-only** — no cloud accounts or billing. Supabase/Next.js (Phase 1) stays on the roadmap until you opt in.
+BAKLOG is **local-first**: your library JSON and store credentials stay on your machine. Optional invite Supabase sign-in and Polar Pro checkout exist when configured; catalogs are not hosted in a BAKLOG cloud by default.

--- a/curated/free_claims.approved.json
+++ b/curated/free_claims.approved.json
@@ -1,98 +1,22 @@
 {
   "ids": [
-    "epic-echo-generation-midnight-edition-069026",
-    "epic-otxo-396b8b",
-    "epic-sol-cesto-e9b803",
     "gamerpower-2478",
     "gamerpower-3301",
     "gamerpower-3421",
-    "gamerpower-3498",
-    "gamerpower-3555",
     "gamerpower-3676",
     "gamerpower-3697",
-    "gamerpower-3709",
-    "gamerpower-3712",
-    "gamerpower-3717",
-    "gamerpower-3720",
-    "gamerpower-3724",
-    "gamerpower-3725",
-    "itad-0a93135bfee3",
-    "itad-0d4598c53ffe",
     "itad-1cfb7de15158",
     "itad-2c618502e94c",
     "itad-56b70d2f45d3",
-    "itad-59dc47dd81a3",
-    "itad-5b6611643316",
-    "itad-75d1019b80eb",
-    "itad-840d262ba7fa",
-    "itad-90df86960d93",
-    "itad-920c69f9fdf1",
-    "itad-98730029b14b",
-    "itad-bd4edc3ae553",
-    "itad-cb21d42d706e",
-    "itad-d85d5bb4128d",
-    "itad-dd5b5b16e035",
-    "itad-df07e9ed2270",
-    "itad-eb44ea1d719b"
+    "itad-59dc47dd81a3"
   ],
-  "store_overrides": {
-    "itad-98730029b14b": "indiegala",
-    "itad-dd5b5b16e035": "indiegala"
-  },
+  "store_overrides": {},
   "field_overrides": {
-    "gamerpower-3498": {
-      "title": "Primal Slideee Deluxe (Stove)"
-    },
-    "gamerpower-3555": {
-      "title": "Together After Dark"
-    },
     "gamerpower-3676": {
       "title": "Dire Echo"
     },
     "gamerpower-3697": {
       "title": "NIGHTBELL"
-    },
-    "gamerpower-3709": {
-      "title": "NoRush! - Tower Edition"
-    },
-    "gamerpower-3712": {
-      "title": "Catch Me!"
-    },
-    "itad-0a93135bfee3": {
-      "title": "Slime King"
-    },
-    "itad-0d4598c53ffe": {
-      "title": "Mr.Brocco & Co"
-    },
-    "itad-75d1019b80eb": {
-      "title": "Nova Lands"
-    },
-    "itad-840d262ba7fa": {
-      "title": "The Mound: Omen of Cthulhu: Lost Explorers Swords Pack"
-    },
-    "itad-90df86960d93": {
-      "title": "Tattoo Tycoon"
-    },
-    "itad-920c69f9fdf1": {
-      "title": "The Ouroboros King"
-    },
-    "itad-98730029b14b": {
-      "title": "Carlos the Taco"
-    },
-    "itad-bd4edc3ae553": {
-      "title": "NoRush!"
-    },
-    "itad-cb21d42d706e": {
-      "title": "Princess Farmer"
-    },
-    "itad-d85d5bb4128d": {
-      "title": "Madness Inside"
-    },
-    "itad-dd5b5b16e035": {
-      "title": "The Brave Little Cloud"
-    },
-    "itad-eb44ea1d719b": {
-      "title": "KeepUp Survival"
     }
   },
   "dismissed": [
@@ -108,8 +32,5 @@
     "itad-0c69ed1f1bd8",
     "itad-b07aac9ebd26"
   ],
-  "premium_only_ids": [
-    "gamerpower-3498",
-    "itad-840d262ba7fa"
-  ]
+  "premium_only_ids": []
 }

--- a/curated/free_claims.fallback.json
+++ b/curated/free_claims.fallback.json
@@ -1,34 +1,6 @@
 {
-  "generated_at": "2026-08-01T20:53:53.908375+00:00",
+  "generated_at": "2026-08-06T23:03:43.261835+00:00",
   "items": [
-    {
-      "id": "epic-otxo-396b8b",
-      "store": "epic",
-      "title": "OTXO",
-      "claim_url": "https://store.epicgames.com/en-US/p/otxo-396b8b",
-      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/1608640/header.jpg?t=1775071242",
-      "genres": [],
-      "blurb": null,
-      "ends_at": "2026-08-06T15:00:00Z",
-      "steam_appid": 1608640,
-      "review_percent": 93,
-      "source": "epic",
-      "first_seen": "2026-08-01T20:43:42Z"
-    },
-    {
-      "id": "epic-sol-cesto-e9b803",
-      "store": "epic",
-      "title": "Sol Cesto",
-      "claim_url": "https://store.epicgames.com/en-US/p/sol-cesto-e9b803",
-      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2738490/d505392564204d87cd762d2cdfbd8dd30af8cfdc/header.jpg?t=1782554560",
-      "genres": [],
-      "blurb": null,
-      "ends_at": "2026-08-06T15:00:00Z",
-      "steam_appid": 2738490,
-      "review_percent": 91,
-      "source": "epic",
-      "first_seen": "2026-08-01T20:43:42Z"
-    },
     {
       "id": "gamerpower-2478",
       "store": "itch",

--- a/landing/free-claims.json
+++ b/landing/free-claims.json
@@ -1,34 +1,6 @@
 {
-  "generated_at": "2026-08-01T20:53:53.908375+00:00",
+  "generated_at": "2026-08-06T23:03:43.261835+00:00",
   "items": [
-    {
-      "id": "epic-otxo-396b8b",
-      "store": "epic",
-      "title": "OTXO",
-      "claim_url": "https://store.epicgames.com/en-US/p/otxo-396b8b",
-      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/1608640/header.jpg?t=1775071242",
-      "genres": [],
-      "blurb": null,
-      "ends_at": "2026-08-06T15:00:00Z",
-      "steam_appid": 1608640,
-      "review_percent": 93,
-      "source": "epic",
-      "first_seen": "2026-08-01T20:43:42Z"
-    },
-    {
-      "id": "epic-sol-cesto-e9b803",
-      "store": "epic",
-      "title": "Sol Cesto",
-      "claim_url": "https://store.epicgames.com/en-US/p/sol-cesto-e9b803",
-      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2738490/d505392564204d87cd762d2cdfbd8dd30af8cfdc/header.jpg?t=1782554560",
-      "genres": [],
-      "blurb": null,
-      "ends_at": "2026-08-06T15:00:00Z",
-      "steam_appid": 2738490,
-      "review_percent": 91,
-      "source": "epic",
-      "first_seen": "2026-08-01T20:43:42Z"
-    },
     {
       "id": "gamerpower-2478",
       "store": "itch",

--- a/scripts/test-all.ps1
+++ b/scripts/test-all.ps1
@@ -13,6 +13,27 @@ if (Test-Path $VenvPy) {
     $Python = "python"
 }
 
+# npm/Vitest may print deprecations on stderr; with $ErrorActionPreference=Stop,
+# PowerShell treats NativeCommandError as terminating even when exit code is 0.
+function Invoke-NpmStep {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Label,
+        [Parameter(Mandatory = $true)]
+        [string[]]$NpmArgs
+    )
+    Write-Host "==> $Label"
+    $prev = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        & npm @NpmArgs
+        $code = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $prev
+    }
+    if ($code -ne 0) { exit $code }
+}
+
 Write-Host "==> ruff"
 & $Python -m ruff check .
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
@@ -21,13 +42,8 @@ Write-Host "==> pytest"
 & $Python -m pytest --force-sugar -m "not integration and not slow and not release_smoke" --durations=20
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-Write-Host "==> vitest"
-npm test
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-Write-Host "==> test:perf"
-npm run test:perf
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+Invoke-NpmStep -Label "vitest" -NpmArgs @("test")
+Invoke-NpmStep -Label "test:perf" -NpmArgs @("run", "test:perf")
 
 if (-not $Full) {
     Write-Host ""
@@ -35,27 +51,23 @@ if (-not $Full) {
     exit 0
 }
 
-Write-Host "==> check:module-size"
-npm run check:module-size
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-Write-Host "==> lint"
-npm run lint
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+Invoke-NpmStep -Label "check:module-size" -NpmArgs @("run", "check:module-size")
+Invoke-NpmStep -Label "lint" -NpmArgs @("run", "lint")
 
 Write-Host "==> vendor:supabase + build"
-npm run vendor:supabase
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-npm run build
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+$prev = $ErrorActionPreference
+$ErrorActionPreference = "Continue"
+try {
+    & npm run vendor:supabase
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    & npm run build
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+} finally {
+    $ErrorActionPreference = $prev
+}
 
-Write-Host "==> check:bundle-size"
-npm run check:bundle-size
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-Write-Host "==> check:dist-integrity"
-npm run check:dist-integrity
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+Invoke-NpmStep -Label "check:bundle-size" -NpmArgs @("run", "check:bundle-size")
+Invoke-NpmStep -Label "check:dist-integrity" -NpmArgs @("run", "check:dist-integrity")
 
 Write-Host "==> audit free surface"
 & $Python scripts/audit_free_surface_data.py --fail-on high --out .audit/report.json --baseline-out .audit/baseline.json --findings-out .audit/findings.yaml --handoff-out .audit/handoff.md --csv-out .audit/rows.csv


### PR DESCRIPTION
## Summary
- Align README / PRIVACY / CSRF docs with shipped auth + Connections metrics + strict `X-BAKLOG-Local` CSRF.
- Complete CHANGELOG `[Unreleased]` for post-0.8.47 work; keep version stamps at 0.8.47 (no tag).
- Prune stale approved free-claim ids so `audit_free_surface_data --fail-on high` is green; rebuild hosted/fallback feeds.
- Harden `scripts/test-all.ps1` so Vitest stderr deprecations cannot abort under `$ErrorActionPreference=Stop`.
- Gitignore local `connect-*.log` and root `update-dismiss.json`.

## Test plan
- [ ] `audit_free_surface_data.py --fail-on high` exit 0
- [ ] CI green on merge commit (A0-1)
- [ ] Confirm no `v0.9.00` tag created
- [ ] Spot-check README Phase 0 / PRIVACY Connections / CONTRIBUTING CSRF wording
