### PR TITLE
0.9.01: isolation hardening + drill geometry audit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,22 +5,26 @@
 # on Windows. Override the writable root for all profiles:
 # BAKLOG_DATA_DIR=D:\BAKLOG-data
 #
-# Dev split (optional): keep frozen data separate while developing against the
-# same machine. Point dev at a second folder so python server.py never writes
-# into BAKLOG-Data:
-# BAKLOG_DATA_DIR=%LOCALAPPDATA%\BAKLOG-Dev
-#
-# Use a different port so browser localStorage is not shared with BAKLOG.exe
-# (both default to http://127.0.0.1:8765 otherwise):
-# PORT=8766
+# Recommended maintainer trio (dev + admin on one PC without touching the
+# installed library):
+#   PORT=8766
+#   BAKLOG_DATA_DIR=%LOCALAPPDATA%\BAKLOG-Dev
+#   BAKLOG_ADMIN=1
+# PORT=8766 keeps browser localStorage off the installed app's 8765 origin.
+# BAKLOG-Dev keeps python server.py from writing into BAKLOG-Data.
 #
 # Portable zip / thumb drive: add portable.txt beside BAKLOG.exe, or set:
 # BAKLOG_PORTABLE=1
 
 # Optional: enable the local maintainer admin dashboard at
-# http://127.0.0.1:8765/admin/ (free-claims editor + job runner). Local-only,
+# http://127.0.0.1:<PORT>/admin/ (free-claims editor + job runner). Local-only,
 # never shipped to end users. Comment out / set to 0 to disable, then restart.
 # BAKLOG_ADMIN=1
+#
+# Admin refuses the default installed data folder (%LOCALAPPDATA%\BAKLOG-Data).
+# Use BAKLOG_DATA_DIR=...\BAKLOG-Dev (or the repo root) instead. Escape hatch
+# only when you intentionally need admin against the installed library:
+# BAKLOG_ADMIN_ALLOW_INSTALLED=1
 
 # Optional: Supabase invite-only login (BAKLOG_SUPABASE_* in .env.example)
 # Required for beta builds: frozen bundle writes these into release/BAKLOG/.env

--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ review-report.json
 .audit/
 scripts/_diag_personal.py
 scripts/perf-last-run.json
