### PR TITLE
Put GA4 gtag inline in the landing head

### DIFF
--- a/.cursor/rules/landing.mdc
+++ b/.cursor/rules/landing.mdc
@@ -14,9 +14,7 @@ alwaysApply: false
 
 ## Key files
 
-- `landing/index.html` — hero, waitlist, `#demo` interactive section, inline JSON-LD `@graph`
-- `landing/llms.txt` — AI-crawler summary (no em dashes)
-- `landing/ga.js` — GA4 config for the marketing site (`G-88L32JZQDH`); CSP allowlist in `landing/vercel.json`
+- `landing/index.html` — hero, waitlist, `#demo` interactive section, inline JSON-LD `@graph`, inline GA4 gtag (`G-88L32JZQDH`; CSP hash in `landing/vercel.json`)
 - `landing/demo.js` — IIFE with dummy data (`STATS`, `SPOTLIGHT_GAMES`); mirrors app UX, no app imports
 - `landing/demo.css` — demo dashboard chrome
 - `landing/main.js` — waitlist POST to `/api/subscribe`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Added
 
-- Landing FAQPage + WebSite JSON-LD (kept in sync with the `#faq` list), homepage apple-touch-icon, `llms.txt`, `robots.txt` `/auth/` disallow, `/auth-reset` `X-Robots-Tag`, homepage meta description under 160 characters, footer headings without a skipped level, Google Analytics on the marketing site (`G-88L32JZQDH`), and `npm run check:landing-seo`.
+- Landing FAQPage + WebSite JSON-LD (kept in sync with the `#faq` list), homepage apple-touch-icon, `llms.txt`, `robots.txt` `/auth/` disallow, `/auth-reset` `X-Robots-Tag`, homepage meta description under 160 characters, footer headings without a skipped level, Google Analytics on the marketing site (`G-88L32JZQDH` inline gtag in `<head>`), and `npm run check:landing-seo`.
 
 ### Fixed
 

--- a/landing/README.md
+++ b/landing/README.md
@@ -4,9 +4,8 @@ Static blue-on-blue landing page with an email waitlist, deployed to Vercel.
 
 ## Files
 
-- `index.html` — page markup, inline base CSS, waitlist form shell. No build step.
+- `index.html` — page markup, inline base CSS, waitlist form shell, inline Google tag (`G-88L32JZQDH`) in `<head>`. No build step.
 - `llms.txt` - plain-text site summary for AI crawlers.
-- `ga.js` - Google Analytics (GA4) config for the marketing site. Desktop app telemetry is unchanged (opt-in only).
 - JSON-LD - inline `@graph` on `index.html` (`SoftwareApplication`, `WebSite`, `FAQPage`). Keep FAQPage in sync with the `#faq` details list via `npm run check:landing-seo`.
 - `main.js` — footer year, non-blocking font load, waitlist submit handler.
 - `demo.css` — mega hero dashboard styles (spotlight, marquee, ribbon charts, funnel sections).

--- a/landing/ga.js
+++ b/landing/ga.js
@@ -1,6 +1,0 @@
-window.dataLayer = window.dataLayer || [];
-function gtag() {
-  dataLayer.push(arguments);
-}
-gtag("js", new Date());
-gtag("config", "G-88L32JZQDH");

--- a/landing/index.html
+++ b/landing/index.html
@@ -3,9 +3,14 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <!-- Google Analytics (marketing site only). Desktop app stays no telemetry by default. -->
+  <!-- Google tag (gtag.js) - marketing site only. Desktop app stays no telemetry by default. -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-88L32JZQDH"></script>
-  <script src="ga.js"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-88L32JZQDH');
+  </script>
   <title>BAKLOG: One honest backlog across every store</title>
   <meta name="description" content="One honest backlog across every store. Free forever to import. 12 libraries and 8 wishlists on your machine, no telemetry by default. Invite-only." />
   <meta name="theme-color" content="#0f172a" />

--- a/landing/vercel.json
+++ b/landing/vercel.json
@@ -25,7 +25,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https://www.googletagmanager.com https://*.google-analytics.com; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; form-action 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none'"
+          "value": "default-src 'self'; script-src 'self' 'sha256-MUTZmPoMWlbCHgWnl6ZOqieYIw16NdlicHoRzqNWRKY=' https://www.googletagmanager.com https://*.googletagmanager.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https://www.googletagmanager.com https://*.google-analytics.com; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; form-action 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none'"
         }
       ]
     },
