### PR TITLE
Rank OpenSEO Browse tabs in the SEO playbook

### DIFF
--- a/.cursor/rules/seo-operator.mdc
+++ b/.cursor/rules/seo-operator.mdc
@@ -51,9 +51,23 @@ Connect on `http://localhost:3001`. Redirects: localhost and 127.0.0.1 `/api/gsc
 
 Query data arrives **automatically** after bind (often empty 2-3 days). No Site audit click. No DataForSEO.
 
+## OpenSEO Browse tabs
+
+Stay on **Browse**, not **Chat**. Switch project first (audio ≠ www).
+
+**Use**
+- **GSC Insights** (My site) - the one that matters. Clicks, impressions, queries, pages from Search Console. Free. Check this after 2-3 days.
+- **Dashboard** (Overview) - optional glance. Ignore empty research widgets.
+
+**Skip (need DataForSEO or OpenRouter; not worth it for these sites)**
+- Keyword Research, Domain Overview, Backlinks, Brand Lookup (Research)
+- Rank Tracking, Saved Keywords (My site)
+- Site Audit (My site) - generic anti-bot warning without a DataForSEO key
+- Prompt Explorer (Research), **AI & MCP** (Connect), **Chat** tab
+
 ## Site audit "couldn't fully crawl"
 
-OpenSEO **Site audit** needs `DATAFORSEO_API_KEY`. Without it, logs show the missing env var and the UI shows a generic anti-bot warning. Ignore Site audit. Use Search performance (GSC, free). Do not add DataForSEO for these sites.
+OpenSEO **Site audit** needs `DATAFORSEO_API_KEY`. Without it, logs show the missing env var and the UI shows a generic anti-bot warning. Ignore Site audit. Use **GSC Insights**. Do not add DataForSEO for these sites.
 
 ## Adding another site
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Added
 
-- Landing FAQPage + WebSite JSON-LD (kept in sync with the `#faq` list), homepage apple-touch-icon, `llms.txt`, `robots.txt` `/auth/` disallow, `/auth-reset` `X-Robots-Tag`, homepage meta description under 160 characters, footer headings without a skipped level, Google Analytics on the marketing site (`G-88L32JZQDH` inline gtag in `<head>`), `npm run check:landing-seo`, and the attended OpenSEO/GSC playbook in `.cursor/rules/seo-operator.mdc` (GA4 Search Console product link + per-project URL-prefix map).
+- Landing FAQPage + WebSite JSON-LD (kept in sync with the `#faq` list), homepage apple-touch-icon, `llms.txt`, `robots.txt` `/auth/` disallow, `/auth-reset` `X-Robots-Tag`, homepage meta description under 160 characters, footer headings without a skipped level, Google Analytics on the marketing site (`G-88L32JZQDH` inline gtag in `<head>`), `npm run check:landing-seo`, and the attended OpenSEO/GSC playbook in `.cursor/rules/seo-operator.mdc` (GA4 Search Console product link, per-project URL-prefix map, Browse-tab ranking).
 
 ### Fixed
 


### PR DESCRIPTION
## Summary
- Playbook now ranks OpenSEO sidebar tabs: **GSC Insights** is the one to use; Research / Rank Tracking / Site Audit / AI are skip without DataForSEO or OpenRouter.

## Test plan
- [ ] Sidebar labels still match OpenSEO Browse (GSC Insights, not an old Search performance name)

Made with [Cursor](https://cursor.com)