### PR TITLE
Document attended OpenSEO / GSC / GA playbook

### DIFF
--- a/.cursor/rules/landing.mdc
+++ b/.cursor/rules/landing.mdc
@@ -22,6 +22,8 @@ alwaysApply: false
 
 FAQ JSON-LD must match the `#faq` details list: `npm run check:landing-seo`.
 
+Attended OpenSEO / GSC / GA playbook: `.cursor/rules/seo-operator.mdc`.
+
 ## Serverless
 
 - `landing/api/subscribe.js` — waitlist (Resend + optional Supabase)

--- a/.cursor/rules/seo-operator.mdc
+++ b/.cursor/rules/seo-operator.mdc
@@ -1,0 +1,54 @@
+---
+description: OpenSEO, Search Console, GA4, and baklog.app landing SEO operator playbook. Use when adding sites, GSC, gtag, crawls, DataForSEO, or the site-audit warning.
+alwaysApply: false
+---
+
+# Landing SEO operator (attended)
+
+Local OpenSEO + GSC + marketing GA. Not a product feature. Do not vendor [AKCodez/seo-god](https://github.com/AKCodez/seo-god). Do not add a nightly `claude -p` job. `schedule.mode` in `seo-god.json` stays `none`.
+
+## What is already done (baklog.app, 2026-08-18)
+
+- Landing SEO gates: FAQ JSON-LD, `llms.txt`, robots `/auth/`, meta <=160, heading order. Gate: `npm run check:landing-seo`.
+- GA4 `G-88L32JZQDH` **inline** in `landing/index.html` `<head>` (not `ga.js`). CSP sha256 in `landing/vercel.json`. Auth pages have no gtag.
+- OpenSEO Docker gitignored at `.seo-god/`, loopback only (`127.0.0.1:3001`), `AUTH_MODE=local_noauth`.
+- GSC OAuth is in gitignored `.seo-god/secrets.env`. Property baklog.app is bound.
+- Desktop app still has no telemetry.
+
+## Start / URLs
+
+```powershell
+docker compose -p seo-god -f .seo-god/docker-compose.yml up -d
+```
+
+- Dashboard: `http://localhost:3001` (OAuth cookies). `127.0.0.1:3001` is the same bind; use **localhost** for Connect with Google.
+- Never publish port 3001 off loopback.
+- Recreate after secret edits: `docker compose -p seo-god -f .seo-god/docker-compose.yml up -d --force-recreate`
+
+## Google Analytics
+
+Google's installer looks at **page HTML**. Keep `gtag('config', 'G-88L32JZQDH')` inline in `<head>`. After editing the snippet, recompute the CSP hash (`npm run check:landing-seo` fails if `vercel.json` drifts). Verify in GA4 **Realtime** after loading baklog.app. Ignore iframe checkers (`X-Frame-Options: DENY`).
+
+## Search Console
+
+Same Google account can bind every property it owns. Connect on `http://localhost:3001`. Redirects already include localhost and 127.0.0.1 `/api/gsc/oauth/callback`. If the OAuth client lived in chat, rotate the client secret in GCP and `secrets.env`.
+
+GSC queries can stay empty 24-48h after bind. That is not a failed setup.
+
+## Site audit "couldn't fully crawl"
+
+OpenSEO **Site audit** calls DataForSEO. Without `DATAFORSEO_API_KEY`, logs show `Missing required environment variable: DATAFORSEO_API_KEY` and the UI shows a generic anti-bot warning. baklog.app is not blocking us: sitemap is only `https://baklog.app/`, homepage 200, host Lighthouse SEO 100. Ignore that audit, or use Search Performance (GSC, free). Do not add DataForSEO for this one-page invite site.
+
+## Adding another site
+
+OpenSEO is multi-project. Create a project with the **public https URL**, never `http://localhost:...` (the crawler runs inside Docker, so localhost is the container).
+
+If **New project** fails from localhost, it is usually the same DataForSEO gate, not a bind issue. You can still use GSC on an existing project. Do not reuse this GA id on other sites. Do not reuse the wedding-project OAuth client; the baklog GCP OAuth client is fine if that Gmail owns the other GSC properties.
+
+## Secrets (never commit)
+
+`.seo-god/`, `seo/`, `lighthouse/` are gitignored. `seo-god.json` has no secrets (`gsc.connected` is a flag only).
+
+## Internal sync
+
+Public pre-push may sync to `baklog-internal`. `scripts/sync-internal-repo.ps1` must clear inherited `GIT_DIR` and merge-copy `.cursor/rules/` (never wipe `internal-*.mdc`). Skip with `BAKLOG_SKIP_INTERNAL_SYNC=1`. Edit tracker in `..\baklog-internal\tracker.html` and `git push` there; do not use public sync to publish tracker edits.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 | **Auth** | `auth/` | AES-GCM secrets + OS keyring; CDP browser sign-in (`cdp_browser.py`, `runner.py`) |
 | **Fetchers** | `fetch_*.py`, `fetchers/manifest.json` | Whitelisted subprocess scripts → profile-scoped `games_*.json` |
 | **Frontend** | `index.html`, `js/app.js` | Vanilla ESM modules; optional esbuild `dist/` build |
-| **Landing** | `landing/` | Static marketing site + Vercel serverless (`api/subscribe.js`, `api/report.js`) |
+| **Landing** | `landing/` | Static marketing site + Vercel serverless (`api/subscribe.js`, `api/report.js`). Attended SEO playbook: `.cursor/rules/seo-operator.mdc` |
 | **Profiles** | `profiles/<id>/` | Per-profile catalogs, `data/personal.json`, `cache/auth/` |
 
 Deep reference (maintainer clone only): `docs/ARCHITECTURE.md` in the private `baklog-internal` repo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Added
 
-- Landing FAQPage + WebSite JSON-LD (kept in sync with the `#faq` list), homepage apple-touch-icon, `llms.txt`, `robots.txt` `/auth/` disallow, `/auth-reset` `X-Robots-Tag`, homepage meta description under 160 characters, footer headings without a skipped level, Google Analytics on the marketing site (`G-88L32JZQDH` inline gtag in `<head>`), and `npm run check:landing-seo`.
+- Landing FAQPage + WebSite JSON-LD (kept in sync with the `#faq` list), homepage apple-touch-icon, `llms.txt`, `robots.txt` `/auth/` disallow, `/auth-reset` `X-Robots-Tag`, homepage meta description under 160 characters, footer headings without a skipped level, Google Analytics on the marketing site (`G-88L32JZQDH` inline gtag in `<head>`), `npm run check:landing-seo`, and the attended OpenSEO/GSC playbook in `.cursor/rules/seo-operator.mdc`.
 
 ### Fixed
 

--- a/landing/README.md
+++ b/landing/README.md
@@ -6,7 +6,7 @@ Static blue-on-blue landing page with an email waitlist, deployed to Vercel.
 
 - `index.html` — page markup, inline base CSS, waitlist form shell, inline Google tag (`G-88L32JZQDH`) in `<head>`. No build step.
 - `llms.txt` - plain-text site summary for AI crawlers.
-- JSON-LD - inline `@graph` on `index.html` (`SoftwareApplication`, `WebSite`, `FAQPage`). Keep FAQPage in sync with the `#faq` details list via `npm run check:landing-seo`.
+FAQ JSON-LD must match the `#faq` details list via `npm run check:landing-seo`. Attended OpenSEO / GSC / GA: `.cursor/rules/seo-operator.mdc`.
 - `main.js` — footer year, non-blocking font load, waitlist submit handler.
 - `demo.css` — mega hero dashboard styles (spotlight, marquee, ribbon charts, funnel sections).
 - `demo.js` — interactive demo (dummy data, count-up, spotlight rotation, Chart.js donuts).

--- a/seo-god.json
+++ b/seo-god.json
@@ -2,10 +2,10 @@
   "version": 1,
   "site_url": "https://baklog.app",
   "openseo": {
-    "url": "http://127.0.0.1:3001",
+    "url": "http://localhost:3001",
     "status": "running"
   },
-  "gsc": { "connected": false },
+  "gsc": { "connected": true },
   "phases": {
     "setup": "done",
     "audit": "done",


### PR DESCRIPTION
## Summary
- Add `.cursor/rules/seo-operator.mdc` so future agents follow the same attended OpenSEO + GSC + inline GA path (no vendored seo-god, no nightly Claude, no DataForSEO for baklog.app).
- Note that OpenSEO Site audit / New project errors are a missing `DATAFORSEO_API_KEY` gate, not baklog.app blocking crawls.

## Test plan
- [x] Playbook has no secrets
- [ ] Agents loading the rule can start compose, use localhost:3001, and ignore the site-audit anti-bot warning

Made with [Cursor](https://cursor.com)