### PR TITLE
Refresh SEO playbook with GSC/GA4 property map

### DIFF
--- a/.cursor/rules/seo-operator.mdc
+++ b/.cursor/rules/seo-operator.mdc
@@ -7,13 +7,27 @@ alwaysApply: false
 
 Local OpenSEO + GSC + marketing GA. Not a product feature. Do not vendor [AKCodez/seo-god](https://github.com/AKCodez/seo-god). Do not add a nightly `claude -p` job. `schedule.mode` in `seo-god.json` stays `none`.
 
-## What is already done (baklog.app, 2026-08-18)
+## What is already done (2026-08-18)
 
 - Landing SEO gates: FAQ JSON-LD, `llms.txt`, robots `/auth/`, meta <=160, heading order. Gate: `npm run check:landing-seo`.
 - GA4 `G-88L32JZQDH` **inline** in `landing/index.html` `<head>` (not `ga.js`). CSP sha256 in `landing/vercel.json`. Auth pages have no gtag.
 - OpenSEO Docker gitignored at `.seo-god/`, loopback only (`127.0.0.1:3001`), `AUTH_MODE=local_noauth`.
-- GSC OAuth is in gitignored `.seo-god/secrets.env`. Property baklog.app is bound.
+- GSC OAuth in gitignored `.seo-god/secrets.env`. Sitemaps submitted in GSC.
+- GA4 Admin → **Product links** → **Search Console links** (only that row) linked to `https://baklog.app/`.
 - Desktop app still has no telemetry.
+
+## Property map (keep 1:1)
+
+Each OpenSEO project binds to the matching GSC **URL-prefix**. Same Google account is enough. audio ≠ www.
+
+| OpenSEO project | GSC URL-prefix |
+| --- | --- |
+| baklog.app | `https://baklog.app/` |
+| www.danogrodnik.com | `https://www.danogrodnik.com/` |
+| audio.danogrodnik.com | `https://audio.danogrodnik.com/` |
+| Madishroom | `https://madishroom.com/` |
+
+`www.madishroom.com` redirects to the apex; GSC may still list the www prefix. Do not add a second OpenSEO project for it. `www.baklog.app` 308s away; do not add it.
 
 ## Start / URLs
 
@@ -21,29 +35,33 @@ Local OpenSEO + GSC + marketing GA. Not a product feature. Do not vendor [AKCode
 docker compose -p seo-god -f .seo-god/docker-compose.yml up -d
 ```
 
-- Dashboard: `http://localhost:3001` (OAuth cookies). `127.0.0.1:3001` is the same bind; use **localhost** for Connect with Google.
+- Dashboard: `http://localhost:3001` (OAuth cookies). Use **localhost** for Connect with Google.
 - Never publish port 3001 off loopback.
 - Recreate after secret edits: `docker compose -p seo-god -f .seo-god/docker-compose.yml up -d --force-recreate`
 
 ## Google Analytics
 
-Google's installer looks at **page HTML**. Keep `gtag('config', 'G-88L32JZQDH')` inline in `<head>`. After editing the snippet, recompute the CSP hash (`npm run check:landing-seo` fails if `vercel.json` drifts). Verify in GA4 **Realtime** after loading baklog.app. Ignore iframe checkers (`X-Frame-Options: DENY`).
+Keep `gtag('config', 'G-88L32JZQDH')` inline in `<head>`. After editing the snippet, `npm run check:landing-seo` must still pass (CSP hash). Verify in GA4 **Realtime**. Ignore iframe checkers (`X-Frame-Options: DENY`).
+
+Do not reuse this measurement id on other sites. Other GA4 properties use their own **Search Console links** row if you want query data there.
 
 ## Search Console
 
-Same Google account can bind every property it owns. Connect on `http://localhost:3001`. Redirects already include localhost and 127.0.0.1 `/api/gsc/oauth/callback`. If the OAuth client lived in chat, rotate the client secret in GCP and `secrets.env`.
+Connect on `http://localhost:3001`. Redirects: localhost and 127.0.0.1 `/api/gsc/oauth/callback`. If the OAuth client lived in chat, rotate the client secret in GCP and `secrets.env`.
 
-GSC queries can stay empty 24-48h after bind. That is not a failed setup.
+Query data arrives **automatically** after bind (often empty 2-3 days). No Site audit click. No DataForSEO.
 
 ## Site audit "couldn't fully crawl"
 
-OpenSEO **Site audit** calls DataForSEO. Without `DATAFORSEO_API_KEY`, logs show `Missing required environment variable: DATAFORSEO_API_KEY` and the UI shows a generic anti-bot warning. baklog.app is not blocking us: sitemap is only `https://baklog.app/`, homepage 200, host Lighthouse SEO 100. Ignore that audit, or use Search Performance (GSC, free). Do not add DataForSEO for this one-page invite site.
+OpenSEO **Site audit** needs `DATAFORSEO_API_KEY`. Without it, logs show the missing env var and the UI shows a generic anti-bot warning. Ignore Site audit. Use Search performance (GSC, free). Do not add DataForSEO for these sites.
 
 ## Adding another site
 
-OpenSEO is multi-project. Create a project with the **public https URL**, never `http://localhost:...` (the crawler runs inside Docker, so localhost is the container).
+Public `https://` URL only, never `http://localhost:...` (crawler is inside Docker). New project in the UI may fail without DataForSEO; GSC on an existing project still works. Do not reuse the wedding-project OAuth client.
 
-If **New project** fails from localhost, it is usually the same DataForSEO gate, not a bind issue. You can still use GSC on an existing project. Do not reuse this GA id on other sites. Do not reuse the wedding-project OAuth client; the baklog GCP OAuth client is fine if that Gmail owns the other GSC properties.
+## Do not connect
+
+DataForSEO, OpenRouter/SAM, Telegram, nightly schedule, GA4 Ads/BigQuery/Merchant/social product links.
 
 ## Secrets (never commit)
 
@@ -51,4 +69,4 @@ If **New project** fails from localhost, it is usually the same DataForSEO gate,
 
 ## Internal sync
 
-Public pre-push may sync to `baklog-internal`. `scripts/sync-internal-repo.ps1` must clear inherited `GIT_DIR` and merge-copy `.cursor/rules/` (never wipe `internal-*.mdc`). Skip with `BAKLOG_SKIP_INTERNAL_SYNC=1`. Edit tracker in `..\baklog-internal\tracker.html` and `git push` there; do not use public sync to publish tracker edits.
+Public pre-push may sync to `baklog-internal`. `scripts/sync-internal-repo.ps1` must clear inherited `GIT_DIR` and merge-copy `.cursor/rules/` (never wipe `internal-*.mdc`). Skip with `BAKLOG_SKIP_INTERNAL_SYNC=1`. Edit tracker in `..\baklog-internal\tracker.html` and `git push` there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Added
 
-- Landing FAQPage + WebSite JSON-LD (kept in sync with the `#faq` list), homepage apple-touch-icon, `llms.txt`, `robots.txt` `/auth/` disallow, `/auth-reset` `X-Robots-Tag`, homepage meta description under 160 characters, footer headings without a skipped level, Google Analytics on the marketing site (`G-88L32JZQDH` inline gtag in `<head>`), `npm run check:landing-seo`, and the attended OpenSEO/GSC playbook in `.cursor/rules/seo-operator.mdc`.
+- Landing FAQPage + WebSite JSON-LD (kept in sync with the `#faq` list), homepage apple-touch-icon, `llms.txt`, `robots.txt` `/auth/` disallow, `/auth-reset` `X-Robots-Tag`, homepage meta description under 160 characters, footer headings without a skipped level, Google Analytics on the marketing site (`G-88L32JZQDH` inline gtag in `<head>`), `npm run check:landing-seo`, and the attended OpenSEO/GSC playbook in `.cursor/rules/seo-operator.mdc` (GA4 Search Console product link + per-project URL-prefix map).
 
 ### Fixed
 


### PR DESCRIPTION
## Summary
- Document the live property map (baklog, www/audio danogrodnik, madishroom apex).
- GA4 Admin uses **Search Console links** only; sitemaps stay in GSC; queries arrive without a Site audit.

## Test plan
- [ ] Open `.cursor/rules/seo-operator.mdc` and confirm it matches the GSC + OpenSEO dropdowns

Made with [Cursor](https://cursor.com)