@@ -60,7 +60,7 @@
       "headers": [{ "key": "Cache-Control", "value": "public, max-age=86400" }]
     },
     {
-      "source": "/(main|demo|pro-checkout-gate|ga)\\.js|demo\\.css",
+      "source": "/(main|demo|pro-checkout-gate)\\.js|demo\\.css",
       "headers": [{ "key": "Cache-Control", "value": "public, max-age=86400" }]
     },
     {

--- a/scripts/check-landing-seo.mjs
+++ b/scripts/check-landing-seo.mjs
@@ -2,6 +2,7 @@
  * Landing SEO gate: JSON-LD parse + FAQ sync, required meta, no em dashes.
  * Used as seo-god.json build_cmd. Does not start a server.
  */
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -55,6 +56,21 @@ function scanEmDash(filePath, errors) {
   }
 }
 
+function extractHeadGtagConfig(html) {
+  const headEnd = html.toLowerCase().indexOf("</head>");
+  if (headEnd < 0) return null;
+  const head = html.slice(0, headEnd);
+  const loader = 'src="https://www.googletagmanager.com/gtag/js?id=G-88L32JZQDH"';
+  if (!head.includes(loader)) return null;
+  const after = head.slice(head.indexOf(loader));
+  const start = after.indexOf("<script>");
+  const end = after.indexOf("</script>", start);
+  if (start < 0 || end < 0) return null;
+  const body = after.slice(start + "<script>".length, end);
+  if (!body.includes("G-88L32JZQDH") || !body.includes("gtag(")) return null;
+  return body;
+}
+
 export function checkLandingSeo() {
   const errors = [];
   const indexPath = path.join(landing, "index.html");
@@ -106,13 +122,19 @@ export function checkLandingSeo() {
     });
   }
 
-  if (!html.includes("G-88L32JZQDH") || !fs.existsSync(path.join(landing, "ga.js"))) {
-    errors.push("index.html / ga.js missing Google Analytics measurement id");
-  }
-
-  const vercel = fs.readFileSync(path.join(landing, "vercel.json"), "utf8");
-  if (!vercel.includes("https://www.googletagmanager.com")) {
-    errors.push("vercel.json CSP missing googletagmanager.com for GA");
+  const gtagBody = extractHeadGtagConfig(html);
+  if (!gtagBody) {
+    errors.push("index.html <head> missing inline gtag config for G-88L32JZQDH");
+  } else {
+    const sha = crypto.createHash("sha256").update(gtagBody, "utf8").digest("base64");
+    const token = `'sha256-${sha}'`;
+    const vercel = fs.readFileSync(path.join(landing, "vercel.json"), "utf8");
+    if (!vercel.includes(token)) {
+      errors.push(`vercel.json CSP missing ${token} for the inline gtag snippet`);
+    }
+    if (!vercel.includes("https://www.googletagmanager.com")) {
+      errors.push("vercel.json CSP missing googletagmanager.com for GA");
+    }
   }
 
   const sitemap = fs.readFileSync(path.join(landing, "sitemap.xml"), "utf8");

--- a/scripts/sync-internal-repo.ps1
+++ b/scripts/sync-internal-repo.ps1
@@ -52,9 +52,13 @@ function Invoke-GitAt {
         [Parameter(Mandatory = $true)][string[]]$GitArgs
     )
     Clear-InheritedGitEnv
+    $prevEap = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
     $output = & git -C $Path @GitArgs 2>&1
+    $code = $LASTEXITCODE
+    $ErrorActionPreference = $prevEap
     return [pscustomobject]@{
-        Code   = $LASTEXITCODE
+        Code   = $code
         Output = $output
         Text   = (($output | ForEach-Object { "$_" }) -join "`n").Trim()
     }


### PR DESCRIPTION
## Summary
- Google's installer looks for the unmodified `gtag('config', 'G-88L32JZQDH')` snippet in page HTML. The live site had the loader in `<head>` but config in `ga.js`, so verification never passed.
- Inline the official snippet in `landing/index.html` `<head>` and allow it with a CSP sha256 (no `unsafe-inline`).
- Stop PowerShell `Stop` mode from aborting public push when git writes warnings to stderr.

## Test plan
- [x] `npm run check:landing-seo`
- [x] vitest landing-seo + marketing-claims
- [ ] After Vercel: view-source on https://baklog.app/ shows `gtag('config', 'G-88L32JZQDH')` in `<head>`
- [ ] Retry GA/GSC verify (not the iframe preview - the site sends `X-Frame-Options: DENY`)

Made with [Cursor](https://cursor.com)