### PR TITLE
Landing SEO, marketing GA, and internal-sync isolation

### DIFF
--- a/.cursor/rules/landing.mdc
+++ b/.cursor/rules/landing.mdc
@@ -14,11 +14,15 @@ alwaysApply: false
 
 ## Key files
 
-- `landing/index.html` — hero, waitlist, `#demo` interactive section
+- `landing/index.html` — hero, waitlist, `#demo` interactive section, inline JSON-LD `@graph`
+- `landing/llms.txt` — AI-crawler summary (no em dashes)
+- `landing/ga.js` — GA4 config for the marketing site (`G-88L32JZQDH`); CSP allowlist in `landing/vercel.json`
 - `landing/demo.js` — IIFE with dummy data (`STATS`, `SPOTLIGHT_GAMES`); mirrors app UX, no app imports
 - `landing/demo.css` — demo dashboard chrome
 - `landing/main.js` — waitlist POST to `/api/subscribe`
 - `landing/free-claims.json` — built by `build_free_claims.py` at repo root
+
+FAQ JSON-LD must match the `#faq` details list: `npm run check:landing-seo`.
 
 ## Serverless
 

--- a/.gitignore
+++ b/.gitignore
@@ -114,5 +114,9 @@ scripts/_diag_personal.py
 scripts/perf-last-run.json
 scripts/responsive-overflow-last-run.json
 
+# Local SEO operator (OpenSEO compose, secrets, crawl snapshots). Commit seo-god.json only.
+.seo-god/
+seo/
+
 .vercel
 .env*

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,7 +50,7 @@ backend. These **do** reach the network from a normal install:
 |-------------|---------|---------------------|
 | Store APIs / sites | Fetch **your** libraries (as you) | Your session only |
 | `github.com` | Optional in-app update check + zip download | Version check only |
-| `baklog.app` | Public `free-claims.json`, `sponsors.json` feeds; optional waitlist/report/metrics APIs | Feeds: none. Metrics: **opt-in only** (`shareAnonStats`). Reports: **you** submit |
+| `baklog.app` | Public `free-claims.json`, `sponsors.json` feeds; optional waitlist/report/metrics APIs; marketing-site Google Analytics | Feeds: none. Metrics: **opt-in only** (`shareAnonStats`). Reports: **you** submit. GA: marketing pages only |
 | `*.supabase.co` | Optional login | Auth metadata if enabled |
 | Polar / checkout URLs | Optional Pro purchase | Payment on Polar |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,13 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [Unreleased]
 
+### Added
+
+- Landing FAQPage + WebSite JSON-LD (kept in sync with the `#faq` list), homepage apple-touch-icon, `llms.txt`, `robots.txt` `/auth/` disallow, `/auth-reset` `X-Robots-Tag`, homepage meta description under 160 characters, footer headings without a skipped level, Google Analytics on the marketing site (`G-88L32JZQDH`), and `npm run check:landing-seo`.
+
 ### Fixed
 