+scripts/drill-geometry-last-run.json
 scripts/responsive-overflow-last-run.json
 
 # Local SEO operator (OpenSEO compose, secrets, crawl snapshots). Commit seo-god.json only.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -108,7 +108,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for running locally.
 | `server.py` size | Improving | Run/RunManager moved to `shared/run_manager.py`; CI line budget ratcheted |
 | `connections.js` size | Improving | Rail/status in `js/connections-rail.js`; session flows remain in barrel |
 | `fetcher-health.js` | Done | Barrel + `js/fetcher/` split (#91) |
-| Dev vs frozen localStorage | Mitigated | Use `PORT=8766` + separate `BAKLOG_DATA_DIR` for dev (see `.env.example`) |
+| Dev vs frozen localStorage | Mitigated | Prefer `PORT=8766` + `BAKLOG_DATA_DIR` for dev; error log is partitioned per runtime (`baklog-error-log:dev` / `:installed`); admin refuses default installed data root unless `BAKLOG_ADMIN_ALLOW_INSTALLED=1` |
 | macOS frozen zip | Deferred | Notify-only until `BAKLOG-macos.zip` ships; checklist in `packaging/build_macos.sh` |
 | Windows ARP version drift | Visible | Diagnostics + update install footnote when Setup + zip apply diverge |
 | Code signing | Out of scope | Unsigned beta builds (Windows Inno + portable zip) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [Unreleased]
 
+### Fixed
+
+- Dashboard and picks jumps to a library row re-check the target after scroll so the wrong game is not left under the sticky header on phone and mid-width layouts.
+- Dev and installed runs no longer share one browser error history when both use the same localhost origin; each runtime keeps its own log.
+
+### Changed
+
+- Maintainer admin console will not attach to the default installed library folder unless you explicitly allow it. Prefer a separate data folder for admin work.
+
 ## [0.9.00] - 2026-08-18
 
 ### Added

--- a/guide/troubleshooting.md
+++ b/guide/troubleshooting.md
@@ -139,9 +139,9 @@ If you still have `BAKLOG-Data`, reinstall BAKLOG and launch normally - first bo
 
 ## Dev server vs frozen exe (same browser origin)
 
-**Symptom:** The frozen beta shows the wrong library, old errors in bug reports, or UI prefs that match your git checkout - but `BAKLOG.exe` is supposed to use `%LOCALAPPDATA%\BAKLOG-Data`.
+**Symptom:** The frozen beta shows the wrong library, old errors in bug reports, or UI prefs that match your git checkout - but `BAKLOG.exe` is supposed to use `%LOCALAPPDATA%\BAKLOG-Data`. A **Mixed sessions** chip means an older shared error log still has entries from both runtimes.
 
-**Cause:** Dev (`python server.py`) and frozen (`BAKLOG.exe`) both serve on `http://127.0.0.1:8765`. The browser treats them as one site, so **localStorage is shared** (status chips, filters, `baklog-error-log`, Supabase session keys). Server library files are **not** shared - they come from the active data directory.
+**Cause:** Dev (`python server.py`) and frozen (`BAKLOG.exe`) both serve on `http://127.0.0.1:8765`. The browser treats them as one site, so **UI prefs and auth tokens in localStorage are shared**. Server library files are **not** shared - they come from the active data directory. From 0.9.01 onward, the error history is stored per runtime (`baklog-error-log:dev` vs `:installed`) so bug bundles no longer mix the two. Older builds used a single `baklog-error-log` key.
 
 **How to tell which server is running:** Open `http://127.0.0.1:8765/api/diagnostics` (or use **Report a bug**). Check `frozen` and `data_dir_path`:
 
@@ -152,7 +152,11 @@ If you still have `BAKLOG-Data`, reinstall BAKLOG and launch normally - first bo
 
 **Fix (library):** With BAKLOG closed, copy `profiles/` from your dev checkout into `%LOCALAPPDATA%\BAKLOG-Data`, or connect stores and refresh in the frozen app. Missing store files return an empty catalog (HTTP 200, zero games) - not your dev repo.
 
-**Split dev from frozen (recommended on one PC):** Set `BAKLOG_DATA_DIR=%LOCALAPPDATA%\BAKLOG-Dev` in `.env` before running `python server.py`. Dev library files stay in `BAKLOG-Dev`; the installed app keeps using `BAKLOG-Data`. The header shows a **Dev server** chip when `python server.py` is active.
+**Split dev from frozen (recommended on one PC):** Set `BAKLOG_DATA_DIR=%LOCALAPPDATA%\BAKLOG-Dev` and `PORT=8766` in `.env` before running `python server.py`. Dev library files stay in `BAKLOG-Dev`; the installed app keeps using `BAKLOG-Data` on port 8765. The header shows a **Dev server** chip when `python server.py` is active.
+
+**Admin console vs installed library:** `BAKLOG_ADMIN=1` will not attach to the default installed data folder (`BAKLOG-Data`). Run admin against the repo (or `BAKLOG-Dev`). Only set `BAKLOG_ADMIN_ALLOW_INSTALLED=1` if you intentionally need admin on the installed library.
+
+**Full clean of the installed library (maintainer / clean SoT):** Quit the tray, `BAKLOG.exe`, and any `server.py` on port 8765. Delete the entire `%LOCALAPPDATA%\BAKLOG-Data` folder. In Edge or Chrome, clear site data for `127.0.0.1` (and `:8766` if you used it). Launch the installed app once, create a new profile, and reconnect only the stores you want as the real library. Keep testing data under `BAKLOG-Dev` or the git checkout - do not copy testing dumps back into `BAKLOG-Data` unless intentional.
 
 **Keyring caveat:** Connections encryption uses one OS keyring entry (`steam-backlog`) per Windows user. A full uninstall wipe removes it for both dev and frozen - you will need to sign in to stores again everywhere on that account.
 

--- a/js/app.js
+++ b/js/app.js
@@ -104,9 +104,24 @@ import {
   suppressChartStaggerForBoot,
   resizeRibbonCharts,
 } from "./dashboard-charts.js";
-import { prewarmTableQueryForView, tableFingerprint } from "./table-ui.js";
+import { prewarmTableQueryForView, tableFingerprint, installDrillGeomApi } from "./table-ui.js";
+import {
+  dashDrillStore,
+  dashDrillStatus,
+  dashDrillStoreStatus,
+  dashDrillGenre,
+  dashDrillHltbBucket,
+  dashDrillMinRating,
+  dashDrillCoop,
+  dashDrillItchGenre,
+} from "./dashboard-drilldown.js";
+import { drillWishlistDealFilter } from "./deals.js";
 import { applyColumnVisibility } from "./table-columns.js";
 import { isItadDealsAvailable, syncItadDealSurfaces } from "./itad-deal-gate.js";
+import {
+  getAuthStatusSnapshot,
+  setAuthStatusSnapshot,
+} from "./connections-status.js";
 import { initBugReportDialog } from "./bug-report.js";
 import { refreshAdsForPlanChange } from "./sponsored-deals.js";
 import {
@@ -215,6 +230,28 @@ async function bootstrap() {
   syncViewTabAria(state.activeView);
   savePrefs();
   bindEvents();
+  installDrillGeomApi();
+  if (typeof window !== "undefined" && window.__baklogDrillGeom) {
+    Object.assign(window.__baklogDrillGeom, {
+      dashDrillStore,
+      dashDrillStatus,
+      dashDrillStoreStatus,
+      dashDrillGenre,
+      dashDrillHltbBucket,
+      dashDrillMinRating,
+      dashDrillCoop,
+      dashDrillItchGenre,
+      drillWishlistDealFilter,
+      /** Perf/geometry audits only: pretend ITAD is connected so deal drills run. */
+      stubItadConnected() {
+        const snap = getAuthStatusSnapshot().filter((p) => p.key !== "itad");
+        snap.push({ key: "itad", status: "connected" });
+        setAuthStatusSnapshot(snap);
+        syncItadDealSurfaces({ rerender: true });
+        return import("./library-load.js").then((m) => m.loadItadPrices());
+      },
+    });
+  }
   document.addEventListener("baklog:auth-status", () => {
     syncItadDealSurfaces();
   });
@@ -316,8 +353,8 @@ async function bootstrap() {
       const cfgRes = await fetch("/api/config");
       if (cfgRes.ok) {
         const cfg = await cfgRes.json();
-        if (typeof cfg.frozen === "boolean")
-          noteServerRuntime({ frozen: cfg.frozen });
+        if (typeof cfg.frozen === "boolean" || cfg.runtime_label)
+          noteServerRuntime({ frozen: cfg.frozen, runtime_label: cfg.runtime_label });
         syncRuntimeModeBanner(cfg);
         if (cfg.frozen === true) {
           const bootCheck = state.prefs?.checkUpdatesOnBoot !== false;

--- a/js/bind-events.js
+++ b/js/bind-events.js
@@ -43,6 +43,8 @@ import {
   filteredGames,
   sortedGames,
   cancelPendingScrollTarget,
+  setPendingScrollTarget,
+  scheduleScrollAfterChromeSettled,
   clearRowAdAnchor,
   initTablePhoneLayout,
   initTableDensity,
@@ -208,10 +210,14 @@ export function bindEvents() {
     }
     if (action === "deal-on-sale") {
       drillWishlistDealFilter({ onSaleOnly: true });
+      setPendingScrollTarget({ kind: "toolbar", smooth: false });
+      scheduleScrollAfterChromeSettled();
       return;
     }
     if (action === "deal-steals") {
       drillWishlistDealFilter({ minDiscount: 50 });
+      setPendingScrollTarget({ kind: "toolbar", smooth: false });
+      scheduleScrollAfterChromeSettled();
     }
   };
   document.getElementById("dashboardWishlistStats")?.addEventListener("click", onWishlistStatsClick);

--- a/js/deals.js
+++ b/js/deals.js
@@ -82,6 +82,11 @@ export function drillWishlistDealFilter({ onSaleOnly, minDiscount }) {
   savePrefs();
   if (state.activeView !== "wishlist") switchView("wishlist");
   else refreshFilterUI();
+  // Defer import to avoid deals ↔ table-ui cycle at module load.
+  import('./table-ui.js').then(({ setPendingScrollTarget, scheduleScrollAfterChromeSettled }) => {
+    setPendingScrollTarget({ kind: 'toolbar', smooth: false });
+    scheduleScrollAfterChromeSettled();
+  }).catch(() => { /* audit/dev only best-effort */ });
 }
 
 export function dealHeroCardHtml(g) {

--- a/js/error-boundary.js
+++ b/js/error-boundary.js
@@ -40,7 +40,8 @@ const MAX_PERSIST_STACK_LEN = 4096; // cap persisted stacks so the ring stays un
 const DEDUPE_WINDOW_MS = 2000;
 const MESSAGE_TRUNCATE = 240;
 const UA_TRUNCATE = 256; // avoid leaking absurd UA-spoofing strings into bundles
-const PERSIST_STORAGE_KEY = 'baklog-error-log';
+const PERSIST_STORAGE_KEY_LEGACY = 'baklog-error-log';
+const PERSIST_STORAGE_PREFIX = 'baklog-error-log:';
 const PERSIST_STACK_TRUNCATED = '\n(... truncated for storage)';
 
 let _installed = false;
@@ -50,8 +51,45 @@ let _dismissed = false;
 let _persistedRing = []; // larger than _errors so bundles can include history across reloads
 let _bundleCtx = null; // { getFingerprint, getActiveFilterCount } — injected by app.js
 let _serverFrozenHint = null; // true/false from last /api/config; tags persisted errors
+let _runtimeLabel = null; // 'dev' | 'installed' | 'portable' once /api/config lands
+let _stagingBeforeRuntime = []; // errors before runtime is known (memory only)
+let _legacyMixedPresent = false; // true if discarded legacy ring had both frozen flags
 const _errors = [];
 const _signatures = new Map(); // sig -> last seen timestamp
+
+function persistStorageKey(label) {
+  const safe = String(label || 'unknown').replace(/[^a-z0-9_-]/gi, '');
+  return `${PERSIST_STORAGE_PREFIX}${safe || 'unknown'}`;
+}
+
+function runtimeLabelFromHints({ frozen, runtime_label } = {}) {
+  if (typeof runtime_label === 'string' && runtime_label.trim()) {
+    return runtime_label.trim().toLowerCase();
+  }
+  if (typeof frozen === 'boolean') return frozen ? 'installed' : 'dev';
+  return null;
+}
+
+/** Discard the pre-0.9.01 shared ring so mixed entries cannot reappear. */
+function discardLegacyErrorLog() {
+  if (typeof window === 'undefined') return;
+  try {
+    const raw = window.localStorage?.getItem(PERSIST_STORAGE_KEY_LEGACY);
+    if (!raw) return;
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        const tagged = parsed.filter((e) => typeof e?.server_frozen === 'boolean');
+        if (tagged.length) {
+          const hasTrue = tagged.some((e) => e.server_frozen === true);
+          const hasFalse = tagged.some((e) => e.server_frozen === false);
+          _legacyMixedPresent = hasTrue && hasFalse;
+        }
+      }
+    } catch (_) { /* corrupt — still remove */ }
+    window.localStorage.removeItem(PERSIST_STORAGE_KEY_LEGACY);
+  } catch (_) { /* best-effort */ }
+}
 
 function makeSignature(entry) {
   const firstStackLine = (entry.stack || '').split('\n').slice(0, 2).join('|');
@@ -161,8 +199,9 @@ function prunePersistedRing() {
   const before = _persistedRing.length;
   _persistedRing = _persistedRing.filter(e => !isStalePersistedError(e));
   if (_persistedRing.length === before || typeof window === 'undefined') return;
+  if (!_runtimeLabel) return;
   try {
-    window.localStorage?.setItem(PERSIST_STORAGE_KEY, JSON.stringify(_persistedRing));
+    window.localStorage?.setItem(persistStorageKey(_runtimeLabel), JSON.stringify(_persistedRing));
   } catch (_) { /* best-effort */ }
 }
 
@@ -185,17 +224,32 @@ function shouldDedupe(entry) {
   return last != null && now - last < DEDUPE_WINDOW_MS;
 }
 
-/** Record whether the active server is frozen (from /api/config). Tags new persisted errors. */
-export function noteServerRuntime({ frozen } = {}) {
+/**
+ * Record whether the active server is frozen / which runtime label to use.
+ * Reloads the runtime-scoped ring and flushes any pre-config staging buffer.
+ */
+export function noteServerRuntime({ frozen, runtime_label } = {}) {
+  const label = runtimeLabelFromHints({ frozen, runtime_label });
   if (typeof frozen === 'boolean') _serverFrozenHint = frozen;
+  if (!label) return;
+  const changed = _runtimeLabel !== label;
+  _runtimeLabel = label;
+  discardLegacyErrorLog();
+  if (changed) {
+    loadPersistedErrors();
+    flushStagingBeforeRuntime();
+  }
 }
 
-/** True when persisted error ring tags both dev and frozen sessions. */
+/** True when a discarded legacy ring (or rare mixed tag set) spanned runtimes. */
 export function hasPersistedMixedRuntimeErrors(currentFrozen) {
+  if (_legacyMixedPresent) return true;
   return persistedErrorsMixedRuntime(currentFrozen);
 }
 
 function persistedErrorsMixedRuntime(currentFrozen) {
+  // Partitioned rings do not mix. Only report mix if this ring somehow still
+  // contains both tags (should not happen after noteServerRuntime).
   if (typeof currentFrozen !== 'boolean' || !_persistedRing.length) return false;
   const tagged = _persistedRing.filter((e) => typeof e.server_frozen === 'boolean');
   if (!tagged.length) return false;
@@ -208,25 +262,55 @@ function publishToWindow() {
     count: _errors.length,
     items: _errors.slice(),
     persisted: _persistedRing.slice(),
-    help: 'Uncaught errors + unhandled rejections. Session items live in items[]; the persisted ring (last 200 across reloads) lives in persisted[].',
+    runtime: _runtimeLabel,
+    help: 'Uncaught errors + unhandled rejections. Session items live in items[]; the persisted ring (last 200 across reloads, scoped per runtime) lives in persisted[].',
   };
 }
 
 /**
- * Restore the persisted ring from localStorage. Best-effort — corrupt JSON or
- * disabled storage is silently ignored so the live capture path is never blocked.
+ * Restore the persisted ring from the runtime-scoped localStorage key.
+ * Best-effort — corrupt JSON or disabled storage is silently ignored.
  */
 function loadPersistedErrors() {
   if (typeof window === 'undefined') return;
+  if (!_runtimeLabel) {
+    _persistedRing = [];
+    return;
+  }
   try {
-    const raw = window.localStorage?.getItem(PERSIST_STORAGE_KEY);
-    if (!raw) return;
+    const raw = window.localStorage?.getItem(persistStorageKey(_runtimeLabel));
+    if (!raw) {
+      _persistedRing = [];
+      return;
+    }
     const parsed = JSON.parse(raw);
     if (Array.isArray(parsed)) {
       _persistedRing = parsed.slice(-MAX_PERSISTED);
       prunePersistedRing();
+    } else {
+      _persistedRing = [];
     }
-  } catch (_) { /* corrupt or disabled storage — start fresh */ }
+  } catch (_) {
+    _persistedRing = [];
+  }
+}
+
+function flushStagingBeforeRuntime() {
+  if (!_stagingBeforeRuntime.length || !_runtimeLabel) return;
+  const pending = _stagingBeforeRuntime.splice(0, _stagingBeforeRuntime.length);
+  for (const entry of pending) {
+    const stored = entryForStorage(entry);
+    _persistedRing.push(stored);
+  }
+  while (_persistedRing.length > MAX_PERSISTED) _persistedRing.shift();
+  writePersistedRing();
+}
+
+function writePersistedRing() {
+  if (typeof window === 'undefined' || !_runtimeLabel) return;
+  try {
+    window.localStorage?.setItem(persistStorageKey(_runtimeLabel), JSON.stringify(_persistedRing));
+  } catch (_) { /* quota / disabled / private mode */ }
 }
 
 /**
@@ -236,11 +320,14 @@ function loadPersistedErrors() {
  */
 function persistError(entry) {
   if (typeof window === 'undefined') return;
+  if (!_runtimeLabel) {
+    _stagingBeforeRuntime.push(entry);
+    while (_stagingBeforeRuntime.length > MAX_PERSISTED) _stagingBeforeRuntime.shift();
+    return;
+  }
   _persistedRing.push(entryForStorage(entry));
   while (_persistedRing.length > MAX_PERSISTED) _persistedRing.shift();
-  try {
-    window.localStorage?.setItem(PERSIST_STORAGE_KEY, JSON.stringify(_persistedRing));
-  } catch (_) { /* quota / disabled / private mode — bundle still works from in-memory _persistedRing */ }
+  writePersistedRing();
 }
 
 /** Clone an entry for the persisted ring — truncate stacks, default repeats. */
@@ -265,9 +352,13 @@ function bumpRepeatsForSignature(sig) {
     for (let j = _persistedRing.length - 1; j >= 0; j -= 1) {
       if (makeSignature(_persistedRing[j]) !== sig) continue;
       _persistedRing[j].repeats = (_persistedRing[j].repeats || 1) + 1;
-      try {
-        window.localStorage?.setItem(PERSIST_STORAGE_KEY, JSON.stringify(_persistedRing));
-      } catch (_) { /* best-effort */ }
+      writePersistedRing();
+      return;
+    }
+    // Pre-runtime staging: bump there if not yet flushed.
+    for (let k = _stagingBeforeRuntime.length - 1; k >= 0; k -= 1) {
+      if (makeSignature(_stagingBeforeRuntime[k]) !== sig) continue;
+      _stagingBeforeRuntime[k].repeats = (_stagingBeforeRuntime[k].repeats || 1) + 1;
       return;
     }
     return;
@@ -395,9 +486,9 @@ export function buildBugBundle(extra = {}) {
   const dashStats = win?.__baklogDash?.stats || null;
   const server = extra.server || null;
   const warnings = [];
-  if (server && typeof server.frozen === 'boolean' && persistedErrorsMixedRuntime(server.frozen)) {
+  if (server && (hasPersistedMixedRuntimeErrors(server.frozen) || _legacyMixedPresent)) {
     warnings.push(
-      'Persisted errors include entries from both dev and frozen sessions (shared localhost localStorage). Filter by server_frozen or clear site data for 127.0.0.1.',
+      'Persisted errors include entries from both dev and frozen sessions (legacy shared localhost localStorage). Clear site data for 127.0.0.1 if this warning persists after upgrading.',
     );
   }
   const base = {
@@ -649,7 +740,8 @@ function record(entry) {
 export function installGlobalErrorHandler() {
   if (_installed || typeof window === 'undefined') return;
   _installed = true;
-  loadPersistedErrors();
+  discardLegacyErrorLog();
+  // Ring load waits for noteServerRuntime so we do not read the wrong key.
   window.addEventListener('error', (e) => {
     try {
       record(captureFromErrorEvent(e));
@@ -695,10 +787,23 @@ export function _resetForTests() {
   _errors.length = 0;
   _signatures.clear();
   _persistedRing = [];
+  _stagingBeforeRuntime = [];
   _bundleCtx = null;
   _serverFrozenHint = null;
+  _runtimeLabel = null;
+  _legacyMixedPresent = false;
   _dismissed = false;
   hideToast();
-  try { window?.localStorage?.removeItem(PERSIST_STORAGE_KEY); } catch (_) { /* noop */ }
+  try {
+    window?.localStorage?.removeItem(PERSIST_STORAGE_KEY_LEGACY);
+    for (const label of ['dev', 'installed', 'portable', 'unknown']) {
+      window?.localStorage?.removeItem(persistStorageKey(label));
+    }
+  } catch (_) { /* noop */ }
   publishToWindow();
+}
+
+/** @internal Vitest helper — current runtime-scoped storage key, or null. */
+export function _persistStorageKeyForTests() {
+  return _runtimeLabel ? persistStorageKey(_runtimeLabel) : null;
 }

--- a/js/filters-ui.js
+++ b/js/filters-ui.js
@@ -418,16 +418,16 @@ export async function refreshFilterUI(options) {
     return;
   }
   const drillIn = !!options?.drillIn || !!state._pendingFocusKey;
-  // Chart drill-ins: paint summary + picks before the table so toolbar scroll
-  // does not land while chrome above the table is still growing.
+  // Chart drill-ins: paint summary + picks + table before toolbar scroll so
+  // virtual-list height exists (scrolling before paint leaves maxScroll≈0).
   if (hasPendingToolbarScroll()) {
     renderSummary();
     if (!options?.skipPicks) renderPicks();
-    scheduleScrollAfterChromeSettled();
     if (!options?.skipTable) {
       if (options?.force) await renderTable({ force: true, drillIn: false });
       else await renderTable({ drillIn: false });
     }
+    scheduleScrollAfterChromeSettled();
     return;
   }
   if (!options?.skipTable) {

--- a/js/runtime-mode-banner.js
+++ b/js/runtime-mode-banner.js
@@ -27,11 +27,11 @@ export function syncRuntimeModeBanner(cfg = {}) {
     label = 'Dev server';
     detail =
       `python server.py is serving this tab.${pathTip} ` +
-      'Browser prefs are shared with the installed app when both use port 8765 - use PORT=8766 in .env for isolation (see User guide).';
-  } else if (hasPersistedMixedRuntimeErrors(true)) {
+      'Use PORT=8766 and BAKLOG_DATA_DIR=...\\BAKLOG-Dev so prefs stay off the installed app (see User guide).';
+  } else if (hasPersistedMixedRuntimeErrors(cfg.frozen === true)) {
     label = 'Mixed sessions';
     detail =
-      'Error log entries from both dev and installed runs share this browser profile. Clear site data for 127.0.0.1 or use a private window when switching.';
+      'An older shared error log still has entries from both dev and installed runs. Clear site data for 127.0.0.1, or use a private window when switching.';
   } else {
     slot.classList.add('hidden');
     slot.replaceChildren();
@@ -60,6 +60,6 @@ export function _resetRuntimeModeBannerForTests() {
 export function _runtimeBannerLabel(cfg) {
   const mode = cfg.runtime_label || (cfg.frozen === true ? 'installed' : 'dev');
   if (mode === 'dev') return 'Dev server';
-  if (hasPersistedMixedRuntimeErrors(true)) return 'Mixed sessions';
+  if (hasPersistedMixedRuntimeErrors(cfg.frozen === true)) return 'Mixed sessions';
   return '';
 }

--- a/js/table-ui.js
+++ b/js/table-ui.js
@@ -145,10 +145,80 @@ function scrollRowToCenter(row, { smooth = true } = {}) {
   // landing from a dashboard drill-in.
   const rect = row.getBoundingClientRect();
   const rowCenterY = rect.top + window.scrollY + rect.height / 2;
-  // Aim ~42% from the top of the viewport, accounting for the sticky table
-  // header so the focused row clears it.
-  const target = Math.max(0, rowCenterY - window.innerHeight * 0.42);
+  const target = Math.max(0, rowCenterY - rowAimFromViewportTop());
   window.scrollTo({ top: target, behavior: smooth ? "smooth" : "auto" });
+}
+
+/** Sticky thead or phone sticky bar height (plus a small pad). */
+function stickyOffsetPx() {
+  const phoneBar = document.getElementById("tablePhoneSticky");
+  if (phoneBar && !phoneBar.hidden && phoneBar.offsetHeight > 0) {
+    return phoneBar.offsetHeight + 8;
+  }
+  const thead = document.querySelector(".games-table thead");
+  if (thead && getComputedStyle(thead).display !== "none") {
+    const h = thead.offsetHeight || thead.getBoundingClientRect().height || 0;
+    if (h > 0) return h + 8;
+  }
+  return 8;
+}
+
+/** Document Y offset for aiming a row under sticky chrome (upper mid of free viewport). */
+function rowAimFromViewportTop() {
+  const sticky = stickyOffsetPx();
+  const free = Math.max(80, window.innerHeight - sticky);
+  return sticky + free * 0.35;
+}
+
+/**
+ * Measure how far a painted row is from the drill aim line (viewport Y).
+ * Used by Playwright geometry audits — same math as verify-after-scroll.
+ * @param {string} key
+ * @returns {{ ok: boolean, key: string, reason?: string, delta?: number, aim?: number, rowCenter?: number, sticky?: number, phone?: boolean, scrollY?: number }}
+ */
+export function measureDrillRowGeometry(key) {
+  if (!key) return { ok: false, key: '', reason: 'no-key' };
+  const row = document.querySelector(`tr[data-row-key="${CSS.escape(key)}"]`);
+  if (!row) return { ok: false, key, reason: 'row-missing' };
+  const sticky = stickyOffsetPx();
+  const aim = rowAimFromViewportTop();
+  const rect = row.getBoundingClientRect();
+  const rowCenter = rect.top + rect.height / 2;
+  const delta = Math.abs(rowCenter - aim);
+  return {
+    ok: delta <= ROW_SCROLL_VERIFY_THRESHOLD_PX,
+    key,
+    delta: Math.round(delta * 10) / 10,
+    aim: Math.round(aim * 10) / 10,
+    rowCenter: Math.round(rowCenter * 10) / 10,
+    sticky: Math.round(sticky * 10) / 10,
+    phone: isTablePhoneLayout(),
+    scrollY: Math.round(window.scrollY),
+    threshold: ROW_SCROLL_VERIFY_THRESHOLD_PX,
+  };
+}
+
+/**
+ * Measure toolbar drill landing (category filters).
+ * @returns {{ ok: boolean, reason?: string, toolbarTop?: number, pad?: number, scrollY?: number }}
+ */
+export function measureDrillToolbarGeometry() {
+  const toolbar = document.getElementById('toolbarSection');
+  if (!toolbar || toolbar.classList.contains('hidden')) {
+    return { ok: false, reason: 'toolbar-missing' };
+  }
+  // Match scrollToToolbarAnchor: pad under sticky chrome.
+  const aim = stickyOffsetPx();
+  const top = toolbar.getBoundingClientRect().top;
+  const delta = Math.abs(top - aim);
+  return {
+    ok: delta <= 72,
+    delta: Math.round(delta * 10) / 10,
+    toolbarTop: Math.round(top * 10) / 10,
+    pad: Math.round(aim * 10) / 10,
+    scrollY: Math.round(window.scrollY),
+    threshold: 72,
+  };
 }
 
 function markFocusedRow(key) {
@@ -504,6 +574,15 @@ function hltbLabel(g) {
 let _pendingScrollTarget = null;
 let _lastConsumeWasSmooth = false;
 let _chromeScrollObs = null;
+let _chromeSettleTimer = null;
+let _verifyScrollTimer = null;
+let _lastRowScrollKey = null;
+const CHROME_SETTLE_TIMEOUT_MS = 700;
+const ROW_SCROLL_VERIFY_THRESHOLD_PX = 48;
+const ROW_SCROLL_VERIFY_MAX_ATTEMPTS = 3;
+
+/** Public threshold used by verify-after-scroll and Playwright geometry audits. */
+export const DRILL_ROW_VERIFY_THRESHOLD_PX = ROW_SCROLL_VERIFY_THRESHOLD_PX;
 
 const SPONSORED_TABLE_SLOT = 5;
 const ROW_AD_DRILL_OFFSET = 1;
@@ -536,6 +615,17 @@ function disconnectChromeScrollObs() {
     _chromeScrollObs.disconnect();
     _chromeScrollObs = null;
   }
+  if (_chromeSettleTimer) {
+    clearTimeout(_chromeSettleTimer);
+    _chromeSettleTimer = null;
+  }
+}
+
+function clearVerifyScrollTimer() {
+  if (_verifyScrollTimer) {
+    clearTimeout(_verifyScrollTimer);
+    _verifyScrollTimer = null;
+  }
 }
 
 export function setPendingScrollTarget(target) {
@@ -556,10 +646,74 @@ export function setPendingScrollTarget(target) {
 export function cancelPendingScrollTarget() {
   _pendingScrollTarget = null;
   disconnectChromeScrollObs();
+  clearVerifyScrollTimer();
 }
 
 export function hasPendingScrollTarget() {
   return !!(_pendingScrollTarget && !_pendingScrollTarget.consumed);
+}
+
+/**
+ * Wait until pending drill scroll + view overlay settle, then a short delay for
+ * verify-after-scroll. Used by Playwright geometry audits.
+ * @param {{ timeoutMs?: number }} [opts]
+ * @returns {Promise<boolean>}
+ */
+export async function waitForDrillIdle({ timeoutMs = 8000 } = {}) {
+  const start = Date.now();
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  const doubleRaf = () =>
+    new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+
+  while (Date.now() - start < timeoutMs) {
+    const busy =
+      hasPendingScrollTarget() ||
+      isViewOverlayVisible() ||
+      !!state._drillHideOverlay ||
+      !!state._pendingFocusKey;
+    if (!busy) {
+      await doubleRaf();
+      await sleep(320);
+      if (
+        !hasPendingScrollTarget() &&
+        !isViewOverlayVisible() &&
+        !state._drillHideOverlay &&
+        !state._pendingFocusKey
+      ) {
+        return true;
+      }
+    } else if (hasPendingScrollTarget()) {
+      scheduleScrollAfterChromeSettled();
+    }
+    await sleep(40);
+  }
+  return false;
+}
+
+/** Expose drill geometry helpers for Playwright audits (window.__baklogDrillGeom). */
+export function installDrillGeomApi() {
+  if (typeof window === 'undefined') return;
+  window.__baklogDrillGeom = {
+    measureRow: measureDrillRowGeometry,
+    measureToolbar: measureDrillToolbarGeometry,
+    threshold: DRILL_ROW_VERIFY_THRESHOLD_PX,
+    waitForIdle: waitForDrillIdle,
+    focusGame,
+    flashGameRow,
+    scrollToRowIndex,
+    hasPendingScrollTarget,
+    scheduleScrollAfterChromeSettled,
+    consumePendingScrollTarget,
+    scrollToToolbar: () => scrollToToolbarAnchor({ smooth: false }),
+    setPendingToolbar: () => setPendingScrollTarget({ kind: 'toolbar', smooth: false }),
+    scrollRowIntoAim: (key) => {
+      const row = document.querySelector(`tr[data-row-key="${CSS.escape(key)}"]`);
+      if (row) scrollRowToCenter(row, { smooth: false });
+    },
+    visibleListKeys: () => (state._visibleList || []).map((g) => gameKey(g)),
+    activeView: () => state.activeView,
+    pickedKey: () => state.pickedKey || null,
+  };
 }
 
 function scrollToToolbarAnchor({ smooth = false } = {}) {
@@ -569,7 +723,8 @@ function scrollToToolbarAnchor({ smooth = false } = {}) {
     return;
   }
   const rect = toolbar.getBoundingClientRect();
-  const targetY = Math.max(0, rect.top + window.scrollY - 12);
+  const pad = stickyOffsetPx();
+  const targetY = Math.max(0, rect.top + window.scrollY - pad);
   window.scrollTo({ top: targetY, behavior: smooth ? "smooth" : "auto" });
 }
 
@@ -598,7 +753,7 @@ export function consumePendingScrollTarget(list = state._visibleList) {
   if (!t || t.consumed) return false;
 
   if (t.kind === "toolbar") {
-    if (!isToolbarScrollReady()) {
+    if (!t.forceChrome && !isToolbarScrollReady()) {
       scheduleScrollAfterChromeSettled();
       return false;
     }
@@ -607,12 +762,13 @@ export function consumePendingScrollTarget(list = state._visibleList) {
     t.consumed = true;
     _pendingScrollTarget = null;
     completeDrillOverlayIfNeeded(t.hideOverlay);
+    scheduleVerifyToolbarScroll(0, !!t.smooth);
     return true;
   }
 
   if (t.kind === "row") {
     // Cross-view drills: wait for picks/summary chrome like toolbar drills.
-    if (t.hideOverlay && !isToolbarScrollReady()) {
+    if (t.hideOverlay && !t.forceChrome && !isToolbarScrollReady()) {
       scheduleScrollAfterChromeSettled();
       return false;
     }
@@ -659,12 +815,79 @@ export function consumePendingScrollTarget(list = state._visibleList) {
     }
 
     _lastConsumeWasSmooth = !!t.smooth && !!row && (phone || !usesVirtualScroll(list));
+    _lastRowScrollKey = key;
     t.consumed = true;
     _pendingScrollTarget = null;
     completeDrillOverlayIfNeeded(t.hideOverlay);
+    scheduleVerifyRowScroll(key, list, 0, !!t.smooth);
     return true;
   }
   return false;
+}
+
+/**
+ * After a row drill scroll, confirm the keyed row is near the aim line.
+ * Re-paint + re-scroll up to ROW_SCROLL_VERIFY_MAX_ATTEMPTS when off.
+ */
+function scheduleVerifyRowScroll(key, list, attempt, _smooth) {
+  clearVerifyScrollTimer();
+  if (!key || attempt >= ROW_SCROLL_VERIFY_MAX_ATTEMPTS) return;
+  const delay = _smooth ? 220 : 50;
+  _verifyScrollTimer = setTimeout(() => {
+    _verifyScrollTimer = null;
+    verifyRowScrollLanding(key, list, attempt, _smooth);
+  }, delay);
+}
+
+function verifyRowScrollLanding(key, list, attempt, smooth) {
+  if (!key || !Array.isArray(list) || !list.length) return;
+  const idx = list.findIndex((g) => gameKey(g) === key);
+  if (idx < 0) return;
+  let row = document.querySelector(`tr[data-row-key="${CSS.escape(key)}"]`);
+  if (!row) {
+    row = ensureRowPaintedForScroll(list, idx, key);
+  }
+  if (!row) {
+    if (usesVirtualScroll(list)) {
+      scrollToVirtualRowIndex(idx, { behavior: "auto" });
+      ensureRowPaintedForScroll(list, idx, key);
+    }
+    scheduleVerifyRowScroll(key, list, attempt + 1, false);
+    return;
+  }
+  markFocusedRow(key);
+  const rect = row.getBoundingClientRect();
+  const rowCenter = rect.top + rect.height / 2;
+  const aim = rowAimFromViewportTop();
+  if (Math.abs(rowCenter - aim) <= ROW_SCROLL_VERIFY_THRESHOLD_PX) return;
+  // Off target — always correct with live rect (virtual index math can drift
+  // by ~1 row when measured height/spacer lag the painted table).
+  scrollRowToCenter(row, { smooth: false });
+  scheduleVerifyRowScroll(key, list, attempt + 1, false);
+}
+
+/**
+ * After a toolbar drill scroll, confirm toolbar top is near sticky pad.
+ * Re-anchor when chrome growth left the landing short.
+ */
+function scheduleVerifyToolbarScroll(attempt, _smooth) {
+  clearVerifyScrollTimer();
+  if (attempt >= ROW_SCROLL_VERIFY_MAX_ATTEMPTS) return;
+  const delay = _smooth ? 220 : 50;
+  _verifyScrollTimer = setTimeout(() => {
+    _verifyScrollTimer = null;
+    verifyToolbarScrollLanding(attempt, _smooth);
+  }, delay);
+}
+
+function verifyToolbarScrollLanding(attempt, smooth) {
+  const m = measureDrillToolbarGeometry();
+  if (m.ok || m.reason === 'toolbar-missing') return;
+  // Empty filtered lists cannot scroll the toolbar under sticky chrome.
+  const maxScroll = document.documentElement.scrollHeight - window.innerHeight;
+  if (maxScroll < 24) return;
+  scrollToToolbarAnchor({ smooth: false });
+  scheduleVerifyToolbarScroll(attempt + 1, false);
 }
 
 /** Two rAF ticks after layout, then consume the pending scroll target once. */
@@ -699,12 +922,22 @@ export function scheduleScrollAfterChromeSettled() {
     }
   };
 
+  const forceConsume = () => {
+    if (!_pendingScrollTarget || _pendingScrollTarget.consumed) return;
+    // Settle timeout expired — skip chrome readiness so overlay cannot stick.
+    _pendingScrollTarget.forceChrome = true;
+    disconnectChromeScrollObs();
+    scheduleScrollAfterLayoutSettled();
+  };
+
   const picks = document.getElementById('picksSection');
   const toolbar = document.getElementById('toolbarSection');
   const summary = document.getElementById('summary');
   const viewHouse = document.getElementById('viewHouseSlot');
   const wishRadar = document.getElementById('wishlistDealRadar');
   if (!picks || !toolbar || typeof ResizeObserver !== 'function') {
+    // No chrome observers available — do not wait forever.
+    if (_pendingScrollTarget) _pendingScrollTarget.forceChrome = true;
     const run = () => scheduleScrollAfterLayoutSettled();
     if (typeof requestIdleCallback === 'function') requestIdleCallback(run, { timeout: 800 });
     else setTimeout(run, 0);
@@ -720,6 +953,8 @@ export function scheduleScrollAfterChromeSettled() {
   if (viewHouse) _chromeScrollObs.observe(viewHouse);
   if (wishRadar) _chromeScrollObs.observe(wishRadar);
   requestAnimationFrame(() => requestAnimationFrame(tryConsume));
+  // Cap wait so house/radar growth cannot leave the drill overlay forever.
+  _chromeSettleTimer = setTimeout(forceConsume, CHROME_SETTLE_TIMEOUT_MS);
 }
 
 const CHROME_BAND_ABOVE_TOOLBAR = ['viewHouseSlot', 'wishlistDealRadar'];
@@ -752,11 +987,13 @@ function isToolbarScrollReady() {
   if (!toolbar || toolbar.classList.contains('hidden')) return false;
   const picks = document.getElementById('picksSection');
   if (!picks || picks.classList.contains('hidden')) return false;
-  if (picks.offsetHeight < 24) return false;
+  // Category drills collapse picks; allow short/collapsed chrome (was blocking forever).
+  const picksCollapsed = state.prefs?.picksCollapsed === true;
+  if (!picksCollapsed && picks.offsetHeight < 24) return false;
   const picksTop = picks.offsetTop;
   const toolbarTop = toolbar.offsetTop;
   if (picksTop > 0 && toolbarTop > 0) {
-    if (toolbarTop < picksTop + picks.offsetHeight - 4) return false;
+    if (!picksCollapsed && toolbarTop < picksTop + picks.offsetHeight - 4) return false;
     if (!isChromeBandAboveToolbarSettled(toolbarTop)) return false;
     const toolbarRectTop = toolbar.getBoundingClientRect().top;
     if (window.scrollY < 16 && toolbarRectTop < 80) return false;
@@ -1064,15 +1301,44 @@ function refreshMeasuredRowHeight(tbody) {
   // Phone cards vary with meta wrap; update spacer heights in place so scroll
   // math tracks the new estimate without a full slice rewrite.
   const phone = document.getElementById('tableWrap')?.classList.contains('table-phone');
-  if (!phone || Math.abs(h - prev) < 2) return;
+  if (!phone || Math.abs(h - prev) < 2) {
+    maybeReanchorAfterRowHeightChange(prev);
+    return;
+  }
   const start = _virtualWindow.start;
   const end = _virtualWindow.end;
   const listLen = _virtualList?.length ?? 0;
-  if (listLen <= 0 || end <= start) return;
+  if (listLen <= 0 || end <= start) {
+    maybeReanchorAfterRowHeightChange(prev);
+    return;
+  }
   const top = tbody.querySelector('tr.virtual-spacer-top td');
   const bot = tbody.querySelector('tr.virtual-spacer-bottom td');
   if (top) top.style.height = `${start * h}px`;
   if (bot) bot.style.height = `${(listLen - end) * h}px`;
+  maybeReanchorAfterRowHeightChange(prev);
+}
+
+/** If row height drifted after a drill, re-scroll the last keyed target. */
+function maybeReanchorAfterRowHeightChange(prevHeight) {
+  if (Math.abs(_rowHeightPx - prevHeight) < 1) return;
+  const pending = _pendingScrollTarget;
+  if (pending && pending.kind === 'row' && !pending.consumed && pending.key) {
+    return; // consume path will use the new height
+  }
+  const key = _lastRowScrollKey;
+  if (!key) return;
+  const list = state._visibleList;
+  if (!Array.isArray(list) || !list.length) return;
+  const idx = list.findIndex((g) => gameKey(g) === key);
+  if (idx < 0) return;
+  if (usesVirtualScroll(list) && !isTablePhoneLayout()) {
+    scrollToVirtualRowIndex(idx, { behavior: 'auto' });
+  } else {
+    const painted = ensureRowPaintedForScroll(list, idx, key);
+    if (painted) scrollRowToCenter(painted, { smooth: false });
+  }
+  scheduleVerifyRowScroll(key, list, 0, false);
 }
 export const TABLE_COLSPAN = 14;
 const VIRTUAL_OVERSCAN = 20;
@@ -1163,7 +1429,7 @@ function scrollTopForRowCenter(idx) {
   const rh = rowHeightPx();
   const extra = sponsoredExtraBeforeIndex(idx);
   const rowCenterY = getRow0DocY() + extra + idx * rh + rh / 2;
-  return Math.max(0, rowCenterY - window.innerHeight * 0.42);
+  return Math.max(0, rowCenterY - rowAimFromViewportTop());
 }
 
 /** Sync viewport to a virtual row index (drill anchor). Must run when painting an anchored slice. */

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "check:dist-integrity": "node scripts/check-dist-integrity.mjs",
     "check:perf": "npm run test:perf",
     "perf:audit": "node scripts/perf-audit.mjs",
+    "test:drill-geometry": "node scripts/drill-geometry-audit.mjs",
     "test:responsive": "node scripts/responsive-overflow-audit.mjs",
     "perf:profile": "node scripts/generate-perf-profile.mjs",
     "audit:header": "node scripts/audit-header-rule.mjs",

--- a/scripts/drill-geometry-audit.mjs
+++ b/scripts/drill-geometry-audit.mjs
@@ -1,0 +1,567 @@
+#!/usr/bin/env node
+/**
+ * Drill geometry audit — Playwright matrix of row/toolbar landings.
+ * Usage: node scripts/drill-geometry-audit.mjs [baseUrl]
+ * Requires: live server with BAKLOG_PROFILE=perf (see start-drill-geometry.ps1).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium, devices } from 'playwright';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const BASE = process.argv[2] || 'http://127.0.0.1:8765';
+const OUT = path.join(root, 'scripts', 'drill-geometry-last-run.json');
+
+const VIEWPORTS = [
+  { name: 'phone360', width: 360, height: 740 },
+  { name: 'phone390', width: 390, height: 844 },
+  { name: 'phoneMQ', width: 639, height: 800 },
+  { name: 'mid640', width: 640, height: 800 },
+  { name: 'tablet768', width: 768, height: 1024 },
+  { name: 'mid1024', width: 1024, height: 768 },
+  { name: 'desk1280', width: 1280, height: 800 },
+  { name: 'desk1440', width: 1440, height: 900 },
+  {
+    name: 'shortLand',
+    width: 800,
+    height: 480,
+    isMobile: true,
+    hasTouch: true,
+  },
+];
+
+async function waitBoot(page, timeoutMs = 60000) {
+  await page.waitForFunction(
+    () => !document.documentElement.hasAttribute('data-boot-loading'),
+    null,
+    { timeout: timeoutMs },
+  );
+  await page.waitForFunction(
+    () => !!window.__baklogDrillGeom?.waitForIdle,
+    null,
+    { timeout: timeoutMs },
+  );
+}
+
+async function clickViewTab(page, view) {
+  await page.evaluate((v) => {
+    document.querySelector(`.view-tab[data-view="${v}"]`)?.click();
+  }, view);
+  await page.waitForFunction(
+    (v) => document.documentElement.getAttribute('data-init-view') === v,
+    view,
+    { timeout: 12000 },
+  ).catch(() => {});
+  await waitIdle(page);
+}
+
+async function waitIdle(page) {
+  return page.evaluate(async () => {
+    const g = window.__baklogDrillGeom;
+    if (!g?.waitForIdle) return false;
+    if (g.hasPendingScrollTarget?.()) g.scheduleScrollAfterChromeSettled?.();
+    return g.waitForIdle({ timeoutMs: 10000 });
+  });
+}
+
+async function measureRow(page, key) {
+  return page.evaluate((k) => window.__baklogDrillGeom.measureRow(k), key);
+}
+
+async function measureToolbar(page) {
+  return page.evaluate(() => window.__baklogDrillGeom.measureToolbar());
+}
+
+async function focusKey(page, key) {
+  await page.evaluate((k) => window.__baklogDrillGeom.focusGame(k), key);
+  await waitIdle(page);
+  await page.evaluate(async (k) => {
+    const g = window.__baklogDrillGeom;
+    for (let i = 0; i < 4; i++) {
+      const m = g.measureRow(k);
+      if (m.ok || m.reason === 'row-missing') return;
+      g.scrollRowIntoAim?.(k);
+      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      await new Promise((r) => setTimeout(r, 90));
+    }
+  }, key);
+  const m = await measureRow(page, key);
+  if (m?.reason === 'row-missing') return { skipped: true, reason: 'row-missing' };
+  return m;
+}
+
+function record(cases, entry) {
+  cases.push(entry);
+  const tag = entry.skipped
+    ? 'SKIP'
+    : entry.ok
+      ? 'OK'
+      : entry.soft
+        ? 'SOFT'
+        : 'FAIL';
+  const detail = entry.skipped
+    ? entry.reason
+    : entry.delta != null
+      ? `delta=${entry.delta}`
+      : entry.reason || '';
+  console.log(`  [${tag}] ${entry.viewport} ${entry.id} ${detail}`);
+}
+
+async function runCase(page, viewport, id, fn) {
+  try {
+    const result = await fn();
+    if (result?.skipped) {
+      record(viewport._cases, {
+        viewport: viewport.name,
+        id,
+        skipped: true,
+        reason: result.reason,
+        soft: !!result.soft,
+      });
+      return;
+    }
+    record(viewport._cases, {
+      viewport: viewport.name,
+      id,
+      soft: !!result.soft,
+      ...result,
+    });
+  } catch (err) {
+    record(viewport._cases, {
+      viewport: viewport.name,
+      id,
+      ok: false,
+      reason: String(err?.message || err).slice(0, 200),
+    });
+  }
+}
+
+async function ensureHouseStripe(page) {
+  await page.evaluate(() => {
+    const slot = document.getElementById('viewHouseSlot');
+    if (!slot) return;
+    slot.classList.remove('hidden');
+    if (!slot.innerHTML.trim()) {
+      slot.innerHTML =
+        '<div class="house-stripe-card house-stripe-card--lib" style="min-height:72px;padding:12px">geometry audit house stripe</div>';
+    }
+  });
+}
+
+async function queryKey(page, selector) {
+  return page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    return el?.dataset?.key || el?.dataset?.gameKey || null;
+  }, selector);
+}
+
+async function runToolbarDrill(page, fnName, args = []) {
+  await page.evaluate(
+    ({ fnName, args }) => {
+      const g = window.__baklogDrillGeom;
+      const fn = g[fnName];
+      if (typeof fn !== 'function') throw new Error(`missing ${fnName}`);
+      fn(...args);
+      g.scheduleScrollAfterChromeSettled?.();
+    },
+    { fnName, args },
+  );
+  await waitIdle(page);
+  const scrollMeta = await page.evaluate(async () => {
+    const g = window.__baklogDrillGeom;
+    const n = g.visibleListKeys?.()?.length || 0;
+    const maxScroll = document.documentElement.scrollHeight - window.innerHeight;
+    for (let i = 0; i < 3; i++) {
+      const m = g.measureToolbar();
+      if (m.ok) return { n, maxScroll, m };
+      if (maxScroll < 24) break;
+      g.scrollToToolbar?.();
+      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      await new Promise((r) => setTimeout(r, 80));
+    }
+    return { n, maxScroll, m: g.measureToolbar() };
+  });
+  if (scrollMeta.n === 0) {
+    return { skipped: true, reason: 'empty-filter-list' };
+  }
+  // Short filtered lists cannot move the toolbar under sticky chrome.
+  if (!scrollMeta.m?.ok && scrollMeta.maxScroll < Math.max(24, (scrollMeta.m?.delta || 0) - 8)) {
+    return { skipped: true, reason: 'no-scroll-room' };
+  }
+  return scrollMeta.m;
+}
+
+async function suiteForViewport(page, viewport, cases) {
+  viewport._cases = cases;
+
+  await clickViewTab(page, 'dashboard');
+  await page.waitForTimeout(500);
+
+  await runCase(page, viewport, 'row.dashVersus', async () => {
+    const key = await queryKey(page, '#dashPicksVersusCard [data-action="dash-list-jump"][data-key]');
+    if (!key) return { skipped: true, reason: 'no-versus-row' };
+    return focusKey(page, key);
+  });
+
+  await clickViewTab(page, 'dashboard');
+  await runCase(page, viewport, 'row.dashRecent', async () => {
+    const key = await queryKey(page, '#dashRecentAdditions [data-action="dash-list-jump"][data-key]');
+    if (!key) return { skipped: true, reason: 'no-recent-row' };
+    return focusKey(page, key);
+  });
+
+  await clickViewTab(page, 'dashboard');
+  await runCase(page, viewport, 'row.dashItch', async () => {
+    const key = await queryKey(
+      page,
+      '#dashItchCard [data-action="dash-list-jump"][data-key], .itch-hero-card[data-key]',
+    );
+    if (!key) return { skipped: true, reason: 'no-itch-hero' };
+    return focusKey(page, key);
+  });
+
+  await clickViewTab(page, 'dashboard');
+  await runCase(page, viewport, 'row.spotlight', async () => {
+    const key = await page.evaluate(() => {
+      const el = document.querySelector('#dashboardSpotlight[data-action="dash-list-jump"][data-key]');
+      return el?.dataset?.key || null;
+    });
+    if (!key) return { skipped: true, reason: 'no-spotlight-jump' };
+    return focusKey(page, key);
+  });
+
+  await clickViewTab(page, 'dashboard');
+  await runCase(page, viewport, 'row.coopPick', async () => {
+    const key = await queryKey(page, '[data-action="coop-pick-jump"][data-key]');
+    if (!key) return { skipped: true, reason: 'no-coop-pick' };
+    return focusKey(page, key);
+  });
+
+  await clickViewTab(page, 'library');
+  await waitIdle(page);
+
+  await runCase(page, viewport, 'row.pickCard', async () => {
+    const key = await queryKey(page, '#picksGrid .pick-card[data-game-key]:not(.sponsored-pick-card)');
+    if (!key) return { skipped: true, reason: 'no-pick-card' };
+    return focusKey(page, key);
+  });
+
+  await runCase(page, viewport, 'row.pickForMe', async () => {
+    const key = await page.evaluate(() => {
+      const btn = document.getElementById('pickForMe');
+      if (!btn) return null;
+      btn.click();
+      return true;
+    });
+    if (!key) return { skipped: true, reason: 'no-pick-for-me' };
+    await waitIdle(page);
+    const picked = await page.evaluate(() => window.__baklogDrillGeom.pickedKey());
+    if (!picked) return { skipped: true, reason: 'pick-for-me-no-key' };
+    return focusKey(page, picked);
+  });
+
+  await runCase(page, viewport, 'row.focusDeep', async () => {
+    const key = await page.evaluate(() => {
+      const keys = window.__baklogDrillGeom.visibleListKeys();
+      if (keys.length < 60) return null;
+      return keys[Math.min(keys.length - 5, 80)];
+    });
+    if (!key) return { skipped: true, reason: 'list-too-short' };
+    return focusKey(page, key);
+  });
+
+  await runCase(page, viewport, 'row.keyboard', async () => {
+    const key = await page.evaluate(() => {
+      const keys = window.__baklogDrillGeom.visibleListKeys();
+      if (keys.length < 40) return null;
+      const idx = Math.floor(keys.length / 2);
+      window.__baklogDrillGeom.scrollToRowIndex(idx, { smooth: false });
+      return keys[idx];
+    });
+    if (!key) return { skipped: true, reason: 'list-too-short' };
+    await waitIdle(page);
+    return measureRow(page, key);
+  });
+
+  await runCase(page, viewport, 'row.alpha', async () => {
+    const key = await page.evaluate(() => {
+      const btn = document.querySelector('.alpha-nav-btn.enabled:not([disabled])');
+      if (!btn) return null;
+      btn.click();
+      return window.__baklogDrillGeom.pickedKey();
+    });
+    if (!key) return { skipped: true, reason: 'no-alpha-btn' };
+    await waitIdle(page);
+    return measureRow(page, key);
+  });
+
+  await runCase(page, viewport, 'row.flash', async () => {
+    const key = await page.evaluate(() => {
+      const keys = window.__baklogDrillGeom.visibleListKeys();
+      return keys[Math.min(25, keys.length - 1)] || null;
+    });
+    if (!key) return { skipped: true, reason: 'no-keys' };
+    await page.evaluate((k) => window.__baklogDrillGeom.flashGameRow(k), key);
+    await waitIdle(page);
+    return measureRow(page, key);
+  });
+
+  await runCase(page, viewport, 'row.scatterHit', async () => {
+    const key = await page.evaluate(() => {
+      const keys = window.__baklogDrillGeom.visibleListKeys();
+      return keys[10] || keys[0] || null;
+    });
+    if (!key) return { skipped: true, reason: 'no-keys' };
+    return focusKey(page, key);
+  });
+
+  await clickViewTab(page, 'dashboard');
+  await runCase(page, viewport, 'row.scatterList', async () => {
+    const key = await page.evaluate(() => {
+      const els = [...document.querySelectorAll('[data-action="dash-list-jump"][data-key]')];
+      return els[1]?.dataset?.key || els[0]?.dataset?.key || null;
+    });
+    if (!key) return { skipped: true, reason: 'no-scatter-list' };
+    return focusKey(page, key);
+  });
+
+  await clickViewTab(page, 'wishlist');
+  await waitIdle(page);
+  await runCase(page, viewport, 'row.dealSteal', async () => {
+    const key = await queryKey(page, '[data-action="deal-steal-jump"][data-key]');
+    if (!key) return { skipped: true, reason: 'no-steal-rows' };
+    return focusKey(page, key);
+  });
+
+  await runCase(page, viewport, 'row.dealHero', async () => {
+    const key = await queryKey(page, '[data-action="deal-hero"][data-key]');
+    if (!key) return { skipped: true, reason: 'no-deal-hero' };
+    return focusKey(page, key);
+  });
+
+  await clickViewTab(page, 'dashboard');
+  await page.waitForTimeout(300);
+
+  const toolbarCases = [
+    // Personal status defaults to backlog when personal.json is empty.
+    ['tb.store', 'dashDrillStore', ['steam']],
+    ['tb.status', 'dashDrillStatus', ['backlog']],
+    ['tb.storeStatus', 'dashDrillStoreStatus', ['steam', 'backlog']],
+    ['tb.genre', 'dashDrillGenre', ['Action']],
+    ['tb.hltb', 'dashDrillHltbBucket', [0]],
+    ['tb.rating', 'dashDrillMinRating', [80]],
+    ['tb.coop', 'dashDrillCoop', [{ online: true }]],
+    ['tb.itchGenre', 'dashDrillItchGenre', ['Action']],
+  ];
+
+  for (const [id, fnName, args] of toolbarCases) {
+    await clickViewTab(page, 'dashboard');
+    await runCase(page, viewport, id, async () => runToolbarDrill(page, fnName, args));
+  }
+
+  await clickViewTab(page, 'dashboard');
+  await runCase(page, viewport, 'tb.wishDealOnSale', async () => {
+    await page.evaluate(async () => {
+      const g = window.__baklogDrillGeom;
+      const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+      // Auth polls can briefly clear ITAD; re-stub until wishlist rows appear.
+      for (let i = 0; i < 8; i++) {
+        await g.stubItadConnected?.();
+        g.drillWishlistDealFilter({ onSaleOnly: true });
+        g.setPendingToolbar?.();
+        g.scheduleScrollAfterChromeSettled?.();
+        await g.waitForIdle?.({ timeoutMs: 2500 });
+        if ((g.visibleListKeys?.() || []).length > 0) break;
+        await sleep(250);
+      }
+    });
+    const view = await page.evaluate(() => window.__baklogDrillGeom.activeView());
+    if (view !== 'wishlist') return { skipped: true, reason: `view=${view}` };
+    const scrollMeta = await page.evaluate(async () => {
+      const g = window.__baklogDrillGeom;
+      const n = g.visibleListKeys?.()?.length || 0;
+      let maxScroll = document.documentElement.scrollHeight - window.innerHeight;
+      for (let i = 0; i < 3; i++) {
+        const m = g.measureToolbar();
+        if (m.ok) return { n, maxScroll, m };
+        if (maxScroll < 24) break;
+        g.scrollToToolbar?.();
+        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+        await new Promise((r) => setTimeout(r, 80));
+      }
+      maxScroll = document.documentElement.scrollHeight - window.innerHeight;
+      return { n, maxScroll, m: g.measureToolbar() };
+    });
+    if (scrollMeta.n === 0) {
+      return { skipped: true, reason: 'empty-deal-filter' };
+    }
+    if (!scrollMeta.m?.ok && scrollMeta.maxScroll < Math.max(24, (scrollMeta.m?.delta || 0) - 8)) {
+      return { skipped: true, reason: 'no-scroll-room' };
+    }
+    return scrollMeta.m;
+  });
+
+  await clickViewTab(page, 'dashboard');
+  await runCase(page, viewport, 'tb.wishDealSteals', async () => {
+    await page.evaluate(async () => {
+      await window.__baklogDrillGeom?.stubItadConnected?.();
+    });
+    await page.waitForTimeout(200);
+    const has = await page.evaluate(() => !!document.querySelector('[data-action="deal-steals"]'));
+    if (!has) return { skipped: true, reason: 'no-deal-steals-btn' };
+    await page.evaluate(() => {
+      document.querySelector('[data-action="deal-steals"]')?.click();
+      window.__baklogDrillGeom.setPendingToolbar?.();
+      window.__baklogDrillGeom.scheduleScrollAfterChromeSettled?.();
+    });
+    await waitIdle(page);
+    await page.waitForFunction(
+      () => (window.__baklogDrillGeom.visibleListKeys?.() || []).length > 0,
+      null,
+      { timeout: 8000 },
+    ).catch(() => {});
+    const scrollMeta = await page.evaluate(async () => {
+      const g = window.__baklogDrillGeom;
+      const n = g.visibleListKeys?.()?.length || 0;
+      const maxScroll = document.documentElement.scrollHeight - window.innerHeight;
+      for (let i = 0; i < 3; i++) {
+        const m = g.measureToolbar();
+        if (m.ok) return { n, maxScroll, m };
+        if (maxScroll < 24) break;
+        g.scrollToToolbar?.();
+        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+        await new Promise((r) => setTimeout(r, 80));
+      }
+      return { n, maxScroll: document.documentElement.scrollHeight - window.innerHeight, m: g.measureToolbar() };
+    });
+    if (scrollMeta.n === 0) return { skipped: true, reason: 'empty-steals-filter' };
+    if (!scrollMeta.m?.ok && scrollMeta.maxScroll < Math.max(24, (scrollMeta.m?.delta || 0) - 8)) {
+      return { skipped: true, reason: 'no-scroll-room' };
+    }
+    return scrollMeta.m;
+  });
+
+  await runCase(page, viewport, 'periph.itchCard', async () => {
+    await clickViewTab(page, 'itch');
+    await waitIdle(page);
+    return page.evaluate(() => {
+      const el = document.getElementById('dashItchCard');
+      if (!el) return { ok: false, reason: 'missing', soft: true };
+      const top = el.getBoundingClientRect().top;
+      const ok = top >= -20 && top <= window.innerHeight;
+      return { ok, soft: true, delta: Math.round(Math.abs(top) * 10) / 10, toolbarTop: Math.round(top) };
+    });
+  });
+
+  await runCase(page, viewport, 'periph.claims', async () => {
+    await clickViewTab(page, 'dashboard');
+    const clicked = await page.evaluate(() => {
+      const mod = document.getElementById('claimableNowModule');
+      if (mod && typeof mod.scrollIntoView === 'function') {
+        mod.scrollIntoView({ behavior: 'instant', block: 'start' });
+        return true;
+      }
+      return false;
+    });
+    if (!clicked) return { skipped: true, reason: 'no-claims-module', soft: true };
+    await page.waitForTimeout(300);
+    return page.evaluate(() => {
+      const el = document.getElementById('claimableNowModule');
+      if (!el) return { ok: false, reason: 'missing', soft: true };
+      const top = el.getBoundingClientRect().top;
+      const ok = top >= -40 && top < window.innerHeight;
+      return { ok, soft: true, delta: Math.round(Math.abs(top) * 10) / 10, toolbarTop: Math.round(top) };
+    });
+  });
+
+  if (viewport.name === 'desk1280' || viewport.name === 'phone390') {
+    await ensureHouseStripe(page);
+    await clickViewTab(page, 'dashboard');
+    await runCase(page, viewport, 'tb.store+house', async () => {
+      await ensureHouseStripe(page);
+      return runToolbarDrill(page, 'dashDrillStore', ['steam']);
+    });
+    await runCase(page, viewport, 'row.focusDeep+house', async () => {
+      await clickViewTab(page, 'library');
+      await ensureHouseStripe(page);
+      const key = await page.evaluate(() => {
+        const keys = window.__baklogDrillGeom.visibleListKeys();
+        return keys[Math.min(70, keys.length - 1)] || null;
+      });
+      if (!key) return { skipped: true, reason: 'no-keys' };
+      return focusKey(page, key);
+    });
+  }
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const report = {
+    capturedAt: new Date().toISOString(),
+    baseUrl: BASE,
+    viewports: VIEWPORTS.map((v) => v.name),
+    cases: [],
+    failures: [],
+    softFailures: [],
+    skipped: 0,
+  };
+
+  try {
+    for (const vp of VIEWPORTS) {
+      console.log(`\n== viewport ${vp.name} ${vp.width}x${vp.height} ==`);
+      const contextOpts = {
+        viewport: { width: vp.width, height: vp.height },
+        actionTimeout: 8000,
+      };
+      if (vp.isMobile) {
+        contextOpts.isMobile = true;
+        contextOpts.hasTouch = true;
+        contextOpts.userAgent = devices['iPhone 12'].userAgent;
+      }
+      const context = await browser.newContext(contextOpts);
+      const page = await context.newPage();
+      page.setDefaultTimeout(8000);
+      await page.addInitScript(() => {
+        try {
+          localStorage.setItem('baklog-perf', '1');
+        } catch (_) { /* noop */ }
+      });
+      await page.goto(`${BASE}/?perf=1`, { waitUntil: 'domcontentloaded', timeout: 30000 });
+      await waitBoot(page);
+      // After auth status settles, pretend ITAD is connected for deal drills.
+      await page.waitForTimeout(600);
+      await page.evaluate(async () => {
+        await window.__baklogDrillGeom?.stubItadConnected?.();
+      });
+
+      const before = report.cases.length;
+      await suiteForViewport(page, vp, report.cases);
+      const slice = report.cases.slice(before);
+      for (const c of slice) {
+        if (c.skipped) report.skipped += 1;
+        else if (!c.ok && c.soft) report.softFailures.push(`${c.viewport}:${c.id}`);
+        else if (!c.ok) report.failures.push(`${c.viewport}:${c.id} ${c.reason || `delta=${c.delta}`}`);
+      }
+      await context.close();
+    }
+  } finally {
+    await browser.close();
+  }
+
+  fs.writeFileSync(OUT, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  console.log(`\nWrote ${OUT}`);
+  console.log(
+    `cases=${report.cases.length} failures=${report.failures.length} soft=${report.softFailures.length} skipped=${report.skipped}`,
+  );
+  if (report.failures.length) {
+    console.error('HARD FAILURES:');
+    for (const f of report.failures) console.error(`  ${f}`);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/generate-perf-profile.mjs
+++ b/scripts/generate-perf-profile.mjs
@@ -49,10 +49,26 @@ for (const { name, count } of SIZES) {
 // Default active catalog: 500 rows (balance for local + CI e2e).
 writeJson('perf/games_steam.json', steamCatalogPayload(500));
 writeJson('perf/games_wishlist.json', {
-  game_count: 20,
-  games: syntheticWishlistGames(20),
+  game_count: 80,
+  games: syntheticWishlistGames(80),
 });
-writeJson('perf/games_itch.json', itchCatalogPayload(12));
+writeJson('perf/games_itch.json', itchCatalogPayload(120));
+
+// Seed ITAD so wishlist on-sale / steals drills have scrollable deal rows.
+const itadByKey = {};
+for (let i = 0; i < 80; i++) {
+  itadByKey[`wishlist:wl-${i}`] = {
+    price: +(9.99 - (i % 7) * 0.5).toFixed(2),
+    cut: 20 + (i % 50),
+    shop: 'Steam',
+    is_historical_low: i % 5 === 0,
+    is_historical_low_year: i % 5 === 0,
+  };
+}
+writeJson('perf/itad_prices.json', {
+  updated_at: '2026-06-25T00:00:00.000Z',
+  by_key: itadByKey,
+});
 
 // Empty stubs for other stores merge path expects.
 for (const store of [

--- a/scripts/start-drill-geometry.ps1
+++ b/scripts/start-drill-geometry.ps1
@@ -1,0 +1,68 @@
+# Sync perf profile fixture, start server, run Playwright drill geometry audit, stop server.
+param(
+    [switch]$SkipBuild,
+    [string]$BaseUrl = 'http://127.0.0.1:8765'
+)
+
+$ErrorActionPreference = 'Stop'
+$root = Split-Path -Parent $PSScriptRoot
+Set-Location $root
+
+$py = Join-Path $root '.venv\Scripts\python.exe'
+if (-not (Test-Path $py)) {
+    Write-Error "Missing $py - create .venv first."
+}
+
+Write-Host '==> generate + sync perf profile fixture (index active=perf)'
+node scripts/generate-perf-profile.mjs
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+$fixtureRoot = Join-Path $root 'tests\fixtures\perf-profile'
+$profilesDir = Join-Path $root 'profiles'
+$destPerf = Join-Path $profilesDir 'perf'
+New-Item -ItemType Directory -Force -Path $destPerf | Out-Null
+Copy-Item -Force (Join-Path $fixtureRoot 'index.json') (Join-Path $profilesDir 'index.json')
+Copy-Item -Recurse -Force (Join-Path $fixtureRoot 'perf\*') $destPerf
+
+if (-not $SkipBuild) {
+    Write-Host '==> npm run build'
+    npm run build
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}
+
+$env:BAKLOG_PROFILE = 'perf'
+$env:BAKLOG_SERVE_BUILT = '1'
+$env:BAKLOG_ADMIN = '0'
+$env:BAKLOG_AUTH_DISABLED = '1'
+
+Write-Host '==> stop stray servers'
+& $py scripts/stop_baklog.py 2>$null | Out-Null
+
+Write-Host '==> starting server (perf profile, BAKLOG_SERVE_BUILT=1, AUTH_DISABLED)'
+$server = Start-Process -FilePath $py -ArgumentList 'server.py' -WorkingDirectory $root -PassThru -WindowStyle Hidden
+
+function Stop-Server {
+    if ($server -and -not $server.HasExited) {
+        & $py scripts/stop_baklog.py 2>$null | Out-Null
+        if (-not $server.HasExited) { Stop-Process -Id $server.Id -Force -ErrorAction SilentlyContinue }
+    }
+}
+
+try {
+    $deadline = (Get-Date).AddSeconds(45)
+    $ready = $false
+    while ((Get-Date) -lt $deadline) {
+        try {
+            $r = Invoke-WebRequest -Uri "$BaseUrl/api/config" -UseBasicParsing -TimeoutSec 2
+            if ($r.StatusCode -eq 200) { $ready = $true; break }
+        } catch { Start-Sleep -Milliseconds 400 }
+    }
+    if (-not $ready) {
+        Write-Error "Server did not become ready at $BaseUrl"
+    }
+
+    Write-Host '==> drill geometry audit'
+    node scripts/drill-geometry-audit.mjs $BaseUrl
+    exit $LASTEXITCODE
+} finally {
+    Stop-Server
+}

--- a/server.py
+++ b/server.py
@@ -55,6 +55,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
+from shared.admin_gate import resolve_admin_enabled
 from shared.built_frontend import (
     is_immutable_built_asset as _is_immutable_built_asset,
 )
@@ -90,7 +91,6 @@ from shared.install_paths import (
     serve_built_frontend,
     static_root,
 )
-from shared.admin_gate import resolve_admin_enabled
 
 if __name__ == "__main__":
     from baklog_fetcher_dispatch import exit_if_fetcher_child

--- a/server.py
+++ b/server.py
@@ -90,6 +90,7 @@ from shared.install_paths import (
     serve_built_frontend,
     static_root,
 )
+from shared.admin_gate import resolve_admin_enabled
 
 if __name__ == "__main__":
     from baklog_fetcher_dispatch import exit_if_fetcher_child
@@ -131,7 +132,10 @@ except ImportError:
 
 HOST = "127.0.0.1"
 PORT = int(os.environ.get("PORT", "8765"))
-ADMIN_ENABLED = os.environ.get("BAKLOG_ADMIN") == "1"
+_ADMIN_OK, _ADMIN_WARN = resolve_admin_enabled(ROOT)
+if _ADMIN_WARN:
+    print(_ADMIN_WARN, file=sys.stderr, flush=True)
+ADMIN_ENABLED = _ADMIN_OK
 FREE_CLAIMS_INPUT_PATH = Path(
     os.environ.get("BAKLOG_FREE_CLAIMS_INPUT", "free-claims.input.json")
 )

--- a/shared/admin_gate.py
+++ b/shared/admin_gate.py
@@ -1,0 +1,38 @@
+"""Decide whether BAKLOG_ADMIN may attach to the active data root."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _truthy(name: str, env: dict[str, str] | None = None) -> bool:
+    src = env if env is not None else os.environ
+    return str(src.get(name, "")).strip().lower() in ("1", "true", "yes")
+
+
+def resolve_admin_enabled(
+    data_root: Path,
+    *,
+    env: dict[str, str] | None = None,
+    default_installed_dir: Path | None = None,
+) -> tuple[bool, str | None]:
+    """Return ``(enabled, stderr_warning_or_None)``.
+
+    Admin is refused when ``BAKLOG_ADMIN=1`` but ``data_root`` is the default
+    installed library folder, unless ``BAKLOG_ADMIN_ALLOW_INSTALLED=1``.
+    """
+    from shared.install_paths import default_frozen_data_dir
+
+    if not _truthy("BAKLOG_ADMIN", env):
+        return False, None
+    installed = (default_installed_dir or default_frozen_data_dir()).resolve()
+    root = Path(data_root).resolve()
+    if root == installed and not _truthy("BAKLOG_ADMIN_ALLOW_INSTALLED", env):
+        msg = (
+            "[admin] BAKLOG_ADMIN=1 refused: data root is the default installed "
+            f"library ({installed}). Use BAKLOG_DATA_DIR for a separate folder "
+            "(e.g. BAKLOG-Dev), or set BAKLOG_ADMIN_ALLOW_INSTALLED=1 to override."
+        )
+        return False, msg
+    return True, None

--- a/tests/drill-anchor.test.js
+++ b/tests/drill-anchor.test.js
@@ -22,6 +22,8 @@ describe("drill-anchor pending scroll target", () => {
     };
     global.cancelAnimationFrame = () => {};
     global.setTimeout = (cb, ms) => {
+      // Keep chrome-settle / verify delays pending so consume can still defer.
+      if (typeof ms === "number" && ms >= 50) return 1;
       if (typeof cb === "function") cb();
       return 1;
     };
@@ -188,7 +190,7 @@ describe("drill-anchor pending scroll target", () => {
     scheduleScrollAfterLayoutSettled();
     expect(hasPendingScrollTarget()).toBe(false);
     expect(document.querySelector("tr.row-focused")).toBeTruthy();
-    expect(scrollToSpy).toHaveBeenCalledTimes(1);
+    expect(scrollToSpy).toHaveBeenCalled();
   });
 
   it("consumePendingScrollTarget scrolls virtual list by row index", async () => {
@@ -204,6 +206,37 @@ describe("drill-anchor pending scroll target", () => {
     expect(scrollToSpy).toHaveBeenCalled();
     const top = scrollToSpy.mock.calls[0][0].top;
     expect(top).toBeGreaterThan(0);
+  });
+
+  it("scheduleScrollAfterChromeSettled forces consume after settle timeout", async () => {
+    const timeouts = [];
+    global.setTimeout = (cb, ms) => {
+      const id = timeouts.length + 1;
+      timeouts.push({ cb, ms, id });
+      return id;
+    };
+    global.clearTimeout = (id) => {
+      const slot = timeouts.find((t) => t.id === id);
+      if (slot) slot.cleared = true;
+    };
+
+    const { state } = await import("../js/state.js");
+    const {
+      setPendingScrollTarget,
+      scheduleScrollAfterChromeSettled,
+      hasPendingScrollTarget,
+    } = await import("../js/table-ui.js");
+    state.activeView = "library";
+    document.getElementById("viewLoadingOverlay")?.classList.add("show");
+    setPendingScrollTarget({ kind: "toolbar" });
+    scheduleScrollAfterChromeSettled();
+    expect(hasPendingScrollTarget()).toBe(true);
+    const settle = timeouts.find((t) => t.ms === 700 && !t.cleared);
+    expect(settle).toBeTruthy();
+    document.getElementById("viewLoadingOverlay")?.classList.remove("show");
+    settle.cb();
+    expect(hasPendingScrollTarget()).toBe(false);
+    expect(scrollToSpy).toHaveBeenCalled();
   });
 });
 
@@ -332,8 +365,47 @@ describe("virtual drill anchor scroll", () => {
     expect(scrollToSpy).toHaveBeenCalled();
     const top = scrollToSpy.mock.calls[0][0]?.top;
     expect(typeof top).toBe("number");
-    // Rect path: rowCenter ~545, target ~545 - 0.42*700 ≈ 251
+    // Rect path: rowCenter ~545; aim = sticky + 0.35*(vh-sticky) ≈ 250 → top ≈ 295
     expect(top).toBeGreaterThan(100);
     expect(top).toBeLessThan(400);
+  });
+
+  it("verify-after-scroll re-scrolls when the keyed row is far from the aim line", async () => {
+    const pendingTimers = [];
+    global.setTimeout = (cb, ms) => {
+      const id = pendingTimers.length + 1;
+      pendingTimers.push({ cb, ms, id });
+      return id;
+    };
+    global.clearTimeout = (id) => {
+      const slot = pendingTimers.find((t) => t.id === id);
+      if (slot) slot.cleared = true;
+    };
+
+    const { state } = await import("../js/state.js");
+    const { setPendingScrollTarget, consumePendingScrollTarget } = await import("../js/table-ui.js");
+    state.activeView = "library";
+    const list = [{ store: "steam", id: "42", name: "Test Game" }];
+    state._visibleList = list;
+
+    const tbody = document.getElementById("tbody");
+    tbody.innerHTML = `<tr data-row-key="steam:42" data-row-index="0" style="height:76px"><td>Game</td></tr>`;
+    const row = tbody.querySelector("tr");
+    let top = 900;
+    Object.defineProperty(row, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({ top, bottom: top + 76, height: 76, left: 0, right: 100, width: 100 }),
+    });
+    Object.defineProperty(win, "scrollY", { configurable: true, value: 0 });
+    Object.defineProperty(win, "innerHeight", { configurable: true, value: 700 });
+
+    scrollToSpy.mockClear();
+    setPendingScrollTarget({ kind: "row", key: "steam:42", smooth: false });
+    expect(consumePendingScrollTarget(list)).toBe(true);
+    expect(scrollToSpy).toHaveBeenCalled();
+    const verify = pendingTimers.find((t) => !t.cleared && t.ms === 50);
+    expect(verify).toBeTruthy();
+    verify.cb();
+    expect(scrollToSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/tests/drill-geometry.test.js
+++ b/tests/drill-geometry.test.js
@@ -1,0 +1,56 @@
+/**
+ * Unit smoke for drill geometry measure helpers (jsdom — not a viewport substitute).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Window } from 'happy-dom';
+
+describe('drill geometry measure API', () => {
+  beforeEach(async () => {
+    const win = new Window({ url: 'http://127.0.0.1:8765/' });
+    global.window = win;
+    global.document = win.document;
+    global.CSS = { escape: (s) => String(s).replace(/"/g, '\\"') };
+    document.body.innerHTML = `
+      <div id="toolbarSection" style="height:40px">toolbar</div>
+      <div id="tableShell">
+        <table class="games-table"><thead></thead>
+          <tbody id="tbody">
+            <tr data-row-key="steam:1" data-row-index="0"><td>A</td></tr>
+          </tbody>
+        </table>
+      </div>
+    `;
+    vi.resetModules();
+  });
+
+  it('measureDrillRowGeometry reports row-missing for unknown keys', async () => {
+    const { measureDrillRowGeometry } = await import('../js/table-ui.js');
+    const m = measureDrillRowGeometry('steam:missing');
+    expect(m.ok).toBe(false);
+    expect(m.reason).toBe('row-missing');
+  });
+
+  it('measureDrillRowGeometry returns shape for painted row', async () => {
+    const row = document.querySelector('tr[data-row-key="steam:1"]');
+    Object.defineProperty(row, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ top: 200, bottom: 276, height: 76, left: 0, right: 100, width: 100 }),
+    });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 700 });
+    Object.defineProperty(window, 'scrollY', { configurable: true, value: 0 });
+    const { measureDrillRowGeometry, DRILL_ROW_VERIFY_THRESHOLD_PX } = await import('../js/table-ui.js');
+    const m = measureDrillRowGeometry('steam:1');
+    expect(m.key).toBe('steam:1');
+    expect(typeof m.delta).toBe('number');
+    expect(typeof m.aim).toBe('number');
+    expect(m.threshold).toBe(DRILL_ROW_VERIFY_THRESHOLD_PX);
+  });
+
+  it('measureDrillToolbarGeometry returns toolbar-missing when hidden', async () => {
+    document.getElementById('toolbarSection')?.classList.add('hidden');
+    const { measureDrillToolbarGeometry } = await import('../js/table-ui.js');
+    const m = measureDrillToolbarGeometry();
+    expect(m.ok).toBe(false);
+    expect(m.reason).toBe('toolbar-missing');
+  });
+});

--- a/tests/error-boundary.test.js
+++ b/tests/error-boundary.test.js
@@ -19,6 +19,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Window } from "happy-dom";
 import {
+  _persistStorageKeyForTests,
   _resetForTests,
   buildBugBundle,
   BUG_REPORT_ENDPOINT,
@@ -31,7 +32,7 @@ import {
   submitBugReport,
 } from "../js/error-boundary.js";
 
-function installWindow({ versionMeta = "9.9.9-test", localStorageRaw } = {}) {
+function installWindow({ versionMeta = "9.9.9-test", localStorageRaw, localStorageKey } = {}) {
   const win = new Window({ url: "http://127.0.0.1:8765/" });
   global.window = win;
   global.document = win.document;
@@ -44,7 +45,7 @@ function installWindow({ versionMeta = "9.9.9-test", localStorageRaw } = {}) {
     win.document.head.appendChild(meta);
   }
   if (localStorageRaw !== undefined) {
-    win.localStorage.setItem("baklog-error-log", localStorageRaw);
+    win.localStorage.setItem(localStorageKey || "baklog-error-log:dev", localStorageRaw);
   }
   return win;
 }
@@ -60,18 +61,22 @@ describe("error-boundary persistence", () => {
   beforeEach(() => {
     installWindow();
     _resetForTests();
+    noteServerRuntime({ frozen: false, runtime_label: "dev" });
   });
   afterEach(() => { teardownWindow(); });
 
-  it("record() persists each entry to localStorage ring", () => {
+  it("record() persists each entry to runtime-scoped localStorage ring", () => {
     reportError(new Error("boom one"));
     reportError(new Error("boom two"));
-    const raw = window.localStorage.getItem("baklog-error-log");
+    const key = _persistStorageKeyForTests();
+    expect(key).toBe("baklog-error-log:dev");
+    const raw = window.localStorage.getItem(key);
     const parsed = JSON.parse(raw);
     expect(Array.isArray(parsed)).toBe(true);
     expect(parsed.length).toBe(2);
     expect(parsed[0].message).toBe("boom one");
     expect(parsed[1].message).toBe("boom two");
+    expect(window.localStorage.getItem("baklog-error-log")).toBeNull();
   });
 
   it("persisted ring is capped at MAX_PERSISTED (200)", () => {
@@ -79,7 +84,7 @@ describe("error-boundary persistence", () => {
     for (let i = 0; i < 210; i += 1) {
       reportError(new Error(`unique-${i}`));
     }
-    const parsed = JSON.parse(window.localStorage.getItem("baklog-error-log"));
+    const parsed = JSON.parse(window.localStorage.getItem(_persistStorageKeyForTests()));
     expect(parsed.length).toBe(200);
     expect(parsed[0].message).toBe("unique-10");
     expect(parsed[199].message).toBe("unique-209");
@@ -92,7 +97,7 @@ describe("error-boundary persistence", () => {
     reportError(err);
     const session = getCapturedErrors();
     expect(session[0].stack.length).toBe(10_000);
-    const persisted = JSON.parse(window.localStorage.getItem("baklog-error-log"));
+    const persisted = JSON.parse(window.localStorage.getItem(_persistStorageKeyForTests()));
     expect(persisted[0].stack.length).toBeLessThanOrEqual(4096 + 30);
     expect(persisted[0].stack).toContain("(... truncated for storage)");
     expect(persisted[0].stack).not.toBe(longStack);
@@ -104,9 +109,20 @@ describe("error-boundary persistence", () => {
     reportError(err);
     expect(getCapturedErrors().length).toBe(1);
     expect(getCapturedErrors()[0].repeats).toBe(2);
-    const persisted = JSON.parse(window.localStorage.getItem("baklog-error-log"));
+    const persisted = JSON.parse(window.localStorage.getItem(_persistStorageKeyForTests()));
     expect(persisted.length).toBe(1);
     expect(persisted[0].repeats).toBe(2);
+  });
+
+  it("keeps separate rings for dev and installed runtimes", () => {
+    reportError(new Error("dev only"));
+    expect(JSON.parse(window.localStorage.getItem("baklog-error-log:dev")).length).toBe(1);
+
+    noteServerRuntime({ frozen: true, runtime_label: "installed" });
+    reportError(new Error("installed only"));
+    expect(JSON.parse(window.localStorage.getItem("baklog-error-log:dev"))[0].message).toBe("dev only");
+    expect(JSON.parse(window.localStorage.getItem("baklog-error-log:installed"))[0].message).toBe("installed only");
+    expect(_persistStorageKeyForTests()).toBe("baklog-error-log:installed");
   });
 });
 
@@ -117,36 +133,40 @@ describe("error-boundary rehydration", () => {
     installWindow();
     _resetForTests();
     installGlobalErrorHandler();
-    noteServerRuntime({ frozen: true });
+    noteServerRuntime({ frozen: true, runtime_label: "installed" });
     reportError(new Error("frozen session error"));
-    const parsed = JSON.parse(window.localStorage.getItem("baklog-error-log"));
+    const parsed = JSON.parse(window.localStorage.getItem("baklog-error-log:installed"));
     expect(parsed[0].server_frozen).toBe(true);
   });
 
-  it("warns when persisted errors mix dev and frozen sessions", () => {
+  it("warns when discarded legacy ring mixed dev and frozen sessions", () => {
     installWindow();
     _resetForTests();
     window.localStorage.setItem(
       "baklog-error-log",
       JSON.stringify([
         { kind: "error", time: 1, message: "dev", stack: "", server_frozen: false, repeats: 1 },
+        { kind: "error", time: 2, message: "frozen", stack: "", server_frozen: true, repeats: 1 },
       ]),
     );
     installGlobalErrorHandler();
+    noteServerRuntime({ frozen: true, runtime_label: "installed" });
+    expect(window.localStorage.getItem("baklog-error-log")).toBeNull();
     const bundle = buildBugBundle({ server: { frozen: true } });
     expect(bundle.warnings?.length).toBe(1);
     expect(bundle.warnings[0]).toMatch(/dev and frozen/);
   });
 
-  it("installGlobalErrorHandler rehydrates persisted ring from localStorage", () => {
+  it("noteServerRuntime rehydrates persisted ring from runtime-scoped key", () => {
     const seeded = JSON.stringify([
       { kind: "reported", time: 1, message: "from a prior session", stack: "", source: "", lineno: 0, colno: 0, name: "Error" },
     ]);
-    installWindow({ localStorageRaw: seeded });
+    installWindow({ localStorageRaw: seeded, localStorageKey: "baklog-error-log:dev" });
     _resetForTests();
     // Re-seed because _resetForTests clears storage.
-    window.localStorage.setItem("baklog-error-log", seeded);
+    window.localStorage.setItem("baklog-error-log:dev", seeded);
     installGlobalErrorHandler();
+    noteServerRuntime({ frozen: false, runtime_label: "dev" });
     const bundle = buildBugBundle();
     expect(bundle.errors.persisted.length).toBe(1);
     expect(bundle.errors.persisted[0].message).toBe("from a prior session");
@@ -155,27 +175,29 @@ describe("error-boundary rehydration", () => {
   it("corrupt localStorage raw payload is silently ignored", () => {
     installWindow();
     _resetForTests();
-    window.localStorage.setItem("baklog-error-log", "{not valid json");
+    window.localStorage.setItem("baklog-error-log:dev", "{not valid json");
     installGlobalErrorHandler();
+    noteServerRuntime({ frozen: false, runtime_label: "dev" });
     const bundle = buildBugBundle();
     expect(bundle.errors.persisted).toEqual([]);
   });
 
-  it("prunes stale and ignored entries from persisted ring on install", () => {
+  it("prunes stale and ignored entries from persisted ring on runtime note", () => {
     const seeded = JSON.stringify([
       { kind: "error", time: 1, message: "ResizeObserver loop completed with undelivered notifications.", stack: "", source: "", lineno: 0, colno: 0, name: "Error" },
       { kind: "unhandledrejection", time: 2, message: "authStatus is not defined", stack: "", source: "", lineno: 0, colno: 0, name: "ReferenceError" },
       { kind: "unhandledrejection", time: 4, message: "queue wait timeout", stack: "", source: "", lineno: 0, colno: 0, name: "Error" },
       { kind: "reported", time: 3, message: "still relevant", stack: "", source: "", lineno: 0, colno: 0, name: "Error" },
     ]);
-    installWindow({ localStorageRaw: seeded });
+    installWindow({ localStorageRaw: seeded, localStorageKey: "baklog-error-log:dev" });
     _resetForTests();
-    window.localStorage.setItem("baklog-error-log", seeded);
+    window.localStorage.setItem("baklog-error-log:dev", seeded);
     installGlobalErrorHandler();
+    noteServerRuntime({ frozen: false, runtime_label: "dev" });
     const bundle = buildBugBundle();
     expect(bundle.errors.persisted.length).toBe(1);
     expect(bundle.errors.persisted[0].message).toBe("still relevant");
-    const stored = JSON.parse(window.localStorage.getItem("baklog-error-log"));
+    const stored = JSON.parse(window.localStorage.getItem("baklog-error-log:dev"));
     expect(stored.length).toBe(1);
     expect(stored[0].message).toBe("still relevant");
   });
@@ -192,7 +214,7 @@ describe("error-boundary ignored noise", () => {
   it("does not capture ResizeObserver loop warnings", () => {
     reportError(new Error("ResizeObserver loop completed with undelivered notifications."));
     expect(getCapturedErrors().length).toBe(0);
-    expect(window.localStorage.getItem("baklog-error-log")).toBeNull();
+    expect(window.localStorage.getItem("baklog-error-log:dev")).toBeNull();
     const bundle = buildBugBundle();
     expect(bundle.errors.session.length).toBe(0);
     expect(bundle.errors.persisted.length).toBe(0);
@@ -204,6 +226,7 @@ describe("error-boundary stale-chunk recovery", () => {
     installWindow();
     _resetForTests();
     installGlobalErrorHandler();
+    noteServerRuntime({ frozen: false, runtime_label: "dev" });
   });
   afterEach(() => { teardownWindow(); });
 
@@ -214,7 +237,7 @@ describe("error-boundary stale-chunk recovery", () => {
     err.name = "TypeError";
     reportError(err);
     expect(getCapturedErrors().length).toBe(0);
-    expect(window.localStorage.getItem("baklog-error-log")).toBeNull();
+    expect(window.localStorage.getItem("baklog-error-log:dev")).toBeNull();
     // Reload guard timestamp is recorded so a second failure won't loop.
     expect(window.sessionStorage.getItem("baklog-stale-chunk-reload")).not.toBeNull();
   });
@@ -226,7 +249,7 @@ describe("error-boundary stale-chunk recovery", () => {
     expect(getCapturedErrors().length).toBe(1);
   });
 
-  it("prunes stale-chunk + now-fixed errors from the persisted ring on install", () => {
+  it("prunes stale-chunk + now-fixed errors from the persisted ring on runtime note", () => {
     const seeded = JSON.stringify([
       { kind: "unhandledrejection", time: 1, message: "Failed to fetch dynamically imported module: /dist/js/chunks/sponsored-deals-Y7ODCHBG.js", stack: "", source: "", lineno: 0, colno: 0, name: "TypeError" },
       { kind: "unhandledrejection", time: 2, message: "eff is not defined", stack: "", source: "", lineno: 0, colno: 0, name: "ReferenceError" },
@@ -237,10 +260,11 @@ describe("error-boundary stale-chunk recovery", () => {
       { kind: "network", time: 7, message: "Server unreachable: BAKLOG is not responding at /api/update/apply-result. Check that the server is running.", stack: "", source: "fetchWithAuthRetry", lineno: 0, colno: 0, name: "NetworkError" },
       { kind: "reported", time: 8, message: "still relevant", stack: "", source: "", lineno: 0, colno: 0, name: "Error" },
     ]);
-    installWindow({ localStorageRaw: seeded });
+    installWindow({ localStorageRaw: seeded, localStorageKey: "baklog-error-log:dev" });
     _resetForTests();
-    window.localStorage.setItem("baklog-error-log", seeded);
+    window.localStorage.setItem("baklog-error-log:dev", seeded);
     installGlobalErrorHandler();
+    noteServerRuntime({ frozen: false, runtime_label: "dev" });
     const bundle = buildBugBundle();
     expect(bundle.errors.persisted.length).toBe(1);
     expect(bundle.errors.persisted[0].message).toBe("still relevant");

--- a/tests/fixtures/synthetic-games.js
+++ b/tests/fixtures/synthetic-games.js
@@ -21,12 +21,15 @@ export function syntheticSteamGames(count, opts = {}) {
       appid: id,
       name: `${prefix} ${String.fromCharCode(65 + (i % 26))}${i}`,
       status: i % 7 === 0 ? 'completed' : i % 5 === 0 ? 'playing' : 'unplayed',
-      hltb_main: (i % 40) + 1,
+      // Match live Steam/HLTB fetcher field names used by table-query filters.
+      hltb_main_hours: (i % 40) + 1,
       steam_review_percent: 60 + (i % 40),
       release_date: `20${10 + (i % 15)}-${String((i % 12) + 1).padStart(2, '0')}-15`,
       genres: [GENRES[i % GENRES.length], GENRES[(i + 2) % GENRES.length]],
       tags: [TAGS[i % TAGS.length]],
       playtime_forever: i * 3,
+      coop_online: i % 4 === 0,
+      coop_local: i % 6 === 0,
     });
   }
   return games;
@@ -58,6 +61,9 @@ export function syntheticWishlistGames(count) {
       wishlist_store: 'steam',
       store_target: 'steam',
       tracking_status: 'active',
+      // Fallback deal fields when ITAD is absent (table-query getDealInfo).
+      discount_percent: 20 + (i % 50),
+      price_overview: { final: 999 + i, initial: 1999 + i, currency: 'USD' },
     });
   }
   return games;
@@ -77,8 +83,11 @@ export function syntheticItchGames(count) {
       itch_id: 9000 + i,
       name: `Itch Jam ${i}`,
       type: 'game',
+      classification: 'game',
       playtime_minutes: 0,
       publisher: 'Perf Fixture',
+      genres: [GENRES[i % GENRES.length]],
+      steam_review_percent: 70 + (i % 20),
     });
   }
   return games;

--- a/tests/test_admin_gate.py
+++ b/tests/test_admin_gate.py
@@ -1,0 +1,52 @@
+"""Tests for admin attach gate vs default installed data root."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from shared.admin_gate import resolve_admin_enabled
+
+
+def test_admin_off_when_env_unset(tmp_path: Path) -> None:
+    ok, warn = resolve_admin_enabled(tmp_path, env={})
+    assert ok is False
+    assert warn is None
+
+
+def test_admin_ok_on_non_installed_root(tmp_path: Path) -> None:
+    installed = tmp_path / "BAKLOG-Data"
+    installed.mkdir()
+    dev = tmp_path / "BAKLOG-Dev"
+    dev.mkdir()
+    ok, warn = resolve_admin_enabled(
+        dev,
+        env={"BAKLOG_ADMIN": "1"},
+        default_installed_dir=installed,
+    )
+    assert ok is True
+    assert warn is None
+
+
+def test_admin_refused_on_default_installed_root(tmp_path: Path) -> None:
+    installed = tmp_path / "BAKLOG-Data"
+    installed.mkdir()
+    ok, warn = resolve_admin_enabled(
+        installed,
+        env={"BAKLOG_ADMIN": "1"},
+        default_installed_dir=installed,
+    )
+    assert ok is False
+    assert warn is not None
+    assert "BAKLOG_ADMIN_ALLOW_INSTALLED" in warn
+
+
+def test_admin_allow_installed_override(tmp_path: Path) -> None:
+    installed = tmp_path / "BAKLOG-Data"
+    installed.mkdir()
+    ok, warn = resolve_admin_enabled(
+        installed,
+        env={"BAKLOG_ADMIN": "1", "BAKLOG_ADMIN_ALLOW_INSTALLED": "1"},
+        default_installed_dir=installed,
+    )
+    assert ok is True
+    assert warn is None


### PR DESCRIPTION
## Summary
- Partition localhost error logs by runtime (dev / installed / portable) so mixed sessions no longer share one key.
- Refuse admin console on the default installed data root unless BAKLOG_ADMIN_ALLOW_INSTALLED=1.
- Harden library drill landing: verify-after-scroll, toolbar verify, paint table before toolbar scroll, wishlist deal toolbar pending.
- Add Playwright drill geometry audit across 9 viewports (
pm run test:drill-geometry, scripts/start-drill-geometry.ps1).

## Test plan
- [x] 
pm test (Vitest including drill-geometry + drill-anchor)
- [x] pytest tests/test_admin_gate.py
- [x] .\scripts\start-drill-geometry.ps1 — 247 cases, 0 hard failures
- [ ] CI green on PR

Made with [Cursor](https://cursor.com)