### PR TITLE
fix: add top inset for pre-header alert banners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [Unreleased]
 
+### Fixed
+
+- Pre-header alert banners (ITAD price refresh and siblings) use the same 1rem top inset as the app header, so they no longer sit flush to the viewport.
+
 ### Changed
 
 - `curated/free_claims.approved.json` and `curated/free_claims.auto.json` are gitignored (maintainer Claims ops only). Publish still commits `landing/free-claims.json` + `curated/free_claims.fallback.json`.

--- a/app.css
+++ b/app.css
@@ -5658,8 +5658,13 @@ html[data-theme="ember"] .brand-logo-pills {
 .migration-banner.hidden {
   display: none;
 }
-#migrationBanner {
-  margin-top: 0.75rem;
+/* Shell padding-top is 0 so the header supplies the inset. When a banner is
+   the first visible chrome above the header, match header.app-header. */
+.app-shell > .migration-banner:not(.hidden) {
+  margin-top: 1rem;
+}
+.app-shell > .migration-banner:not(.hidden) ~ .migration-banner:not(.hidden) {
+  margin-top: 0;
 }
 #authReconnectBanner:not(.hidden),
 #authSecretsBanner:not(.hidden) {


### PR DESCRIPTION
## Summary
- Pre-header banners (ITAD price refresh and siblings) sat flush to the viewport because `.app-shell` has `padding-top: 0` and only the header supplied the inset.
- First visible `.migration-banner` now gets the same 1rem top inset as `header.app-header`; stacked banners keep their existing gap.

## Test plan
- [ ] Reload the dashboard with the ITAD Prices refreshed banner visible and confirm space above the orange border.
- [ ] Dismiss the banner and confirm the header still sits at the same top inset.
- [ ] If another pre-header banner is showing (claims / library watch), confirm it also has top space and stacked banners do not double the gap.

Made with [Cursor](https://cursor.com)