+- Cursor stop-hook tracker reminder honors `loop_count` and reminds at most once per conversation, so Docker/WSL completion pings no longer restart the follow-up loop.
 - Wishlist deal radar (Today's Top Deal / Steals), Picks deals, dashboard deal counts, and on-sale spotlight ignore user-hidden and cross-store-dupe wishlist rows - the same visible list the wishlist table already uses.
 - Pre-header alert banners (ITAD price refresh and siblings) use the same 1rem top inset as the app header, so they no longer sit flush to the viewport.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Fixed
 
+- Public pre-push no longer treats `baklog-internal` as the public work tree: the sync script clears inherited `GIT_DIR`, merge-copies rule dirs so internal-only files survive, and resets public HEAD if that leak is detected.
 - Cursor stop-hook tracker reminder honors `loop_count` and reminds at most once per conversation, so Docker/WSL completion pings no longer restart the follow-up loop.
 - Wishlist deal radar (Today's Top Deal / Steals), Picks deals, dashboard deal counts, and on-sale spotlight ignore user-hidden and cross-store-dupe wishlist rows - the same visible list the wishlist table already uses.
 - Pre-header alert banners (ITAD price refresh and siblings) use the same 1rem top inset as the app header, so they no longer sit flush to the viewport.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -18,7 +18,7 @@ Nothing else leaves your machine except direct calls to storefronts and
 enrichment services (network hosts below), plus optional `baklog.app` endpoints
 in **Hosted surfaces** when you use those features.
 
-Last updated: 2026-06-09.
+Last updated: 2026-08-18.
 
 ## Hosted surfaces (baklog.app)
 
@@ -27,6 +27,7 @@ These are optional and separate from the local dashboard:
 | Surface | What it collects | When |
 |---------|------------------|------|
 | Waitlist (`/api/subscribe`) | Email you submit | You opt in on the landing page |
+| Google Analytics (GA4 `G-88L32JZQDH`) | Anonymous page views on the marketing site | Browser loads baklog.app (not the desktop app) |
 | Bug report (`/api/report`) | Whitelisted diagnostic bundle you paste/send | You click **Send report** in the app |
 | Free claims feed (`free-claims.json`) | Public curated giveaway metadata (no personal data) | App polls when you open Claimable Now |
 | Sponsored deals feed (`sponsors.json`) | Public house/paid ad metadata (no personal data) | App fetches when online (profile override → hosted → bundled) |
@@ -41,7 +42,7 @@ The local app does **not** upload your library or credentials to these endpoints
   provide. Each storefront sees its own normal API/scrape traffic from you.
 - The **local app** has no remote backend for your library: the authors never
   receive your catalog, notes, or credentials automatically.
-- The **baklog.app** marketing site is separate (waitlist email, optional bug
+- The **baklog.app** marketing site is separate (Google Analytics page views, waitlist email, optional bug
   reports you send, public free-claims feed) — see **Hosted surfaces** below.
 - Backups of your personal data and fetched libraries are written locally and
   not transmitted anywhere.

--- a/landing/README.md
+++ b/landing/README.md
@@ -5,7 +5,9 @@ Static blue-on-blue landing page with an email waitlist, deployed to Vercel.
 ## Files
 
 - `index.html` — page markup, inline base CSS, waitlist form shell. No build step.
-- `structured-data.json` — JSON-LD for crawlers (loaded externally for CSP compliance).
+- `llms.txt` - plain-text site summary for AI crawlers.
+- `ga.js` - Google Analytics (GA4) config for the marketing site. Desktop app telemetry is unchanged (opt-in only).
+- JSON-LD - inline `@graph` on `index.html` (`SoftwareApplication`, `WebSite`, `FAQPage`). Keep FAQPage in sync with the `#faq` details list via `npm run check:landing-seo`.
 - `main.js` — footer year, non-blocking font load, waitlist submit handler.
 - `demo.css` — mega hero dashboard styles (spotlight, marquee, ribbon charts, funnel sections).
 - `demo.js` — interactive demo (dummy data, count-up, spotlight rotation, Chart.js donuts).
@@ -372,3 +374,5 @@ Users can optionally enable **Share anonymous usage counts** in the app (Connect
 python tools/make_og_image.py          # run from the repo root; writes landing/assets/og.png
 python tools/make_apple_touch_icon.py  # writes landing/apple-touch-icon.png
 ```
+
+Gate after landing HTML/JSON-LD edits: `npm run check:landing-seo` from the repo root (does not start a server).

--- a/landing/ga.js
+++ b/landing/ga.js
@@ -1,0 +1,6 @@
+window.dataLayer = window.dataLayer || [];
+function gtag() {
+  dataLayer.push(arguments);
+}
+gtag("js", new Date());
+gtag("config", "G-88L32JZQDH");

--- a/landing/index.html
+++ b/landing/index.html
@@ -3,8 +3,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- Google Analytics (marketing site only). Desktop app stays no telemetry by default. -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-88L32JZQDH"></script>
+  <script src="ga.js"></script>
   <title>BAKLOG: One honest backlog across every store</title>
-  <meta name="description" content="One honest backlog across every store. Free forever to import · 12 libraries and 8 wishlists · runs on your machine, no telemetry by default. Watch 0 → 2,000+ games climb in ~90 seconds. MIT source on GitHub. Invite-only early access." />
+  <meta name="description" content="One honest backlog across every store. Free forever to import. 12 libraries and 8 wishlists on your machine, no telemetry by default. Invite-only." />
   <meta name="theme-color" content="#0f172a" />
   <meta name="robots" content="index, follow" />
   <meta name="author" content="BAKLOG" />
@@ -13,6 +16,7 @@
   <meta name="impact-site-verification" value="dc7618b3-fd26-44a1-b6d1-df252ccab181" />
   <link rel="canonical" href="https://baklog.app/" />
   <link rel="icon" href="favicon.svg" type="image/svg+xml" />
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
 
   <!-- Open Graph / social -->
   <meta property="og:type" content="website" />
@@ -43,9 +47,10 @@
   <script src="pro-checkout-gate.js" defer></script>
   <script src="main.js" defer></script>
 
-  <!-- Structured data: inline. The src attribute is ignored on ld+json blocks,
-       and data blocks aren't executed so CSP script-src doesn't apply to them. -->
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"BAKLOG","applicationCategory":"GameApplication","operatingSystem":"Windows, macOS, Linux","url":"https://baklog.app/","codeRepository":"https://github.com/Ogrods/BAKLOG","license":"https://opensource.org/licenses/MIT","description":"One honest backlog across every store. Free forever to import; 12 libraries and 8 wishlists; runs on your machine. Watch 0 → 2,000+ games climb in ~90 seconds. Claimable Now helps you never miss a free game again. Open source (MIT). Optional paid tier to support BAKLOG. Invite-only early access.","offers":[{"@type":"Offer","name":"Free","price":"0","priceCurrency":"USD"},{"@type":"Offer","name":"Support BAKLOG","price":"5","priceCurrency":"USD","billingDuration":"P1M"}],"publisher":{"@type":"Organization","name":"BAKLOG","url":"https://baklog.app/"}}</script>
+  <!-- Structured data: inline. data blocks aren't executed so CSP script-src
+       does not apply. Keep FAQPage in sync with the #faq details list
+       (npm run check:landing-seo). -->
+  <script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"SoftwareApplication","name":"BAKLOG","applicationCategory":"GameApplication","operatingSystem":"Windows, macOS, Linux","url":"https://baklog.app/","codeRepository":"https://github.com/Ogrods/BAKLOG","license":"https://opensource.org/licenses/MIT","description":"One honest backlog across every store. Free forever to import; 12 libraries and 8 wishlists; runs on your machine. Watch 0 → 2,000+ games climb in ~90 seconds. Claimable Now helps you never miss a free game again. Open source (MIT). Optional paid tier to support BAKLOG. Invite-only early access.","offers":[{"@type":"Offer","name":"Free","price":"0","priceCurrency":"USD"},{"@type":"Offer","name":"Support BAKLOG","price":"5","priceCurrency":"USD","billingDuration":"P1M"}],"publisher":{"@type":"Organization","name":"BAKLOG","url":"https://baklog.app/"}},{"@type":"WebSite","name":"BAKLOG","url":"https://baklog.app/","publisher":{"@type":"Organization","name":"BAKLOG","url":"https://baklog.app/"}},{"@type":"FAQPage","url":"https://baklog.app/#faq","mainEntity":[{"@type":"Question","name":"Is it safe?","acceptedAnswer":{"@type":"Answer","text":"Your credentials stay encrypted on your machine (AES-256-GCM, OS keychain). Store sign-in runs in your own local browser, not a container and not a shared cloud vault. Fetches go straight from your PC to each storefront, from your IP. There is no BAKLOG server holding your library. The full app is open source (MIT) with a published threat model that lists what we defend and what we do not (local malware, storefront ToS, and the rest). baklog.app never receives your catalog. The marketing site uses Google Analytics for anonymous page views. Waitlist email if you request an invite, and a bug report only if you click Send."}},{"@type":"Question","name":"Is it open source?","acceptedAnswer":{"@type":"Answer","text":"Yes. BAKLOG is released under the MIT license. The full app (server, fetchers, auth, and dashboard) lives in the public GitHub repo: clone it and run from source today. No hidden builds, no closed-source telemetry layer. The invite beta is packaged builds on top of the same tree. Optional paid features are conveniences on top of the same open codebase, not a fork of your data into our cloud."}},{"@type":"Question","name":"Is it free?","acceptedAnswer":{"@type":"Answer","text":"Yes. Importing your library across every store is free forever: auto-fetch on connect, full dashboard, ownership-aware deals (with sponsored slots in deal cards on the free tier), cached trophy summary % (no on-demand deep re-pull), and Claimable Now for full-game giveaways. Store refresh on the free tier is one store at a time, on demand; auto-refresh quietly updates one stale store every ~30 min while the app is open. An optional paid tier adds more - see Support BAKLOG. Nothing you use free today moves behind paywall."}},{"@type":"Question","name":"What's in the paid tier?","acceptedAnswer":{"@type":"Answer","text":"Optional Pro support adds a few conveniences today: fewer sponsored deal cards, scheduled stale-store refresh without keeping the app open, deep achievement/trophy sync (full on-demand re-pull; free tier shows cached % only), a bonus claimables feed for DLC, add-ons, and in-game bonuses filtered out of the free feed, and queued bulk refresh (queue every stale store from Fetcher health). Coming soon: cloud sync across machines and deal/watchlist alerts. Support BAKLOG or Support BAKLOG (yearly). The free tier keeps everything you need to import, browse, and decide what to play next."}},{"@type":"Question","name":"What's the difference between free and paid refresh?","acceptedAnswer":{"@type":"Answer","text":"On the free tier, you refresh one store at a time: click a fetcher chip, wait for it to finish, click the next. Auto-refresh (on by default) quietly updates one stale store every ~30 minutes while the app is open. Pro supporters get scheduled refresh that runs even when the app is closed (tray or OS scheduler). Queued bulk refresh (one action queues every stale store back-to-back from Fetcher health) is live on Pro. Your credentials and data still stay on your machine. Only the convenience layer changes."}},{"@type":"Question","name":"Does BAKLOG show me free games to claim?","acceptedAnswer":{"@type":"Answer","text":"Never miss a free game again. Claimable Now is a maintainer-curated free-game feed that aggregates active giveaways from Epic, GOG, Steam, Prime, and more, sourced via GamerPower, IsThereAnyDeal, and the Epic Store, right in your dashboard. A notification banner alerts you when new drops land. The feed is ownership-aware: it skips games you already own somewhere in your library. Included on the free tier. For Epic mobile claims and other free entry paths, see starting from zero."}},{"@type":"Question","name":"I don't really own games yet. Is BAKLOG still for me?","acceptedAnswer":{"@type":"Answer","text":"Yes. You don't need a paid library to start. See starting from zero for free entry paths: Epic, Prime, GOG, free-to-play hits, and more. BAKLOG tracks your collection from the first claim, and Claimable Now aggregates the week's free drops in your dashboard."}},{"@type":"Question","name":"Do I have to refresh it?","acceptedAnswer":{"@type":"Answer","text":"Not manually. When you connect a store, BAKLOG auto-fetches its library. While the app is open, auto-refresh for stores older than 24h is on by default (Connections). ITAD deal prices refresh on a schedule. On the free tier there's no background sync while closed. Pro supporters get scheduled refresh while closed; cloud sync between machines is a coming Pro perk."}},{"@type":"Question","name":"Why is my count different from what the store shows?","acceptedAnswer":{"@type":"Answer","text":"Stores pad your library with things that aren't games: DLC skins, soundtracks, wallpapers, betas, and store apps. BAKLOG filters those out automatically so the number you see is real games, not shelf clutter. That filter is built-in and you never have to manage it. Separately, you can hide any game you just don't want to see and restore it later from the Hidden games panel."}},{"@type":"Question","name":"Does it upload my library?","acceptedAnswer":{"@type":"Answer","text":"No. Your catalog and credentials stay in your local profile folder. Store fetches go straight from your PC to each storefront. baklog.app never receives your library JSON. The marketing site uses Google Analytics for anonymous page views. Waitlist email if you request an invite, a bug report only if you click Send, and a public free-games metadata feed."}},{"@type":"Question","name":"Can I run it without waiting for an invite?","acceptedAnswer":{"@type":"Answer","text":"Yes. Clone github.com/Ogrods/BAKLOG and run from source on Windows, macOS, or Linux. The invite beta is optional packaged builds and update delivery on top of the same MIT tree."}},{"@type":"Question","name":"How is this different from Playnite?","acceptedAnswer":{"@type":"Answer","text":"Playnite is a launcher: it opens games and unifies your library view. BAKLOG is a backlog dashboard: what to play next, cross-store dedupe, wishlist deal radar, and ownership-aware sale checks. Many people use both. BAKLOG is not trying to replace your launcher."}},{"@type":"Question","name":"Isn't scraping against the rules?","acceptedAnswer":{"@type":"Answer","text":"BAKLOG automates requests you could make yourself, in your own browser, with your own credentials, on your own machine. Each storefront sees normal traffic from your IP, as you."}},{"@type":"Question","name":"Why invite-only right now?","acceptedAnswer":{"@type":"Answer","text":"We are onboarding in small waves so we can fix what breaks on real setups before opening the doors. Request an invite and you are in line for the next wave."}},{"@type":"Question","name":"Do you sell my data?","acceptedAnswer":{"@type":"Answer","text":"No. BAKLOG has no business model built on your library. We do not collect, host, or sell catalog data. There is no server holding it to sell. Optional invite login (Supabase) stores your email only; games stay local."}}]}]}</script>
 
   <style>
     @font-face {
@@ -555,7 +560,7 @@
     .foot-social a:hover { color: #fff; border-color: var(--text-mute); background: rgba(255,255,255,0.06); }
     .foot-social svg { width: 18px; height: 18px; fill: currentColor; }
     .foot-links { display: grid; grid-template-columns: repeat(2, auto); gap: 2rem 3.5rem; }
-    .foot-col h4 { margin: 0 0 0.65rem; font-size: 0.72rem; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-mute); }
+    .foot-col h3 { margin: 0 0 0.65rem; font-size: 0.72rem; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-mute); }
     .foot-col a { display: block; font-size: 0.9rem; line-height: 1.45; font-weight: 600; padding: 0.15rem 0; }
     .foot-bottom { display: flex; flex-wrap: wrap; justify-content: space-between; align-items: center; gap: 0.75rem 1.5rem; margin-top: 2.5rem; padding-top: 1.5rem; border-top: 1px solid var(--border-subtle); font-size: 0.8rem; color: var(--text-mute); }
     .foot-legal, .foot-trademark, .foot-affiliate { margin: 0; }
@@ -848,7 +853,7 @@
             <li>Store sign-in opens your own installed Chrome or Edge on your machine. Session cookies stay in a local browser profile on disk. No container, no remote sandbox, nothing shipped to us.</li>
             <li>Credentials encrypted at rest (AES-256-GCM); keys in Windows Credential Manager, macOS Keychain, or Linux Secret Service</li>
             <li>No telemetry by default. <a href="https://github.com/Ogrods/BAKLOG" target="_blank" rel="noopener noreferrer">MIT source on GitHub</a> with a published <a href="https://github.com/Ogrods/BAKLOG/blob/main/SECURITY.md" target="_blank" rel="noopener noreferrer">threat model</a> you can read before you trust us</li>
-            <li>baklog.app is separate from your library: waitlist email if you request an invite, a bug report only if you click Send, and a public free-games feed. Your catalog never uploads there.</li>
+            <li>baklog.app is separate from your library: Google Analytics for anonymous page views, waitlist email if you request an invite, a bug report only if you click Send, and a public free-games feed. Your catalog never uploads there.</li>
             <li>We do not sell data because we do not host it. Optional invite login stores email only; your games stay in your local profile folder.</li>
           </ul>
         </article>
@@ -1017,19 +1022,19 @@
       <h2>There is no BAKLOG server to breach.</h2>
       <p>Your library JSON and store credentials stay on your PC. Fetches go to each storefront from your IP, through your own browser session. We do not run a datacenter copy of anyone's catalog.</p>
       <p>Sign-in is not a remote container: your installed Chrome or Edge opens locally, cookies land in a browser profile on disk, and nothing is shipped to us. Local-first is that architecture, not a trick about binding to localhost.</p>
-      <p>Skeptical? Read the published <a href="https://github.com/Ogrods/BAKLOG/blob/main/SECURITY.md" target="_blank" rel="noopener noreferrer">threat model</a> and <a href="https://github.com/Ogrods/BAKLOG/blob/main/PRIVACY.md" target="_blank" rel="noopener noreferrer">privacy inventory</a> before you trust us. The <a href="https://github.com/Ogrods/BAKLOG" target="_blank" rel="noopener noreferrer">full MIT tree</a> is public: server, fetchers, auth, dashboard. No telemetry by default on the desktop app; opt-in anonymous aggregate metrics only. baklog.app only touches waitlist email, opt-in bug reports you send, and a public free-games feed.</p>
+      <p>Skeptical? Read the published <a href="https://github.com/Ogrods/BAKLOG/blob/main/SECURITY.md" target="_blank" rel="noopener noreferrer">threat model</a> and <a href="https://github.com/Ogrods/BAKLOG/blob/main/PRIVACY.md" target="_blank" rel="noopener noreferrer">privacy inventory</a> before you trust us. The <a href="https://github.com/Ogrods/BAKLOG" target="_blank" rel="noopener noreferrer">full MIT tree</a> is public: server, fetchers, auth, dashboard. No telemetry by default on the desktop app; opt-in anonymous aggregate metrics only. baklog.app uses Google Analytics for anonymous page views on the marketing site, plus waitlist email, opt-in bug reports you send, and a public free-games feed. Your catalog never uploads there.</p>
     </div>
   </section>
 
   <!-- ============ FAQ ============ -->
-  <section class="band">
+  <section class="band" id="faq">
     <div class="wrap" style="text-align:center">
       <span class="eyebrow">Questions</span>
       <h2>Straight answers.</h2>
       <div class="faq" style="text-align:left">
         <details>
           <summary>Is it safe?</summary>
-          <p>Your credentials stay encrypted on your machine (AES-256-GCM, OS keychain). Store sign-in runs in your own local browser, not a container and not a shared cloud vault. Fetches go straight from your PC to each storefront, from your IP. There is no BAKLOG server holding your library. The full app is <a href="https://github.com/Ogrods/BAKLOG" target="_blank" rel="noopener noreferrer">open source (MIT)</a> with a published <a href="https://github.com/Ogrods/BAKLOG/blob/main/SECURITY.md" target="_blank" rel="noopener noreferrer">threat model</a> that lists what we defend and what we do not (local malware, storefront ToS, and the rest). baklog.app only sees a waitlist email or an opt-in bug report you send; it never receives your catalog.</p>
+          <p>Your credentials stay encrypted on your machine (AES-256-GCM, OS keychain). Store sign-in runs in your own local browser, not a container and not a shared cloud vault. Fetches go straight from your PC to each storefront, from your IP. There is no BAKLOG server holding your library. The full app is <a href="https://github.com/Ogrods/BAKLOG" target="_blank" rel="noopener noreferrer">open source (MIT)</a> with a published <a href="https://github.com/Ogrods/BAKLOG/blob/main/SECURITY.md" target="_blank" rel="noopener noreferrer">threat model</a> that lists what we defend and what we do not (local malware, storefront ToS, and the rest). baklog.app never receives your catalog. The marketing site uses Google Analytics for anonymous page views. Waitlist email if you request an invite, and a bug report only if you click Send.</p>
         </details>
         <details>
           <summary>Is it open source?</summary>
@@ -1065,7 +1070,7 @@
         </details>
         <details>
           <summary>Does it upload my library?</summary>
-          <p>No. Your catalog and credentials stay in your local profile folder. Store fetches go straight from your PC to each storefront. baklog.app never receives your library JSON. The only things that touch this site are a waitlist email if you request an invite, a bug report only if you click Send, and a public free-games metadata feed.</p>
+          <p>No. Your catalog and credentials stay in your local profile folder. Store fetches go straight from your PC to each storefront. baklog.app never receives your library JSON. The marketing site uses Google Analytics for anonymous page views. Waitlist email if you request an invite, a bug report only if you click Send, and a public free-games metadata feed.</p>
         </details>
         <details>
           <summary>Can I run it without waiting for an invite?</summary>
@@ -1149,7 +1154,7 @@
         </div>
         <nav class="foot-links" aria-label="Footer">
           <div class="foot-col">
-            <h4>Community</h4>
+            <h3>Community</h3>
             <!-- Discord + GitHub: keep in sync with shared/community.json -->
             <a href="#waitlist">Request an invite</a>
             <a href="https://discord.gg/VFvxN5nCCB" target="_blank" rel="noopener noreferrer">Discord</a>
@@ -1159,7 +1164,7 @@
             <a href="mailto:dan@baklog.app">dan@baklog.app</a>
           </div>
           <div class="foot-col">
-            <h4>Data sources</h4>
+            <h3>Data sources</h3>
             <a href="https://www.protondb.com/" target="_blank" rel="noopener noreferrer">ProtonDB</a>
             <a href="https://isthereanydeal.com/" target="_blank" rel="noopener noreferrer">IsThereAnyDeal</a>
             <a href="https://www.gamerpower.com/" target="_blank" rel="noopener noreferrer">GamerPower</a>

--- a/landing/llms.txt
+++ b/landing/llms.txt
@@ -1,0 +1,26 @@
+# BAKLOG
+
+> Local-only cross-store game backlog dashboard. Library JSON, credentials, and personal data stay on the user's machine.
+
+## Site
+
+- Homepage: https://baklog.app/
+- Source: https://github.com/Ogrods/BAKLOG
+- License: MIT
+- User guide: https://github.com/Ogrods/BAKLOG/tree/main/guide
+
+## What baklog.app is
+
+baklog.app is the marketing site, invite waitlist, hosted auth pages, and public feeds (`/free-claims.json`, `/sponsors.json`). It does not host user libraries. The marketing site uses Google Analytics for anonymous page views.
+
+## Product facts
+
+- Runs on Windows, macOS, and Linux on the user's PC.
+- Imports 12 store libraries and 8 wishlists.
+- Free forever to import. Optional paid Pro tier for conveniences.
+- Invite-only packaged beta; anyone can clone and run from source.
+- No telemetry by default. Optional opt-in anonymous aggregate metrics.
+
+## Contact
+
+dan@baklog.app

--- a/landing/robots.txt
+++ b/landing/robots.txt
@@ -1,6 +1,7 @@
 User-agent: *
 Allow: /
 
+Disallow: /auth/
 Disallow: /auth-confirmed
 Disallow: /auth-reset
 Disallow: /success

--- a/landing/sitemap.xml
+++ b/landing/sitemap.xml
@@ -2,6 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://baklog.app/</loc>
+    <lastmod>2026-08-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/landing/vercel.json
+++ b/landing/vercel.json
@@ -25,7 +25,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; form-action 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none'"
+          "value": "default-src 'self'; script-src 'self' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https://www.googletagmanager.com https://*.google-analytics.com; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; form-action 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none'"
         }
       ]
     },
@@ -52,11 +52,15 @@
       "headers": [{ "key": "Cache-Control", "value": "public, max-age=86400" }]
     },
     {
+      "source": "/llms.txt",
+      "headers": [{ "key": "Cache-Control", "value": "public, max-age=86400" }]
+    },
+    {
       "source": "/apple-touch-icon.png",
       "headers": [{ "key": "Cache-Control", "value": "public, max-age=86400" }]
     },
     {
-      "source": "/(main|demo|pro-checkout-gate)\\.js|demo\\.css",
+      "source": "/(main|demo|pro-checkout-gate|ga)\\.js|demo\\.css",
       "headers": [{ "key": "Cache-Control", "value": "public, max-age=86400" }]
     },
     {
@@ -86,6 +90,17 @@
     },
     {
       "source": "/auth-confirmed",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=300" },
+        { "key": "X-Robots-Tag", "value": "noindex, nofollow" },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://*.supabase.co wss://*.supabase.co; form-action 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none'"
+        }
+      ]
+    },
+    {
+      "source": "/auth-reset",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=300" },
         { "key": "X-Robots-Tag", "value": "noindex, nofollow" },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "watch:tailwind": "tailwindcss -i styles/tailwind-input.css -o tailwind.css --watch",
     "build": "node scripts/build-frontend.mjs",
     "landing": "python -m http.server 4000 --directory landing",
+    "check:landing-seo": "node scripts/check-landing-seo.mjs",
     "check:spotlight:baseline": "node scripts/spotlight-visual-check.mjs --mode=baseline",
     "check:spotlight": "node scripts/spotlight-visual-check.mjs --mode=after",
     "vendor:supabase": "esbuild node_modules/@supabase/supabase-js/dist/index.mjs --bundle --format=esm --outfile=js/vendor/supabase-js.mjs && node -e \"import fs from 'node:fs'; fs.mkdirSync('landing/vendor',{recursive:true}); fs.copyFileSync('js/vendor/supabase-js.mjs','landing/vendor/supabase-js.mjs')\"",

--- a/scripts/check-landing-seo.mjs
+++ b/scripts/check-landing-seo.mjs
@@ -1,0 +1,150 @@
+/**
+ * Landing SEO gate: JSON-LD parse + FAQ sync, required meta, no em dashes.
+ * Used as seo-god.json build_cmd. Does not start a server.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(import.meta.dirname, "..");
+const landing = path.join(root, "landing");
+const EM_DASH = "\u2014";
+
+export function extractFaqFromHtml(html) {
+  const start = html.indexOf('class="faq"');
+  if (start < 0) return [];
+  const end = html.indexOf("</section>", start);
+  const block = html.slice(start, end < 0 ? undefined : end);
+  const re = /<summary>([\s\S]*?)<\/summary>\s*<p>([\s\S]*?)<\/p>/g;
+  const items = [];
+  let m;
+  while ((m = re.exec(block))) {
+    items.push({
+      q: m[1].replace(/<[^>]+>/g, "").trim(),
+      a: m[2].replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim(),
+    });
+  }
+  return items;
+}
+
+function parseLdBlocks(html) {
+  const re = /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g;
+  const docs = [];
+  let m;
+  while ((m = re.exec(html))) {
+    docs.push(JSON.parse(m[1]));
+  }
+  return docs;
+}
+
+function flattenLd(docs) {
+  const nodes = [];
+  for (const doc of docs) {
+    if (doc && Array.isArray(doc["@graph"])) nodes.push(...doc["@graph"]);
+    else if (doc) nodes.push(doc);
+  }
+  return nodes;
+}
+
+function scanEmDash(filePath, errors) {
+  const text = fs.readFileSync(filePath, "utf8");
+  const idx = text.indexOf(EM_DASH);
+  if (idx >= 0) {
+    const line = text.slice(0, idx).split("\n").length;
+    errors.push(`${path.relative(root, filePath)}:${line} contains an em dash (U+2014)`);
+  }
+}
+
+export function checkLandingSeo() {
+  const errors = [];
+  const indexPath = path.join(landing, "index.html");
+  const html = fs.readFileSync(indexPath, "utf8");
+
+  if (!html.includes('<link rel="canonical" href="https://baklog.app/"')) {
+    errors.push("index.html missing canonical https://baklog.app/");
+  }
+  const descMatch = html.match(/<meta name="description" content="([^"]*)"/);
+  if (!descMatch) {
+    errors.push("index.html missing meta description");
+  } else if (descMatch[1].length > 160) {
+    errors.push(`index.html meta description is ${descMatch[1].length} chars (max 160)`);
+  }
+  if (!html.includes('property="og:image"')) {
+    errors.push("index.html missing og:image");
+  }
+  if (!html.includes('rel="apple-touch-icon"')) {
+    errors.push("index.html missing apple-touch-icon");
+  }
+  if (!html.includes('id="faq"')) {
+    errors.push("index.html FAQ section missing id=faq");
+  }
+
+  let nodes = [];
+  try {
+    nodes = flattenLd(parseLdBlocks(html));
+  } catch (err) {
+    errors.push(`JSON-LD parse failed: ${err.message}`);
+    return errors;
+  }
+
+  const types = new Set(nodes.map((n) => n && n["@type"]).filter(Boolean));
+  for (const need of ["SoftwareApplication", "WebSite", "FAQPage"]) {
+    if (!types.has(need)) errors.push(`JSON-LD missing @type ${need}`);
+  }
+
+  const faqPage = nodes.find((n) => n && n["@type"] === "FAQPage");
+  const htmlFaq = extractFaqFromHtml(html);
+  if (!htmlFaq.length) errors.push("no FAQ details/summary pairs in index.html");
+  const ldQs = (faqPage?.mainEntity || []).map((e) => e?.name);
+  if (ldQs.length !== htmlFaq.length) {
+    errors.push(`FAQPage has ${ldQs.length} questions, HTML has ${htmlFaq.length}`);
+  } else {
+    htmlFaq.forEach((item, i) => {
+      if (ldQs[i] !== item.q) {
+        errors.push(`FAQ question ${i + 1} mismatch: JSON-LD ${JSON.stringify(ldQs[i])} vs HTML ${JSON.stringify(item.q)}`);
+      }
+    });
+  }
+
+  if (!html.includes("G-88L32JZQDH") || !fs.existsSync(path.join(landing, "ga.js"))) {
+    errors.push("index.html / ga.js missing Google Analytics measurement id");
+  }
+
+  const vercel = fs.readFileSync(path.join(landing, "vercel.json"), "utf8");
+  if (!vercel.includes("https://www.googletagmanager.com")) {
+    errors.push("vercel.json CSP missing googletagmanager.com for GA");
+  }
+
+  const sitemap = fs.readFileSync(path.join(landing, "sitemap.xml"), "utf8");
+  if (!sitemap.includes("<loc>https://baklog.app/</loc>")) {
+    errors.push("sitemap.xml missing https://baklog.app/");
+  }
+
+  const robots = fs.readFileSync(path.join(landing, "robots.txt"), "utf8");
+  if (!robots.includes("Disallow: /auth/")) {
+    errors.push("robots.txt missing Disallow: /auth/");
+  }
+  if (!robots.includes("Sitemap: https://baklog.app/sitemap.xml")) {
+    errors.push("robots.txt missing Sitemap URL");
+  }
+
+  const llms = path.join(landing, "llms.txt");
+  if (!fs.existsSync(llms)) errors.push("landing/llms.txt missing");
+  else scanEmDash(llms, errors);
+
+  for (const name of fs.readdirSync(landing)) {
+    if (name.endsWith(".html")) scanEmDash(path.join(landing, name), errors);
+  }
+
+  return errors;
+}
+
+if (path.resolve(process.argv[1] || "") === fileURLToPath(import.meta.url)) {
+  const errors = checkLandingSeo();
+  if (errors.length) {
+    console.error(`landing SEO check failed (${errors.length}):`);
+    for (const e of errors) console.error(`  ${e}`);
+    process.exit(1);
+  }
+  console.log("landing SEO check ok");
+}

--- a/scripts/hooks/pre-push-internal.ps1
+++ b/scripts/hooks/pre-push-internal.ps1
@@ -1,5 +1,9 @@
 # Pre-push internal sync helper - runs from scripts/hooks/pre-push.
 # Syncs gitignored internal paths to baklog-internal when they changed since last sync.
+#
+# This runs inside a public-repo hook. Git sets GIT_DIR to the public .git;
+# sync-internal-repo.ps1 must clear that env before any git command in the
+# private clone. Set BAKLOG_SKIP_INTERNAL_SYNC=1 to skip.
 param(
     [string]$InternalRepo = ""
 )
@@ -13,8 +17,18 @@ if (-not $InternalRepo) {
     $InternalRepo = Join-Path (Split-Path $RepoRoot -Parent) "baklog-internal"
 }
 
+if ($env:BAKLOG_SKIP_INTERNAL_SYNC -eq "1") {
+    Write-Host "[pre-push] BAKLOG_SKIP_INTERNAL_SYNC=1 - skipping internal sync." -ForegroundColor DarkGray
+    exit 0
+}
+
 if (-not (Test-Path $manifestFile)) {
     Write-Host "[pre-push] No internal manifest - skipping internal sync." -ForegroundColor DarkGray
+    exit 0
+}
+
+if (-not (Test-Path -LiteralPath $InternalRepo)) {
+    Write-Host "[pre-push] Internal clone not found at $InternalRepo - skipping." -ForegroundColor DarkGray
     exit 0
 }
 
@@ -61,9 +75,11 @@ if (-not $needsSync) {
 }
 
 Write-Host "[pre-push] Internal docs changed - syncing to private repo..." -ForegroundColor Cyan
-& $syncScript -InternalRepo $InternalRepo -Push
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "[pre-push] Internal sync failed. Push aborted." -ForegroundColor Red
+try {
+    & $syncScript -InternalRepo $InternalRepo -Push
+    if ($LASTEXITCODE -ne 0) { throw "sync-internal-repo.ps1 exited $LASTEXITCODE" }
+} catch {
+    Write-Host "[pre-push] Internal sync failed. Push aborted. $($_.Exception.Message)" -ForegroundColor Red
     exit 1
 }
 Write-Host "[pre-push] Internal sync complete." -ForegroundColor Green

--- a/scripts/hooks/remind-tracker.py
+++ b/scripts/hooks/remind-tracker.py
@@ -1,25 +1,119 @@
 #!/usr/bin/env python3
-"""Cursor stop hook: remind agent to update tracker.html after a session."""
+"""Cursor stop hook: remind agent to update tracker.html after a session.
+
+Always returning followup_message turns every agent stop into a new user turn.
+Cursor's loop_limit is supposed to cap that, but other injected user messages
+(e.g. background shell notifications) start a fresh stop cycle and reset the
+count - the reminder then ping-pongs forever.
+
+Honor loop_count, skip aborted stops, and remember the conversation id so this
+conversation gets at most one reminder.
+"""
+from __future__ import annotations
+
 import json
+import os
 import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+REMINDER = (
+    "Session ending — if you completed meaningful work, update tracker.html: "
+    "mark the relevant PHASES/findings entry [DONE] or [RESOLVED] with a dated note. "
+    "See docs/WORKFLOW.md. Do not create PROGRESS.md. "
+    "Direct-edit-first: when ..\\baklog-internal\\tracker.html exists, edit it there "
+    "and run .\\scripts\\sync-internal-repo.ps1 -Push. "
+    "Only if the internal clone is missing or editing is blocked (e.g. plan mode), "
+    "write .cursor/tracker-pending-<slug>.md and run /apply-tracker-pending later."
+)
+
+TTL_SEC = 12 * 3600
+ANON_TTL_SEC = 20 * 60
+
+
+def state_path() -> Path:
+    override = os.environ.get("BAKLOG_REMIND_TRACKER_STATE")
+    if override:
+        return Path(override)
+    return Path(tempfile.gettempdir()) / "baklog-remind-tracker.json"
+
+
+def _load_state(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _save_state(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def already_reminded(key: str, now: float, path: Path, ttl: int = TTL_SEC) -> bool:
+    if not key:
+        return False
+    data = _load_state(path)
+    ts = data.get(key)
+    try:
+        seen = float(ts)
+    except (TypeError, ValueError):
+        return False
+    return (now - seen) < ttl
+
+
+def mark_reminded(key: str, now: float, path: Path) -> None:
+    data = _load_state(path)
+    cutoff = now - TTL_SEC
+    pruned = {k: v for k, v in data.items() if isinstance(v, (int, float)) and v >= cutoff}
+    pruned[key] = now
+    _save_state(path, pruned)
+
+
+def conversation_key(payload: dict[str, Any]) -> str:
+    for field in ("conversation_id", "conversationId", "session_id", "sessionId"):
+        val = payload.get(field)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    return ""
+
+
+def should_remind(payload: dict[str, Any], *, now: float | None = None, path: Path | None = None) -> bool:
+    """Return True when this stop should inject the tracker follow-up."""
+    if (payload.get("status") or "") == "aborted":
+        return False
+    try:
+        loop_count = int(payload.get("loop_count") or 0)
+    except (TypeError, ValueError):
+        loop_count = 0
+    if loop_count > 0:
+        return False
+    stamp = time.time() if now is None else now
+    store = path if path is not None else state_path()
+    key = conversation_key(payload) or "__anon__"
+    ttl = TTL_SEC if key != "__anon__" else ANON_TTL_SEC
+    if already_reminded(key, stamp, store, ttl=ttl):
+        return False
+    mark_reminded(key, stamp, store)
+    return True
 
 
 def main() -> int:
+    payload: dict[str, Any] = {}
     try:
-        json.load(sys.stdin)
+        raw = json.load(sys.stdin)
+        if isinstance(raw, dict):
+            payload = raw
     except Exception:
         pass
 
-    msg = (
-        "Session ending — if you completed meaningful work, update tracker.html: "
-        "mark the relevant PHASES/findings entry [DONE] or [RESOLVED] with a dated note. "
-        "See docs/WORKFLOW.md. Do not create PROGRESS.md. "
-        "Direct-edit-first: when ..\\baklog-internal\\tracker.html exists, edit it there "
-        "and run .\\scripts\\sync-internal-repo.ps1 -Push. "
-        "Only if the internal clone is missing or editing is blocked (e.g. plan mode), "
-        "write .cursor/tracker-pending-<slug>.md and run /apply-tracker-pending later."
-    )
-    print(json.dumps({"followup_message": msg}))
+    if should_remind(payload):
+        print(json.dumps({"followup_message": REMINDER}), flush=True)
+    else:
+        print("{}", flush=True)
     return 0
 
 

--- a/scripts/sync-internal-repo.ps1
+++ b/scripts/sync-internal-repo.ps1
@@ -11,48 +11,163 @@
 #   .\scripts\sync-internal-repo.ps1 -InternalRepo "D:\repos\baklog-internal" -Push
 #   .\scripts\sync-internal-repo.ps1 -NoCommit
 #
+# Safety (do not weaken — this script runs from the public pre-push hook):
+#   Git hooks set GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE to the repo being
+#   pushed. A cd into baklog-internal does NOT retarget git; `git add -A` and
+#   `git commit` would stage the private tree into the public repo. Always
+#   Clear-InheritedGitEnv, then `git -C $InternalRepo`, then confirm the public
+#   HEAD SHA did not move (reset it if it did). Directory copies merge; they
+#   never delete dest-only files such as .cursor/rules/internal-*.mdc.
+#
 param(
     [string]$InternalRepo = "",
+    [string]$RepoRoot = "",
+    [string]$ManifestFile = "",
     [string]$Message = "",
     [switch]$Push,
     [switch]$NoCommit
 )
 
 $ErrorActionPreference = "Stop"
-$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
-if (-not $InternalRepo) {
-    $InternalRepo = Join-Path (Split-Path $RepoRoot -Parent) "baklog-internal"
-}
-if (Test-Path -LiteralPath $InternalRepo) {
-    $InternalRepo = (Resolve-Path -LiteralPath $InternalRepo).Path
-} else {
-    New-Item -ItemType Directory -Force -Path $InternalRepo | Out-Null
-    $InternalRepo = (Resolve-Path -LiteralPath $InternalRepo).Path
-}
 
-$manifestFile = Join-Path $PSScriptRoot "internal-manifest.txt"
-if (-not (Test-Path $manifestFile)) {
-    Write-Error "Missing manifest: $manifestFile"
-}
-
-function Copy-InternalPath($rel) {
-    $src = Join-Path $RepoRoot $rel
-    if (-not (Test-Path $src)) { return $false }
-    $dest = Join-Path $InternalRepo $rel
-    $parent = Split-Path $dest -Parent
-    if ($parent -and -not (Test-Path $parent)) {
-        New-Item -ItemType Directory -Force -Path $parent | Out-Null
+function Clear-InheritedGitEnv {
+    @(
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_NAMESPACE",
+        "GIT_COMMON_DIR",
+        "GIT_PREFIX",
+        "GIT_SUPER_PREFIX"
+    ) | ForEach-Object {
+        if (Test-Path "Env:$_") { Remove-Item "Env:$_" }
     }
-    if ((Get-Item $src).PSIsContainer) {
-        if (Test-Path $dest) { Remove-Item $dest -Recurse -Force }
-        Copy-Item -Path $src -Destination $dest -Recurse -Force
+}
+
+function Invoke-GitAt {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string[]]$GitArgs
+    )
+    Clear-InheritedGitEnv
+    $output = & git -C $Path @GitArgs 2>&1
+    return [pscustomobject]@{
+        Code   = $LASTEXITCODE
+        Output = $output
+        Text   = (($output | ForEach-Object { "$_" }) -join "`n").Trim()
+    }
+}
+
+function Get-RepoToplevel([string]$Path) {
+    $r = Invoke-GitAt -Path $Path -GitArgs @("rev-parse", "--show-toplevel")
+    if ($r.Code -ne 0 -or -not $r.Text) {
+        throw "Not a git work tree: $Path"
+    }
+    return (Resolve-Path -LiteralPath $r.Text).Path.TrimEnd("\", "/")
+}
+
+function Get-OriginUrl([string]$Path) {
+    $r = Invoke-GitAt -Path $Path -GitArgs @("remote", "get-url", "origin")
+    if ($r.Code -ne 0) { return "" }
+    return $r.Text
+}
+
+function Get-HeadSha([string]$Path) {
+    $r = Invoke-GitAt -Path $Path -GitArgs @("rev-parse", "HEAD")
+    if ($r.Code -ne 0 -or -not $r.Text) {
+        throw "Could not read HEAD in $Path"
+    }
+    return $r.Text
+}
+
+function Normalize-RepoPath([string]$Path) {
+    return (Resolve-Path -LiteralPath $Path).Path.TrimEnd("\", "/").ToLowerInvariant()
+}
+
+function Assert-SafeInternalDestination([string]$SourceRoot, [string]$DestRoot) {
+    $srcTop = Get-RepoToplevel $SourceRoot
+    $dstTop = Get-RepoToplevel $DestRoot
+    if ((Normalize-RepoPath $srcTop) -eq (Normalize-RepoPath $dstTop)) {
+        throw "Refusing internal sync: destination is the same git work tree as the public repo ($srcTop)."
+    }
+    $srcUrl = Get-OriginUrl $SourceRoot
+    $dstUrl = Get-OriginUrl $DestRoot
+    if (-not $dstUrl) {
+        throw "Refusing internal sync: $DestRoot has no origin remote."
+    }
+    if ($dstUrl -notmatch "baklog-internal") {
+        throw "Refusing internal sync: origin '$dstUrl' is not baklog-internal."
+    }
+    if ($srcUrl -and ($srcUrl.TrimEnd("/") -ieq $dstUrl.TrimEnd("/"))) {
+        throw "Refusing internal sync: public and internal remotes are identical ($srcUrl)."
+    }
+    if ($dstUrl -match "Ogrods/BAKLOG(\.git)?/?$") {
+        throw "Refusing internal sync: origin looks like the public BAKLOG repo ($dstUrl)."
+    }
+}
+
+function Copy-InternalPath([string]$RepoRoot, [string]$InternalRepo, [string]$rel) {
+    $src = Join-Path $RepoRoot $rel
+    if (-not (Test-Path -LiteralPath $src)) { return $false }
+    $dest = Join-Path $InternalRepo $rel
+    $srcItem = Get-Item -LiteralPath $src
+    if ($srcItem.PSIsContainer) {
+        if (-not (Test-Path -LiteralPath $dest)) {
+            New-Item -ItemType Directory -Force -Path $dest | Out-Null
+        }
+        $srcRoot = $srcItem.FullName.TrimEnd("\", "/")
+        Get-ChildItem -LiteralPath $src -Recurse -File -Force | ForEach-Object {
+            $relFile = $_.FullName.Substring($srcRoot.Length).TrimStart("\", "/")
+            $destFile = Join-Path $dest $relFile
+            $destParent = Split-Path $destFile -Parent
+            if ($destParent -and -not (Test-Path -LiteralPath $destParent)) {
+                New-Item -ItemType Directory -Force -Path $destParent | Out-Null
+            }
+            Copy-Item -LiteralPath $_.FullName -Destination $destFile -Force
+        }
     } else {
-        Copy-Item -Path $src -Destination $dest -Force
+        $parent = Split-Path $dest -Parent
+        if ($parent -and -not (Test-Path -LiteralPath $parent)) {
+            New-Item -ItemType Directory -Force -Path $parent | Out-Null
+        }
+        Copy-Item -LiteralPath $src -Destination $dest -Force
     }
     return $true
 }
 
-$paths = Get-Content $manifestFile | ForEach-Object {
+if (-not $RepoRoot) {
+    $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+} else {
+    $RepoRoot = (Resolve-Path -LiteralPath $RepoRoot).Path
+}
+if (-not $InternalRepo) {
+    $InternalRepo = Join-Path (Split-Path $RepoRoot -Parent) "baklog-internal"
+}
+if (-not (Test-Path -LiteralPath $InternalRepo)) {
+    throw "Internal repo not found: $InternalRepo. Clone Ogrods/baklog-internal as a sibling, then re-run."
+}
+$InternalRepo = (Resolve-Path -LiteralPath $InternalRepo).Path
+
+if (-not $ManifestFile) {
+    $ManifestFile = Join-Path $PSScriptRoot "internal-manifest.txt"
+}
+if (-not (Test-Path -LiteralPath $ManifestFile)) {
+    throw "Missing manifest: $ManifestFile"
+}
+
+if (-not (Test-Path -LiteralPath (Join-Path $InternalRepo ".git"))) {
+    Write-Host ""
+    Write-Host "Destination is not a git repo. Clone your private GitHub repo there, then re-run." -ForegroundColor Yellow
+    Write-Host "  git clone https://github.com/Ogrods/baklog-internal.git `"$InternalRepo`"" -ForegroundColor DarkGray
+    exit 0
+}
+
+Assert-SafeInternalDestination -SourceRoot $RepoRoot -DestRoot $InternalRepo
+$publicHeadBefore = Get-HeadSha $RepoRoot
+
+$paths = Get-Content -LiteralPath $ManifestFile | ForEach-Object {
     $line = $_.Trim()
     if (-not $line -or $line.StartsWith("#")) { return }
     $line
@@ -60,17 +175,11 @@ $paths = Get-Content $manifestFile | ForEach-Object {
 
 $copied = @()
 foreach ($rel in $paths) {
-    if (Copy-InternalPath $rel) { $copied += $rel }
+    if (Copy-InternalPath $RepoRoot $InternalRepo $rel) { $copied += $rel }
 }
 
-$gitHead = "unknown"
-try {
-    Push-Location $RepoRoot
-    $out = git rev-parse --short HEAD 2>$null
-    if ($out) { $gitHead = $out.Trim() }
-} finally {
-    Pop-Location
-}
+$headShort = Invoke-GitAt -Path $RepoRoot -GitArgs @("rev-parse", "--short", "HEAD")
+$gitHead = if ($headShort.Code -eq 0 -and $headShort.Text) { $headShort.Text } else { "unknown" }
 
 $syncManifest = @"
 BAKLOG internal docs sync
@@ -82,7 +191,7 @@ Copied:   $($copied -join ", ")
 Set-Content -Path (Join-Path $InternalRepo "SYNC-MANIFEST.txt") -Value $syncManifest -Encoding UTF8
 
 $readmePath = Join-Path $InternalRepo "README.md"
-if (-not (Test-Path $readmePath)) {
+if (-not (Test-Path -LiteralPath $readmePath)) {
     $seed = @'
 # BAKLOG internal (private)
 
@@ -112,16 +221,17 @@ if ($copied.Count -gt 0) {
     Write-Host "  Copied:      (none - manifest paths missing locally)" -ForegroundColor Yellow
 }
 
-if ($NoCommit) {
-    Write-Host "  Commit:      skipped (-NoCommit)" -ForegroundColor Yellow
-    exit 0
+function Assert-PublicHeadUnchanged([string]$ExpectedHead) {
+    $after = Get-HeadSha $RepoRoot
+    if ($after -eq $ExpectedHead) { return }
+    $reset = Invoke-GitAt -Path $RepoRoot -GitArgs @("reset", "--hard", $ExpectedHead)
+    throw ("Internal sync committed to the public repo (inherited GIT_DIR). " +
+        "Reset public HEAD $after -> $ExpectedHead (git reset --hard exit $($reset.Code)). Refusing to continue.")
 }
 
-$isGit = Test-Path (Join-Path $InternalRepo ".git")
-if (-not $isGit) {
-    Write-Host ""
-    Write-Host "Destination is not a git repo. Clone your private GitHub repo there, then re-run." -ForegroundColor Yellow
-    Write-Host "  git init; git remote add origin YOUR-PRIVATE-REPO-URL" -ForegroundColor DarkGray
+if ($NoCommit) {
+    Write-Host "  Commit:      skipped (-NoCommit)" -ForegroundColor Yellow
+    Assert-PublicHeadUnchanged $publicHeadBefore
     exit 0
 }
 
@@ -129,26 +239,41 @@ if (-not $Message) {
     $Message = "sync internal docs from steam-backlog at $gitHead"
 }
 
-Push-Location $InternalRepo
-try {
-    git add -A
-    $status = git status --porcelain
-    if (-not $status) {
-        Write-Host "  Commit:      nothing to commit (already up to date)" -ForegroundColor DarkGray
-    } else {
-        git commit -m $Message
-        Write-Host "  Commit:      $Message" -ForegroundColor Green
+$addArgs = @("add", "--", "SYNC-MANIFEST.txt", "README.md") + $copied
+$add = Invoke-GitAt -Path $InternalRepo -GitArgs $addArgs
+if ($add.Code -ne 0) {
+    Assert-PublicHeadUnchanged $publicHeadBefore
+    throw "git add in internal repo failed: $($add.Text)"
+}
+
+$status = Invoke-GitAt -Path $InternalRepo -GitArgs @("status", "--porcelain")
+if (-not $status.Text) {
+    Write-Host "  Commit:      nothing to commit (already up to date)" -ForegroundColor DarkGray
+} else {
+    $commit = Invoke-GitAt -Path $InternalRepo -GitArgs @("commit", "-m", $Message)
+    if ($commit.Code -ne 0) {
+        Assert-PublicHeadUnchanged $publicHeadBefore
+        throw "git commit in internal repo failed: $($commit.Text)"
     }
-    if ($Push) {
-        git push 2>$null
-        if ($LASTEXITCODE -ne 0) {
-            git push -u origin HEAD
-            if ($LASTEXITCODE -ne 0) { throw "git push failed" }
+    Write-Host "  Commit:      $Message" -ForegroundColor Green
+}
+
+Assert-PublicHeadUnchanged $publicHeadBefore
+
+$internalTop = Get-RepoToplevel $InternalRepo
+if ((Normalize-RepoPath $internalTop) -eq (Normalize-RepoPath (Get-RepoToplevel $RepoRoot))) {
+    throw "Refusing to push: internal git toplevel collapsed onto the public repo."
+}
+
+if ($Push) {
+    $pushResult = Invoke-GitAt -Path $InternalRepo -GitArgs @("push")
+    if ($pushResult.Code -ne 0) {
+        $pushResult = Invoke-GitAt -Path $InternalRepo -GitArgs @("push", "-u", "origin", "HEAD")
+        if ($pushResult.Code -ne 0) {
+            throw "git push of baklog-internal failed: $($pushResult.Text)"
         }
-        Write-Host "  Push:        done" -ForegroundColor Green
     }
-} finally {
-    Pop-Location
+    Write-Host "  Push:        done" -ForegroundColor Green
 }
 
 Write-Host ""

--- a/scripts/test-all.ps1
+++ b/scripts/test-all.ps1
@@ -52,6 +52,7 @@ if (-not $Full) {
 }
 
 Invoke-NpmStep -Label "check:module-size" -NpmArgs @("run", "check:module-size")
+Invoke-NpmStep -Label "check:landing-seo" -NpmArgs @("run", "check:landing-seo")
 Invoke-NpmStep -Label "lint" -NpmArgs @("run", "lint")
 
 Write-Host "==> vendor:supabase + build"

--- a/seo-god.json
+++ b/seo-god.json
@@ -1,0 +1,28 @@
+{
+  "version": 1,
+  "site_url": "https://baklog.app",
+  "openseo": {
+    "url": "http://127.0.0.1:3001",
+    "status": "running"
+  },
+  "gsc": { "connected": false },
+  "phases": {
+    "setup": "done",
+    "audit": "done",
+    "measure": "in_progress",
+    "ai_visibility": "pending",
+    "schedule": "pending"
+  },
+  "schedule": {
+    "mode": "none",
+    "time_local": "05:00",
+    "marker": ".seo-god/last-run.json"
+  },
+  "ai_prompts_locked": [],
+  "power_ups": {
+    "dataforseo": false,
+    "llm_keys": false,
+    "telegram": false
+  },
+  "build_cmd": "node scripts/check-landing-seo.mjs"
+}

--- a/tests/landing-seo.test.js
+++ b/tests/landing-seo.test.js
@@ -1,0 +1,19 @@
+/* @vitest-environment node */
+import { describe, expect, it } from "vitest";
+import { checkLandingSeo, extractFaqFromHtml } from "../scripts/check-landing-seo.mjs";
+import fs from "node:fs";
+import path from "node:path";
+
+describe("landing SEO gate", () => {
+  it("passes checkLandingSeo", () => {
+    expect(checkLandingSeo()).toEqual([]);
+  });
+
+  it("extracts 15 FAQ pairs from index.html", () => {
+    const html = fs.readFileSync(
+      path.join(import.meta.dirname, "../landing/index.html"),
+      "utf8",
+    );
+    expect(extractFaqFromHtml(html)).toHaveLength(15);
+  });
+});

--- a/tests/test_remind_tracker.py
+++ b/tests/test_remind_tracker.py
@@ -1,0 +1,69 @@
+"""Stop-hook reminder must not ping-pong after the first follow-up."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / "scripts" / "hooks" / "remind-tracker.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("remind_tracker", HOOK)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_first_completed_stop_reminds(tmp_path):
+    mod = _load()
+    state = tmp_path / "state.json"
+    assert mod.should_remind(
+        {"status": "completed", "loop_count": 0, "conversation_id": "c1"},
+        now=1_000.0,
+        path=state,
+    )
+
+
+def test_loop_count_blocks_second_followup(tmp_path):
+    mod = _load()
+    state = tmp_path / "state.json"
+    payload = {"status": "completed", "loop_count": 1, "conversation_id": "c1"}
+    assert not mod.should_remind(payload, now=1_000.0, path=state)
+
+
+def test_same_conversation_is_reminded_once(tmp_path):
+    mod = _load()
+    state = tmp_path / "state.json"
+    first = {"status": "completed", "loop_count": 0, "conversation_id": "chat-9"}
+    again = {"status": "completed", "loop_count": 0, "conversation_id": "chat-9"}
+    assert mod.should_remind(first, now=1_000.0, path=state)
+    assert not mod.should_remind(again, now=1_060.0, path=state)
+
+
+def test_aborted_stop_is_silent(tmp_path):
+    mod = _load()
+    state = tmp_path / "state.json"
+    assert not mod.should_remind(
+        {"status": "aborted", "loop_count": 0, "conversation_id": "c1"},
+        now=1_000.0,
+        path=state,
+    )
+
+
+def test_missing_conversation_id_is_still_debounced(tmp_path):
+    mod = _load()
+    state = tmp_path / "state.json"
+    payload = {"status": "completed", "loop_count": 0}
+    assert mod.should_remind(payload, now=1_000.0, path=state)
+    assert not mod.should_remind(payload, now=1_060.0, path=state)
+
+
+def test_ttl_expiry_allows_a_later_reminder(tmp_path):
+    mod = _load()
+    state = tmp_path / "state.json"
+    payload = {"status": "completed", "loop_count": 0, "conversation_id": "c1"}
+    assert mod.should_remind(payload, now=1_000.0, path=state)
+    later = 1_000.0 + mod.TTL_SEC + 1
+    assert mod.should_remind(payload, now=later, path=state)

--- a/tests/test_sync_internal_repo.py
+++ b/tests/test_sync_internal_repo.py
@@ -1,0 +1,163 @@
+"""Public pre-push must never commit baklog-internal into Ogrods/BAKLOG."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SYNC_PS1 = ROOT / "scripts" / "sync-internal-repo.ps1"
+HOOK_PS1 = ROOT / "scripts" / "hooks" / "pre-push-internal.ps1"
+
+
+def test_sync_script_clears_hook_git_env_and_merge_copies():
+    text = SYNC_PS1.read_text(encoding="utf-8")
+    assert "function Clear-InheritedGitEnv" in text
+    assert "GIT_DIR" in text
+    assert "GIT_INDEX_FILE" in text
+    assert "git -C $Path" in text or "git -C $InternalRepo" in text
+    assert "Remove-Item $dest -Recurse" not in text
+    assert "baklog-internal" in text
+    assert "Ogrods/BAKLOG" in text
+    assert "reset" in text and "--hard" in text
+    hook = HOOK_PS1.read_text(encoding="utf-8")
+    assert "BAKLOG_SKIP_INTERNAL_SYNC" in hook
+    assert "GIT_DIR" in hook
+
+
+def _git(cwd: Path, *args: str, extra_env: dict[str, str] | None = None) -> str:
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    env.update(
+        {
+            "GIT_AUTHOR_NAME": "baklog-test",
+            "GIT_AUTHOR_EMAIL": "baklog-test@example.com",
+            "GIT_COMMITTER_NAME": "baklog-test",
+            "GIT_COMMITTER_EMAIL": "baklog-test@example.com",
+        }
+    )
+    if extra_env:
+        env.update(extra_env)
+    proc = subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert proc.returncode == 0, f"git {args} failed: {proc.stdout}\n{proc.stderr}"
+    return (proc.stdout or "").strip()
+
+
+def _init_repo(path: Path, *, origin: str) -> None:
+    path.mkdir(parents=True)
+    subprocess.run(
+        ["git", "init"],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=path,
+        env={k: v for k, v in os.environ.items() if not k.startswith("GIT_")},
+    )
+    _git(path, "config", "user.email", "baklog-test@example.com")
+    _git(path, "config", "user.name", "baklog-test")
+    _git(path, "checkout", "-B", "main")
+    _git(path, "remote", "add", "origin", origin)
+
+
+def _run_sync(
+    *,
+    repo_root: Path,
+    internal: Path,
+    manifest: Path,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [
+            "powershell.exe",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(SYNC_PS1),
+            "-RepoRoot",
+            str(repo_root),
+            "-InternalRepo",
+            str(internal),
+            "-ManifestFile",
+            str(manifest),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="PowerShell sync script")
+def test_sync_with_hook_git_dir_does_not_move_public_head(tmp_path: Path) -> None:
+    public = tmp_path / "public"
+    internal = tmp_path / "internal"
+    _init_repo(public, origin="https://github.com/Ogrods/BAKLOG.git")
+    _init_repo(internal, origin="https://github.com/Ogrods/baklog-internal.git")
+
+    pub_rules = public / ".cursor" / "rules"
+    pub_rules.mkdir(parents=True)
+    (pub_rules / "landing.mdc").write_text("public-landing-rule\n", encoding="utf-8")
+    (public / "keep-public.txt").write_text("public\n", encoding="utf-8")
+    _git(public, "add", "-A")
+    _git(public, "commit", "-m", "public base")
+    public_head = _git(public, "rev-parse", "HEAD")
+
+    int_rules = internal / ".cursor" / "rules"
+    int_rules.mkdir(parents=True)
+    (int_rules / "internal-workflow.mdc").write_text("keep-me\n", encoding="utf-8")
+    (internal / "README.md").write_text("internal\n", encoding="utf-8")
+    _git(internal, "add", "-A")
+    _git(internal, "commit", "-m", "internal base")
+    internal_head = _git(internal, "rev-parse", "HEAD")
+
+    manifest = tmp_path / "manifest.txt"
+    manifest.write_text(".cursor/rules/\n", encoding="utf-8")
+
+    proc = _run_sync(
+        repo_root=public,
+        internal=internal,
+        manifest=manifest,
+        extra_env={"GIT_DIR": str(public / ".git")},
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
+
+    assert _git(public, "rev-parse", "HEAD") == public_head
+    assert _git(internal, "rev-parse", "HEAD") != internal_head
+    assert (internal / ".cursor" / "rules" / "landing.mdc").read_text(
+        encoding="utf-8"
+    ) == "public-landing-rule\n"
+    assert (internal / ".cursor" / "rules" / "internal-workflow.mdc").read_text(
+        encoding="utf-8"
+    ) == "keep-me\n"
+    assert (public / "keep-public.txt").read_text(encoding="utf-8") == "public\n"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="PowerShell sync script")
+def test_sync_refuses_public_baklog_as_destination(tmp_path: Path) -> None:
+    public = tmp_path / "public"
+    _init_repo(public, origin="https://github.com/Ogrods/BAKLOG.git")
+    (public / "README.md").write_text("public\n", encoding="utf-8")
+    _git(public, "add", "-A")
+    _git(public, "commit", "-m", "public base")
+    public_head = _git(public, "rev-parse", "HEAD")
+
+    manifest = tmp_path / "manifest.txt"
+    manifest.write_text("README.md\n", encoding="utf-8")
+
+    proc = _run_sync(repo_root=public, internal=public, manifest=manifest)
+    assert proc.returncode != 0
+    blob = f"{proc.stdout}\n{proc.stderr}"
+    assert "same git work tree" in blob or "not baklog-internal" in blob
+    assert _git(public, "rev-parse", "HEAD") == public_head


### PR DESCRIPTION
## Summary
- Add baklog.app SEO gates (FAQ JSON-LD, llms.txt, robots, heading order) and Google Analytics `G-88L32JZQDH` on the marketing site only, with CSP allowlists and honest privacy copy.
- Stop the Cursor tracker reminder from looping on Docker/WSL completion pings.
- Fix the public pre-push hook so inherited `GIT_DIR` cannot commit `baklog-internal` into `Ogrods/BAKLOG`, and so `.cursor/rules/` merge-copies instead of wiping internal-only files.

## Test plan
- [x] `node scripts/check-landing-seo.mjs`
- [x] `pytest tests/test_sync_internal_repo.py tests/test_remind_tracker.py` (includes hook `GIT_DIR` leak simulation)
- [ ] Confirm Vercel deploy of baklog.app includes gtag + `landing/ga.js`
- [ ] Confirm `.seo-god/` and OAuth secrets are not in this PR

Made with [Cursor](https://cursor.com)