### PR TITLE
fix: keep hidden wishlist rows off the deal radar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [Unreleased]
 
+### Fixed
+
+- Wishlist deal radar (Today's Top Deal / Steals), Picks deals, dashboard deal counts, and on-sale spotlight ignore user-hidden and cross-store-dupe wishlist rows - the same visible list the wishlist table already uses.
+
 ### Changed
 
 - `curated/free_claims.approved.json` and `curated/free_claims.auto.json` are gitignored (maintainer Claims ops only). Publish still commits `landing/free-claims.json` + `curated/free_claims.fallback.json`.

--- a/js/dashboard-cards.js
+++ b/js/dashboard-cards.js
@@ -7,7 +7,7 @@ import { gameKey, hltbMain, ratingValue, hasEnoughReviews, coverFallbackFor, lib
 import { affiliateUrl, hasLiveAffiliates } from './affiliate.js';
 import { freeItchCount, paidItchCount, itchSpendTotal } from './sabermetrics.js';
 import { gameGenresCanonical } from './genres.js';
-import { getPersonal } from './personal-storage.js';
+import { getPersonal, wishlistGamesBase } from './personal-storage.js';
 import { wishlistGamesWithDeals, dealHeroCardHtml, dealHeroEmptyHtml, dealSaleScoreboardCardHtml, dealStealsCardHtml, getDealInfo, dealScore, effectiveDiscountPercent, isStealDeal } from './deals.js';
 import { isItadDealsAvailable } from './itad-deal-gate.js';
 import {
@@ -381,8 +381,9 @@ export function renderDashboardHouseSlot() {
 
 export function buildWishlistStatsHtml(slot = 'wishlist') {
   if (!isItadDealsAvailable()) return '';
-  const wl = state.wishlistGames;
-  if (!wl.length) {
+  const raw = state.wishlistGames || [];
+  const wl = wishlistGamesBase();
+  if (!raw.length) {
     const cards = [
       dealHeroEmptyHtml({ noWishlist: true }),
       dealSaleScoreboardCardHtml({

--- a/js/dashboard-spotlight.js
+++ b/js/dashboard-spotlight.js
@@ -17,7 +17,7 @@ import {
   normalizeGame,
 } from "./game-core.js";
 import { storeLogoHtml, storeDisplayName } from "./store-logos.js";
-import { getPersonal, filterOutHidden } from "./personal-storage.js";
+import { getPersonal, wishlistGamesBase } from "./personal-storage.js";
 import { spotlightRecentKeysStorageKey } from "./profiles.js";
 import { getDealInfo, cutBucketClass } from "./deals.js";
 import { isItadDealsAvailable } from "./itad-deal-gate.js";
@@ -720,13 +720,10 @@ export function pickSpotlightGames(games, snapIn) {
   }
 
   // "On sale now" is sourced exclusively from the wishlist: surface discounts on
-  // games you want but don't own yet. Mirrors the visible-wishlist filter used by
-  // the deal radar (cross-store-hidden + user-hidden excluded).
-  const wlHidden = state.wishlistCrossStoreHiddenKeys || new Set();
+  // games you want but don't own yet. Same visible-wishlist universe as the
+  // deal radar (cross-store-hidden + user-hidden excluded).
   const wishlistOnSale = isItadDealsAvailable()
-    ? filterOutHidden(
-        (state.wishlistGames || []).filter((g) => !wlHidden.has(gameKey(g))),
-      )
+    ? wishlistGamesBase()
         .filter(hasArt)
         .filter((g) => isOnSale(g) && ratingValue(g) >= 70)
         .map((g) => {

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -22,7 +22,7 @@ import {
   hltbBacklogHoursTitle,
   hltbClearByYearsTitle,
 } from './game-core.js';
-import { getPersonal } from './personal-storage.js';
+import { getPersonal, wishlistGamesBase } from './personal-storage.js';
 import { getDealInfo } from './deals.js';
 import { isItadDealsAvailable } from './itad-deal-gate.js';
 import { ensureChartJs } from './chart-loader.js';
@@ -117,7 +117,7 @@ export function dashboardFingerprint() {
     }
   }
   let dealSig = 0;
-  for (const g of state.wishlistGames || []) {
+  for (const g of wishlistGamesBase()) {
     const d = getDealInfo(g);
     if (d) dealSig += (d.cut || 0) + (d.isHistoricalLow ? 1000 : 0);
   }
@@ -183,7 +183,7 @@ function computeMegaHeroStats(games, snap, agg) {
   const playedHrs = snap.playedHrs;
   const completion = snap.nonSkip ? Math.round(snap.completionRate * 100) : 0;
   const avgRating = agg?.avgRating != null ? agg.avgRating : " - ";
-  const wlDeals = state.wishlistGames.filter(g => { const d = getDealInfo(g); return d && (d.cut || 0) > 0; }).length;
+  const wlDeals = wishlistGamesBase().filter(g => { const d = getDealInfo(g); return d && (d.cut || 0) > 0; }).length;
   const storeCountMap = agg?.storeCounts ? { ...agg.storeCounts } : {};
   if (!agg?.storeCounts) {
     for (const g of games) {

--- a/js/filters-ui.js
+++ b/js/filters-ui.js
@@ -45,7 +45,7 @@ import {
   isOwnedByTitle,
 } from './deals.js';
 import { gameGenresCanonical } from './genres.js';
-import { getPersonal, filterOutHidden, filterCounted, countHiddenLibraryNoiseGames } from './personal-storage.js';
+import { getPersonal, filterOutHidden, filterCounted, countHiddenLibraryNoiseGames, wishlistGamesBase } from './personal-storage.js';
 import {
   savePrefs,
   saveActiveView,
@@ -783,10 +783,10 @@ export function renderSummary() {
     return;
   }
   if (state.activeView === "wishlist") {
-    const wl = state.wishlistGames.filter(g => !state.wishlistCrossStoreHiddenKeys.has(gameKey(g)));
-    const hiddenCount = state.wishlistGames.length - wl.length;
+    const wl = wishlistGamesBase();
+    const hiddenCount = (state.wishlistGames || []).length - wl.length;
     const sourceSet = new Set();
-    for (const g of state.wishlistGames) {
+    for (const g of wl) {
       const s = (g.wishlist_store || g.store_target || (g.store === "wishlist" ? "steam" : g.store) || "").toLowerCase();
       if (s) sourceSet.add(s);
     }

--- a/js/personal-storage.js
+++ b/js/personal-storage.js
@@ -792,6 +792,15 @@ export function libraryGamesBase() {
   return filterOutHidden(out);
 }
 
+/** Visible wishlist: not user-hidden, not a cross-store dupe. Same universe as
+ *  the wishlist table (minus search / deal-filter chips). */
+export function wishlistGamesBase() {
+  const hidden = state.wishlistCrossStoreHiddenKeys || new Set();
+  return filterOutHidden(
+    (state.wishlistGames || []).filter(g => !hidden.has(gameKey(g))),
+  );
+}
+
 /** Visible, counted library size: drops cross-store dupes, user-hidden rows,
  *  and manual rows toggled out of the count. Single source of truth for the
  *  "of Y" denominators and headline totals. */

--- a/js/picks-ui.js
+++ b/js/picks-ui.js
@@ -21,7 +21,7 @@ import {
   isOwnedByTitle,
 } from './deals.js';
 import { isItadDealsAvailable } from './itad-deal-gate.js';
-import { getPersonal, filterOutHidden } from './personal-storage.js';
+import { getPersonal, filterOutHidden, wishlistGamesBase } from './personal-storage.js';
 import { getPicksLimitForView, setPicksLimitForView } from './prefs.js';
 import { syncCoverFits } from './covers.js';
 import { sponsoredPickSlotHtml, sponsoredDealPickSlotHtml, pickLocationForView, houseLocationForView, renderHouseLocationSlot } from './sponsored-deals.js';
@@ -181,8 +181,7 @@ export function renderPicks() {
       if (lb !== la) return lb - la;
       return ratingValue(b) - ratingValue(a);
     });
-  const wishlistDeals = state.wishlistGames
-    .filter(g => !state.wishlistCrossStoreHiddenKeys.has(gameKey(g)))
+  const wishlistDeals = wishlistGamesBase()
     .filter(g => {
       const d = getDealInfo(g);
       if (!d) return false;

--- a/tests/deals.test.js
+++ b/tests/deals.test.js
@@ -5,6 +5,8 @@
 import { describe, expect, it, beforeEach } from 'vitest';
 import { state } from '../js/state.js';
 import { AFFILIATE_CREDENTIALS } from '../js/affiliate.js';
+import { buildWishlistStatsHtml } from '../js/dashboard-cards.js';
+import { setAuthStatusSnapshot } from '../js/connections-status.js';
 import {
   parsePriceLike,
   getDealInfo,
@@ -38,7 +40,11 @@ function resetState() {
   state.itadPriceDroppedKeys = new Set();
   state.ownedNormNames = new Set();
   state.allGames = [];
+  state.wishlistGames = [];
+  state.personal = {};
   state.crossStoreHiddenKeys = new Set();
+  state.wishlistCrossStoreHiddenKeys = new Set();
+  if (typeof window !== 'undefined') window._dataVersion = (window._dataVersion || 0) + 1;
   state.prefs = {
     dealOnSaleOnly: false,
     dealHistoricalLowOnly: false,
@@ -289,6 +295,61 @@ describe('dealHeroCardHtml', () => {
     const html = dealHeroCardHtml({ ...baseGame, hltb_main_hours: 12 });
     expect(html).toContain('deal-hero-stat-dot-hltb');
     expect(html).toContain('12h');
+  });
+});
+
+const signalis = {
+  store: 'wishlist',
+  id: '1262350',
+  name: 'SIGNALIS',
+  steam_review_percent: 96,
+  steam_review_count: 20000,
+};
+const otherDeal = {
+  store: 'wishlist',
+  id: 'other',
+  name: 'Other Deal',
+  steam_review_percent: 82,
+};
+
+function seedWishlistRadarDeals() {
+  setAuthStatusSnapshot([{ key: 'itad', status: 'connected' }]);
+  state.wishlistGames = [signalis, otherDeal];
+  state.itadByKey = {
+    'wishlist:1262350': {
+      price: 4.99,
+      regular: 19.99,
+      cut: 75,
+      is_historical_low: true,
+      shop: 'Steam',
+    },
+    'wishlist:other': { price: 14.99, regular: 19.99, cut: 25, shop: 'Steam' },
+  };
+}
+
+describe('buildWishlistStatsHtml visible wishlist', () => {
+  it('does not feature a user-hidden wishlist game as Top Deal or Steal', () => {
+    seedWishlistRadarDeals();
+    state.personal = { 'wishlist:1262350': { hidden: true } };
+    const html = buildWishlistStatsHtml();
+    expect(html).not.toContain('SIGNALIS');
+    expect(html).toContain('Other Deal');
+  });
+
+  it('still features the same game when it is not hidden', () => {
+    seedWishlistRadarDeals();
+    const html = buildWishlistStatsHtml();
+    expect(html).toContain('SIGNALIS');
+    expect(html).toContain('Today&apos;s top deal');
+    expect(html).toContain('Steals waiting');
+  });
+
+  it('does not feature a cross-store-hidden wishlist game as Top Deal or Steal', () => {
+    seedWishlistRadarDeals();
+    state.wishlistCrossStoreHiddenKeys = new Set(['wishlist:1262350']);
+    const html = buildWishlistStatsHtml();
+    expect(html).not.toContain('SIGNALIS');
+    expect(html).toContain('Other Deal');
   });
 });
 

--- a/tests/picks-empty.test.js
+++ b/tests/picks-empty.test.js
@@ -28,8 +28,11 @@ beforeEach(() => {
     quickWinMaxHours: 15,
   };
   state.sessionPrefs = { crossStoreDedup: false };
+  state.personal = {};
+  state.itadByKey = {};
   state.crossStoreHiddenKeys = new Set();
   state.wishlistCrossStoreHiddenKeys = new Set();
+  if (typeof window !== 'undefined') window._dataVersion = (window._dataVersion || 0) + 1;
   state.activeView = 'library';
   state.dashboardDataReady = true;
   setupPicksDom();
@@ -57,6 +60,33 @@ describe('renderPicks empty library', () => {
     expect(grid?.innerHTML).toContain('Fetcher health');
     expect(grid?.innerHTML).toContain('Connect a store');
     expect(grid?.innerHTML).not.toMatch(/fetch_.*\.py/);
+  });
+
+  it('omits user-hidden and cross-store-hidden wishlist games from deals cards', () => {
+    setAuthStatusSnapshot([{ key: 'itad', status: 'connected' }]);
+    state.activeView = 'wishlist';
+    state.prefs.picksTab = 'wishlistDeals';
+    state.wishlistGames = [
+      { store: 'wishlist', id: '1262350', name: 'SIGNALIS', steam_review_percent: 96 },
+      { store: 'wishlist', id: 'other', name: 'Other Deal', steam_review_percent: 82 },
+    ];
+    state.itadByKey = {
+      'wishlist:1262350': { price: 4.99, cut: 75, shop: 'Steam' },
+      'wishlist:other': { price: 14.99, cut: 25, shop: 'Steam' },
+    };
+    state.personal = { 'wishlist:1262350': { hidden: true } };
+    renderPicks();
+    let grid = document.getElementById('picksGrid');
+    expect(grid?.innerHTML).not.toContain('SIGNALIS');
+    expect(grid?.innerHTML).toContain('Other Deal');
+
+    state.personal = {};
+    state.wishlistCrossStoreHiddenKeys = new Set(['wishlist:other']);
+    if (typeof window !== 'undefined') window._dataVersion = (window._dataVersion || 0) + 1;
+    renderPicks();
+    grid = document.getElementById('picksGrid');
+    expect(grid?.innerHTML).toContain('SIGNALIS');
+    expect(grid?.innerHTML).not.toContain('Other Deal');
   });
 
   it('falls back from wishlist deals tab when ITAD is disconnected', () => {

--- a/tests/spotlight-replay.test.js
+++ b/tests/spotlight-replay.test.js
@@ -267,6 +267,38 @@ describe("spotlight expanded categories", () => {
     expect(sale?._spotlightReason?.eyebrow).toBe("On sale now");
   });
 
+  it("excludes user-hidden wishlist games from On sale now", () => {
+    state.itadByKey = { "wishlist:3": { cut: 40, price: 9.99 } };
+    state.personal = { "wishlist:3": { hidden: true } };
+    state.wishlistGames = [{
+      store: "wishlist",
+      id: 3,
+      name: "Wishlist 3",
+      steam_review_percent: 85,
+      steam_review_count: 1000,
+      library_image: "x.jpg",
+      header_image: "x.jpg",
+    }];
+    const pool = pickSpotlightGames([]);
+    expect(pool.find(g => g.store === "wishlist" && g.id === 3)).toBeUndefined();
+  });
+
+  it("excludes cross-store-hidden wishlist games from On sale now", () => {
+    state.itadByKey = { "wishlist:3": { cut: 40, price: 9.99 } };
+    state.wishlistCrossStoreHiddenKeys = new Set(["wishlist:3"]);
+    state.wishlistGames = [{
+      store: "wishlist",
+      id: 3,
+      name: "Wishlist 3",
+      steam_review_percent: 85,
+      steam_review_count: 1000,
+      library_image: "x.jpg",
+      header_image: "x.jpg",
+    }];
+    const pool = pickSpotlightGames([]);
+    expect(pool.find(g => g.store === "wishlist" && g.id === 3)).toBeUndefined();
+  });
+
   it("tags recent releases as New release", () => {
     state.personal = { "steam:4": { status: "backlog" } };
     const recent = new Date();


### PR DESCRIPTION
## Summary
- Hidden and cross-store-dupe wishlist rows no longer win Today's Top Deal, Steals, or Picks deals.
- `wishlistGamesBase()` is the same visible list the wishlist table already uses (radar, Picks, dashboard counts, summary chips, on-sale spotlight).
- `dealHideOwned` stays a chip, not a radar default.

## Test plan
- [x] `npx vitest run tests/dashboard-empty.test.js tests/deals.test.js tests/picks-empty.test.js tests/spotlight-replay.test.js tests/sponsored-deals.test.js`
- [ ] Hide a wishlist game with a strong ITAD deal (e.g. SIGNALIS) and confirm it leaves Top Deal / Steals / Picks deals
- [ ] Unhide it and confirm it can feature again

Made with [Cursor](https://cursor.com)