### PR TITLE
feat: open beta landing with download link in confirmation email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,14 +30,15 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [Unreleased]
 
+### Changed
+
+- baklog.app is open beta: signup email still collected, confirmation includes the GitHub Releases download link.
+- Maintainer admin console will not attach to the default installed library folder unless you explicitly allow it. Prefer a separate data folder for admin work.
+
 ### Fixed
 
 - Dashboard and picks jumps to a library row re-check the target after scroll so the wrong game is not left under the sticky header on phone and mid-width layouts.
 - Dev and installed runs no longer share one browser error history when both use the same localhost origin; each runtime keeps its own log.
-
-### Changed
-
-- Maintainer admin console will not attach to the default installed library folder unless you explicitly allow it. Prefer a separate data folder for admin work.
 
 ## [0.9.00] - 2026-08-18
 

--- a/landing/README.md
+++ b/landing/README.md
@@ -1,17 +1,17 @@
 # BAKLOG landing page
 
-Static blue-on-blue landing page with an email waitlist, deployed to Vercel.
+Static blue-on-blue landing page with an open-beta email signup, deployed to Vercel.
 
 ## Files
 
-- `index.html` — page markup, inline base CSS, waitlist form shell, inline Google tag (`G-88L32JZQDH`) in `<head>`. No build step.
+- `index.html` — page markup, inline base CSS, open-beta signup form shell, inline Google tag (`G-88L32JZQDH`) in `<head>`. No build step.
 - `llms.txt` - plain-text site summary for AI crawlers.
 FAQ JSON-LD must match the `#faq` details list via `npm run check:landing-seo`. Attended OpenSEO / GSC / GA: `.cursor/rules/seo-operator.mdc`.
-- `main.js` — footer year, non-blocking font load, waitlist submit handler.
+- `main.js` — footer year, non-blocking font load, open-beta signup submit handler.
 - `demo.css` — mega hero dashboard styles (spotlight, marquee, ribbon charts, funnel sections).
 - `demo.js` — interactive demo (dummy data, count-up, spotlight rotation, Chart.js donuts).
 - `assets/sample/*.{webp,png}` — fictional game covers for the spotlight carousel.
-- `api/subscribe.js` — Vercel serverless function; logs waitlist signups (optional Supabase), emails you via [Resend](https://resend.com), and sends the signer a confirmation auto-reply.
+- `api/subscribe.js` — Vercel serverless function; logs signups (optional Supabase, stamps `invited_at` on insert), emails you via [Resend](https://resend.com), and sends the signer a confirmation with the GitHub Releases download link.
 - `api/auth-signup-notify.js` — Vercel serverless function; receives Supabase Database Webhooks on `auth.users` INSERT and emails you when someone creates a BAKLOG account in the app.
 - `api/auth-config.js` — read-only public Supabase URL + anon key for hosted auth pages (`/auth-reset`).
 - `auth-confirmed.html` + `auth-confirmed.js` — email confirmation landing page (works from phone; no local server required).

--- a/landing/api/subscribe.js
+++ b/landing/api/subscribe.js
@@ -1,9 +1,10 @@
-// Vercel serverless function: logs each waitlist signup (optional Supabase),
-// emails the founder via Resend, then sends the signer a confirmation auto-reply.
+// Vercel serverless function: logs each open-beta signup (optional Supabase),
+// emails the founder via Resend, then sends the signer a confirmation with the
+// GitHub Releases download link.
 // Requires env vars: RESEND_API_KEY, NOTIFY_TO, NOTIFY_FROM.
 // Production also requires KV_REST_API_* or UPSTASH_REDIS_REST_* (distributed rate limit).
 // Optional: WELCOME_FROM (defaults to NOTIFY_FROM), WELCOME_REPLY_TO (defaults to NOTIFY_TO),
-// SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY (durable waitlist log).
+// SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY (durable waitlist log; stamps invited_at on insert).
 
 import { checkRateLimit } from "./_rate-limit.js";
 
@@ -45,7 +46,13 @@ async function logToSupabase({ email, ip, time }) {
       "Content-Type": "application/json",
       Prefer: "resolution=ignore-duplicates,return=minimal",
     },
-    body: JSON.stringify({ email, ip, source: "landing", created_at: time }),
+    body: JSON.stringify({
+      email,
+      ip,
+      source: "landing",
+      created_at: time,
+      invited_at: time,
+    }),
   });
   if (r.ok || r.status === 409) {
     // 409 = duplicate email on unique constraint; already on the list.
@@ -71,19 +78,27 @@ async function sendEmail(apiKey, payload) {
   return r;
 }
 
-const CONFIRM_SUBJECT = "You're on the BAKLOG invite list";
+const RELEASE_URL = "https://github.com/Ogrods/BAKLOG/releases/latest";
 
-const CONFIRM_TEXT = `Thanks for requesting a BAKLOG invite.
+const CONFIRM_SUBJECT = "Your BAKLOG open beta download";
 
-You're on the list. BAKLOG is in invite-only beta and we're onboarding in small waves, so you'll get a follow-up here when your spot opens up.
+const CONFIRM_TEXT = `Thanks for signing up for BAKLOG.
 
-A quick refresher on what you signed up for:
+The open beta is available now. Download it here:
+${RELEASE_URL}
+
+Quick start:
+- Grab BAKLOG-Setup.exe (or the portable zip) from the release page.
+- If Windows SmartScreen warns about an unknown publisher, click More info, then Run anyway. The build is not code-signed yet.
+- Launch BAKLOG, open the Connections tab, and connect the stores you use.
+
+A quick refresher:
 - One honest backlog across every store - 12 libraries and 8 wishlists, all on your machine.
 - Local-first: no project-owned server for your catalog; credentials encrypt to disk with your OS keychain; store fetches run from your IP.
-- MIT source on GitHub if you want to verify before install; invite beta is packaged builds on the same tree.
+- MIT source on GitHub if you want to verify before install; the beta is packaged builds on the same tree.
 - Claimable Now surfaces free giveaways; importing your library stays free forever.
 
-No action needed right now - just keep an eye on your inbox.
+Hit a snag? Reply to this email or use Report a bug in the app menu.
 
 - The BAKLOG team
 https://baklog.app`;
@@ -92,16 +107,25 @@ const CONFIRM_HTML = `<!doctype html>
 <html>
   <body style="margin:0;background:#0f172a;font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#e2e8f0;">
     <div style="max-width:520px;margin:0 auto;padding:32px 24px;">
-      <h1 style="font-size:20px;margin:0 0 16px;color:#f8fafc;">You're on the BAKLOG invite list</h1>
-      <p style="font-size:15px;line-height:1.6;margin:0 0 16px;">Thanks for requesting a BAKLOG invite. BAKLOG is in invite-only beta and we're onboarding in small waves, so you'll get a follow-up here when your spot opens up.</p>
-      <p style="font-size:15px;line-height:1.6;margin:0 0 8px;">A quick refresher on what you signed up for:</p>
+      <h1 style="font-size:20px;margin:0 0 16px;color:#f8fafc;">Your BAKLOG open beta download</h1>
+      <p style="font-size:15px;line-height:1.6;margin:0 0 16px;">Thanks for signing up. The open beta is available now.</p>
+      <p style="margin:0 0 20px;">
+        <a href="${RELEASE_URL}" style="display:inline-block;background:#38bdf8;color:#0f172a;font-weight:600;text-decoration:none;padding:10px 18px;border-radius:8px;">Download the beta</a>
+      </p>
+      <p style="font-size:15px;line-height:1.6;margin:0 0 8px;">Quick start:</p>
+      <ul style="font-size:15px;line-height:1.6;margin:0 0 16px;padding-left:20px;">
+        <li>Grab BAKLOG-Setup.exe (or the portable zip) from the release page.</li>
+        <li>If Windows SmartScreen warns about an unknown publisher, click More info, then Run anyway. The build is not code-signed yet.</li>
+        <li>Launch BAKLOG, open the Connections tab, and connect the stores you use.</li>
+      </ul>
+      <p style="font-size:15px;line-height:1.6;margin:0 0 8px;">A quick refresher:</p>
       <ul style="font-size:15px;line-height:1.6;margin:0 0 16px;padding-left:20px;">
         <li>One honest backlog across every store - 12 libraries and 8 wishlists, all on your machine.</li>
         <li>Local-first: no project-owned server for your catalog; credentials encrypt to disk with your OS keychain; store fetches run from your IP.</li>
-        <li>MIT source on GitHub if you want to verify before install; invite beta is packaged builds on the same tree.</li>
+        <li>MIT source on GitHub if you want to verify before install; the beta is packaged builds on the same tree.</li>
         <li>Claimable Now surfaces free giveaways; importing your library stays free forever.</li>
       </ul>
-      <p style="font-size:15px;line-height:1.6;margin:0 0 24px;">No action needed right now - just keep an eye on your inbox.</p>
+      <p style="font-size:15px;line-height:1.6;margin:0 0 24px;">Hit a snag? Reply to this email or use Report a bug in the app menu.</p>
       <p style="font-size:14px;line-height:1.6;margin:0;color:#94a3b8;">- The BAKLOG team<br /><a href="https://baklog.app" style="color:#38bdf8;">baklog.app</a></p>
     </div>
   </body>
@@ -179,7 +203,7 @@ export default {
         from,
         to,
         reply_to: email,
-        subject: `New BAKLOG invite request: ${email}`,
+        subject: `New BAKLOG open beta signup: ${email}`,
         text: `New signup: ${email}\nTime: ${signupTime}\nDurable log: ${durableLog}`,
       });
     } catch (err) {

--- a/landing/index.html
+++ b/landing/index.html
@@ -12,7 +12,7 @@
     gtag('config', 'G-88L32JZQDH');
   </script>
   <title>BAKLOG: One honest backlog across every store</title>
-  <meta name="description" content="One honest backlog across every store. Free forever to import. 12 libraries and 8 wishlists on your machine, no telemetry by default. Invite-only." />
+  <meta name="description" content="One honest backlog across every store. Free forever to import. 12 libraries and 8 wishlists on your machine, no telemetry by default. Open beta." />
   <meta name="theme-color" content="#0f172a" />
   <meta name="robots" content="index, follow" />
   <meta name="author" content="BAKLOG" />
@@ -29,14 +29,14 @@
   <meta property="og:locale" content="en_US" />
   <meta property="og:url" content="https://baklog.app/" />
   <meta property="og:title" content="BAKLOG: One honest backlog across every store" />
-  <meta property="og:description" content="One honest backlog across every store. Free forever · 12 libraries and 8 wishlists · runs on your machine. Watch 0 → 2,000+ games in ~90 seconds. Open source (MIT). Invite-only early access." />
+  <meta property="og:description" content="One honest backlog across every store. Free forever · 12 libraries and 8 wishlists · runs on your machine. Watch 0 → 2,000+ games in ~90 seconds. Open source (MIT). Open beta." />
   <meta property="og:image" content="https://baklog.app/assets/og.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
   <meta property="og:image:alt" content="BAKLOG: one honest backlog across every store" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="BAKLOG: One honest backlog across every store" />
-  <meta name="twitter:description" content="One honest backlog across every store. Free forever · 12 libraries and 8 wishlists · runs on your machine. Watch 0 → 2,000+ games in ~90 seconds. Open source (MIT). Invite-only early access." />
+  <meta name="twitter:description" content="One honest backlog across every store. Free forever · 12 libraries and 8 wishlists · runs on your machine. Watch 0 → 2,000+ games in ~90 seconds. Open source (MIT). Open beta." />
   <meta name="twitter:image" content="https://baklog.app/assets/og.png" />
   <meta name="twitter:image:alt" content="BAKLOG: one honest backlog across every store" />
 
@@ -55,7 +55,7 @@
   <!-- Structured data: inline. data blocks aren't executed so CSP script-src
        does not apply. Keep FAQPage in sync with the #faq details list
        (npm run check:landing-seo). -->
-  <script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"SoftwareApplication","name":"BAKLOG","applicationCategory":"GameApplication","operatingSystem":"Windows, macOS, Linux","url":"https://baklog.app/","codeRepository":"https://github.com/Ogrods/BAKLOG","license":"https://opensource.org/licenses/MIT","description":"One honest backlog across every store. Free forever to import; 12 libraries and 8 wishlists; runs on your machine. Watch 0 → 2,000+ games climb in ~90 seconds. Claimable Now helps you never miss a free game again. Open source (MIT). Optional paid tier to support BAKLOG. Invite-only early access.","offers":[{"@type":"Offer","name":"Free","price":"0","priceCurrency":"USD"},{"@type":"Offer","name":"Support BAKLOG","price":"5","priceCurrency":"USD","billingDuration":"P1M"}],"publisher":{"@type":"Organization","name":"BAKLOG","url":"https://baklog.app/"}},{"@type":"WebSite","name":"BAKLOG","url":"https://baklog.app/","publisher":{"@type":"Organization","name":"BAKLOG","url":"https://baklog.app/"}},{"@type":"FAQPage","url":"https://baklog.app/#faq","mainEntity":[{"@type":"Question","name":"Is it safe?","acceptedAnswer":{"@type":"Answer","text":"Your credentials stay encrypted on your machine (AES-256-GCM, OS keychain). Store sign-in runs in your own local browser, not a container and not a shared cloud vault. Fetches go straight from your PC to each storefront, from your IP. There is no BAKLOG server holding your library. The full app is open source (MIT) with a published threat model that lists what we defend and what we do not (local malware, storefront ToS, and the rest). baklog.app never receives your catalog. The marketing site uses Google Analytics for anonymous page views. Waitlist email if you request an invite, and a bug report only if you click Send."}},{"@type":"Question","name":"Is it open source?","acceptedAnswer":{"@type":"Answer","text":"Yes. BAKLOG is released under the MIT license. The full app (server, fetchers, auth, and dashboard) lives in the public GitHub repo: clone it and run from source today. No hidden builds, no closed-source telemetry layer. The invite beta is packaged builds on top of the same tree. Optional paid features are conveniences on top of the same open codebase, not a fork of your data into our cloud."}},{"@type":"Question","name":"Is it free?","acceptedAnswer":{"@type":"Answer","text":"Yes. Importing your library across every store is free forever: auto-fetch on connect, full dashboard, ownership-aware deals (with sponsored slots in deal cards on the free tier), cached trophy summary % (no on-demand deep re-pull), and Claimable Now for full-game giveaways. Store refresh on the free tier is one store at a time, on demand; auto-refresh quietly updates one stale store every ~30 min while the app is open. An optional paid tier adds more - see Support BAKLOG. Nothing you use free today moves behind paywall."}},{"@type":"Question","name":"What's in the paid tier?","acceptedAnswer":{"@type":"Answer","text":"Optional Pro support adds a few conveniences today: sponsored deal cards removed, scheduled stale-store refresh without keeping the app open, deep achievement/trophy sync (full on-demand re-pull; free tier shows cached % only), a bonus claimables feed for DLC, add-ons, and in-game bonuses filtered out of the free feed, and queued bulk refresh (queue every stale store from Fetcher health). Coming soon: cloud sync across machines and deal/watchlist alerts. Support BAKLOG or Support BAKLOG (yearly). The free tier keeps everything you need to import, browse, and decide what to play next."}},{"@type":"Question","name":"What's the difference between free and paid refresh?","acceptedAnswer":{"@type":"Answer","text":"On the free tier, you refresh one store at a time: click a fetcher chip, wait for it to finish, click the next. Auto-refresh (on by default) quietly updates one stale store every ~30 minutes while the app is open. Pro supporters get scheduled refresh that runs even when the app is closed (tray or OS scheduler). Queued bulk refresh (one action queues every stale store back-to-back from Fetcher health) is live on Pro. Your credentials and data still stay on your machine. Only the convenience layer changes."}},{"@type":"Question","name":"Does BAKLOG show me free games to claim?","acceptedAnswer":{"@type":"Answer","text":"Never miss a free game again. Claimable Now is a maintainer-curated free-game feed that aggregates active giveaways from Epic, GOG, Steam, Prime, and more, sourced via GamerPower, IsThereAnyDeal, and the Epic Store, right in your dashboard. A notification banner alerts you when new drops land. The feed is ownership-aware: it skips games you already own somewhere in your library. Included on the free tier. For Epic mobile claims and other free entry paths, see starting from zero."}},{"@type":"Question","name":"I don't really own games yet. Is BAKLOG still for me?","acceptedAnswer":{"@type":"Answer","text":"Yes. You don't need a paid library to start. See starting from zero for free entry paths: Epic, Prime, GOG, free-to-play hits, and more. BAKLOG tracks your collection from the first claim, and Claimable Now aggregates the week's free drops in your dashboard."}},{"@type":"Question","name":"Do I have to refresh it?","acceptedAnswer":{"@type":"Answer","text":"Not manually. When you connect a store, BAKLOG auto-fetches its library. While the app is open, auto-refresh for stores older than 24h is on by default (Connections). ITAD deal prices refresh on a schedule. On the free tier there's no background sync while closed. Pro supporters get scheduled refresh while closed; cloud sync between machines is a coming Pro perk."}},{"@type":"Question","name":"Why is my count different from what the store shows?","acceptedAnswer":{"@type":"Answer","text":"Stores pad your library with things that aren't games: DLC skins, soundtracks, wallpapers, betas, and store apps. BAKLOG filters those out automatically so the number you see is real games, not shelf clutter. That filter is built-in and you never have to manage it. Separately, you can hide any game you just don't want to see and restore it later from the Hidden games panel."}},{"@type":"Question","name":"Does it upload my library?","acceptedAnswer":{"@type":"Answer","text":"No. Your catalog and credentials stay in your local profile folder. Store fetches go straight from your PC to each storefront. baklog.app never receives your library JSON. The marketing site uses Google Analytics for anonymous page views. Waitlist email if you request an invite, a bug report only if you click Send, and a public free-games metadata feed."}},{"@type":"Question","name":"Can I run it without waiting for an invite?","acceptedAnswer":{"@type":"Answer","text":"Yes. Clone github.com/Ogrods/BAKLOG and run from source on Windows, macOS, or Linux. The invite beta is optional packaged builds and update delivery on top of the same MIT tree."}},{"@type":"Question","name":"How is this different from Playnite?","acceptedAnswer":{"@type":"Answer","text":"Playnite is a launcher: it opens games and unifies your library view. BAKLOG is a backlog dashboard: what to play next, cross-store dedupe, wishlist deal radar, and ownership-aware sale checks. Many people use both. BAKLOG is not trying to replace your launcher."}},{"@type":"Question","name":"Isn't scraping against the rules?","acceptedAnswer":{"@type":"Answer","text":"BAKLOG automates requests you could make yourself, in your own browser, with your own credentials, on your own machine. Each storefront sees normal traffic from your IP, as you."}},{"@type":"Question","name":"Why invite-only right now?","acceptedAnswer":{"@type":"Answer","text":"We are onboarding in small waves so we can fix what breaks on real setups before opening the doors. Request an invite and you are in line for the next wave."}},{"@type":"Question","name":"Do you sell my data?","acceptedAnswer":{"@type":"Answer","text":"No. BAKLOG has no business model built on your library. We do not collect, host, or sell catalog data. There is no server holding it to sell. Optional invite login (Supabase) stores your email only; games stay local."}}]}]}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"SoftwareApplication","name":"BAKLOG","applicationCategory":"GameApplication","operatingSystem":"Windows, macOS, Linux","url":"https://baklog.app/","codeRepository":"https://github.com/Ogrods/BAKLOG","license":"https://opensource.org/licenses/MIT","description":"One honest backlog across every store. Free forever to import; 12 libraries and 8 wishlists; runs on your machine. Watch 0 → 2,000+ games climb in ~90 seconds. Claimable Now helps you never miss a free game again. Open source (MIT). Optional paid tier to support BAKLOG. Open beta.","offers":[{"@type":"Offer","name":"Free","price":"0","priceCurrency":"USD"},{"@type":"Offer","name":"Support BAKLOG","price":"5","priceCurrency":"USD","billingDuration":"P1M"}],"publisher":{"@type":"Organization","name":"BAKLOG","url":"https://baklog.app/"}},{"@type":"WebSite","name":"BAKLOG","url":"https://baklog.app/","publisher":{"@type":"Organization","name":"BAKLOG","url":"https://baklog.app/"}},{"@type":"FAQPage","url":"https://baklog.app/#faq","mainEntity":[{"@type":"Question","name":"Is it safe?","acceptedAnswer":{"@type":"Answer","text":"Your credentials stay encrypted on your machine (AES-256-GCM, OS keychain). Store sign-in runs in your own local browser, not a container and not a shared cloud vault. Fetches go straight from your PC to each storefront, from your IP. There is no BAKLOG server holding your library. The full app is open source (MIT) with a published threat model that lists what we defend and what we do not (local malware, storefront ToS, and the rest). baklog.app never receives your catalog. The marketing site uses Google Analytics for anonymous page views. Signup email if you get the beta, and a bug report only if you click Send."}},{"@type":"Question","name":"Is it open source?","acceptedAnswer":{"@type":"Answer","text":"Yes. BAKLOG is released under the MIT license. The full app (server, fetchers, auth, and dashboard) lives in the public GitHub repo: clone it and run from source today. No hidden builds, no closed-source telemetry layer. The open beta is packaged builds on top of the same tree. Optional paid features are conveniences on top of the same open codebase, not a fork of your data into our cloud."}},{"@type":"Question","name":"Is it free?","acceptedAnswer":{"@type":"Answer","text":"Yes. Importing your library across every store is free forever: auto-fetch on connect, full dashboard, ownership-aware deals (with sponsored slots in deal cards on the free tier), cached trophy summary % (no on-demand deep re-pull), and Claimable Now for full-game giveaways. Store refresh on the free tier is one store at a time, on demand; auto-refresh quietly updates one stale store every ~30 min while the app is open. An optional paid tier adds more - see Support BAKLOG. Nothing you use free today moves behind paywall."}},{"@type":"Question","name":"What's in the paid tier?","acceptedAnswer":{"@type":"Answer","text":"Optional Pro support adds a few conveniences today: sponsored deal cards removed, scheduled stale-store refresh without keeping the app open, deep achievement/trophy sync (full on-demand re-pull; free tier shows cached % only), a bonus claimables feed for DLC, add-ons, and in-game bonuses filtered out of the free feed, and queued bulk refresh (queue every stale store from Fetcher health). Coming soon: cloud sync across machines and deal/watchlist alerts. Support BAKLOG or Support BAKLOG (yearly). The free tier keeps everything you need to import, browse, and decide what to play next."}},{"@type":"Question","name":"What's the difference between free and paid refresh?","acceptedAnswer":{"@type":"Answer","text":"On the free tier, you refresh one store at a time: click a fetcher chip, wait for it to finish, click the next. Auto-refresh (on by default) quietly updates one stale store every ~30 minutes while the app is open. Pro supporters get scheduled refresh that runs even when the app is closed (tray or OS scheduler). Queued bulk refresh (one action queues every stale store back-to-back from Fetcher health) is live on Pro. Your credentials and data still stay on your machine. Only the convenience layer changes."}},{"@type":"Question","name":"Does BAKLOG show me free games to claim?","acceptedAnswer":{"@type":"Answer","text":"Never miss a free game again. Claimable Now is a maintainer-curated free-game feed that aggregates active giveaways from Epic, GOG, Steam, Prime, and more, sourced via GamerPower, IsThereAnyDeal, and the Epic Store, right in your dashboard. A notification banner alerts you when new drops land. The feed is ownership-aware: it skips games you already own somewhere in your library. Included on the free tier. For Epic mobile claims and other free entry paths, see starting from zero."}},{"@type":"Question","name":"I don't really own games yet. Is BAKLOG still for me?","acceptedAnswer":{"@type":"Answer","text":"Yes. You don't need a paid library to start. See starting from zero for free entry paths: Epic, Prime, GOG, free-to-play hits, and more. BAKLOG tracks your collection from the first claim, and Claimable Now aggregates the week's free drops in your dashboard."}},{"@type":"Question","name":"Do I have to refresh it?","acceptedAnswer":{"@type":"Answer","text":"Not manually. When you connect a store, BAKLOG auto-fetches its library. While the app is open, auto-refresh for stores older than 24h is on by default (Connections). ITAD deal prices refresh on a schedule. On the free tier there's no background sync while closed. Pro supporters get scheduled refresh while closed; cloud sync between machines is a coming Pro perk."}},{"@type":"Question","name":"Why is my count different from what the store shows?","acceptedAnswer":{"@type":"Answer","text":"Stores pad your library with things that aren't games: DLC skins, soundtracks, wallpapers, betas, and store apps. BAKLOG filters those out automatically so the number you see is real games, not shelf clutter. That filter is built-in and you never have to manage it. Separately, you can hide any game you just don't want to see and restore it later from the Hidden games panel."}},{"@type":"Question","name":"Does it upload my library?","acceptedAnswer":{"@type":"Answer","text":"No. Your catalog and credentials stay in your local profile folder. Store fetches go straight from your PC to each storefront. baklog.app never receives your library JSON. The marketing site uses Google Analytics for anonymous page views. Signup email if you get the beta, a bug report only if you click Send, and a public free-games metadata feed."}},{"@type":"Question","name":"Can I run it from source instead of the beta installer?","acceptedAnswer":{"@type":"Answer","text":"Yes. Clone github.com/Ogrods/BAKLOG and run from source on Windows, macOS, or Linux. The open beta is packaged builds and update delivery on top of the same MIT tree."}},{"@type":"Question","name":"How is this different from Playnite?","acceptedAnswer":{"@type":"Answer","text":"Playnite is a launcher: it opens games and unifies your library view. BAKLOG is a backlog dashboard: what to play next, cross-store dedupe, wishlist deal radar, and ownership-aware sale checks. Many people use both. BAKLOG is not trying to replace your launcher."}},{"@type":"Question","name":"Isn't scraping against the rules?","acceptedAnswer":{"@type":"Answer","text":"BAKLOG automates requests you could make yourself, in your own browser, with your own credentials, on your own machine. Each storefront sees normal traffic from your IP, as you."}},{"@type":"Question","name":"Is the beta open?","acceptedAnswer":{"@type":"Answer","text":"Yes. BAKLOG is in open beta. Enter your email above and we send a confirmation with the download link to the latest GitHub release."}},{"@type":"Question","name":"Do you sell my data?","acceptedAnswer":{"@type":"Answer","text":"No. BAKLOG has no business model built on your library. We do not collect, host, or sell catalog data. There is no server holding it to sell. Optional account login (Supabase) stores your email only; games stay local."}}]}]}</script>
 
   <style>
     @font-face {
@@ -703,12 +703,12 @@
       <div class="waitlist-row">
         <input type="email" id="email" name="email" placeholder="you@example.com" autocomplete="email" required aria-label="Email address" />
         <input class="honeypot" type="text" name="website" tabindex="-1" autocomplete="off" aria-hidden="true" />
-        <button class="btn" type="submit" id="submitBtn">Request an invite</button>
+        <button class="btn" type="submit" id="submitBtn">Get the beta</button>
       </div>
       <div class="form-reassure">
         <p class="form-secure">
           <svg class="secure-ico" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
-          <strong>Runs on your PC.</strong> No telemetry by default &middot; <a href="https://github.com/Ogrods/BAKLOG" target="_blank" rel="noopener noreferrer">MIT source on GitHub</a> (server, fetchers, auth) &middot; Invite-only beta in small waves.
+          <strong>Runs on your PC.</strong> No telemetry by default &middot; <a href="https://github.com/Ogrods/BAKLOG" target="_blank" rel="noopener noreferrer">MIT source on GitHub</a> (server, fetchers, auth) &middot; Open beta - email gets the download link.
         </p>
       </div>
       <p class="form-msg" id="formMsg" role="status" aria-live="polite"></p>
@@ -724,7 +724,7 @@
       <span class="eyebrow">The accidental library</span>
       <h2>You didn't buy 600 games. They piled up.</h2>
       <p>Free Epic and Prime Gaming Thursdays, a GOG giveaway you grabbed mid-sale, Humble Bundle dumps, the itch.io Palestinian Relief Bundle, the Steam Summer Sale. A modern library is an accident, scattered across launchers you forgot you had. You should not have to visit five storefronts to see what is yours. BAKLOG pulls what you already own from each store into one table on your machine. There is no project-owned server collecting that catalog.</p>
-      <p class="section-invite"><a class="btn" href="#waitlist">Request an invite</a></p>
+      <p class="section-invite"><a class="btn" href="#waitlist">Get the beta</a></p>
     </div>
   </section>
 
@@ -734,10 +734,10 @@
       <div class="section-head">
         <span class="eyebrow">The demo is the product</span>
         <h2>This is your dashboard on day one.</h2>
-        <p>Connect your stores and watch your library count climb. This live sample uses dummy data; the shipped app is the same UI on your PC. Clone <a href="https://github.com/Ogrods/BAKLOG" target="_blank" rel="noopener noreferrer">the MIT repo</a> and run it today, or use a packaged invite build.</p>
+        <p>Connect your stores and watch your library count climb. This live sample uses dummy data; the shipped app is the same UI on your PC. Clone <a href="https://github.com/Ogrods/BAKLOG" target="_blank" rel="noopener noreferrer">the MIT repo</a> and run it today, or grab a packaged beta build.</p>
       </div>
       <div class="demo-mount" id="demoMount" role="region" aria-label="BAKLOG dashboard sample"></div>
-      <p class="demo-cta"><a class="btn" href="#waitlist">Request an invite</a></p>
+      <p class="demo-cta"><a class="btn" href="#waitlist">Get the beta</a></p>
     </div>
   </section>
 
@@ -766,7 +766,7 @@
           <p>Know what to play next, and whether that "deal" is actually worth opening.</p>
         </div>
       </div>
-      <p class="section-invite"><a class="btn" href="#waitlist">Request an invite</a></p>
+      <p class="section-invite"><a class="btn" href="#waitlist">Get the beta</a></p>
     </div>
   </section>
 
@@ -791,7 +791,7 @@
         <svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M16.635 6.162l-5.928 9.377H4.24l1.508-2.3h4.024l1.474-2.335H2.264L.79 13.239h2.156L0 17.84h12.072l4.563-7.259 1.652 2.66h-1.401l-1.473 2.299h4.347l1.473 2.3H24zm-11.461.107L3.7 8.604l9.52-.035 1.474-2.3z"/></svg>
       </div>
       <p class="logo-wall-caption">Steam, Epic, GOG, PlayStation, Xbox, Amazon, Battle.net, Ubisoft, Nintendo, itch.io, Humble, and EA App. Plus 8 wishlist sources for deal radar.</p>
-      <p class="section-invite"><a class="btn" href="#waitlist">Request an invite</a></p>
+      <p class="section-invite"><a class="btn" href="#waitlist">Get the beta</a></p>
     </div>
   </section>
 
@@ -858,8 +858,8 @@
             <li>Store sign-in opens Chrome or Edge on this PC. If neither is installed, BAKLOG downloads a one-time browser. Session cookies stay in a local browser profile on disk. No container, no remote sandbox, nothing shipped to us.</li>
             <li>Credentials encrypted at rest (AES-256-GCM); keys in Windows Credential Manager, macOS Keychain, or Linux Secret Service</li>
             <li>No telemetry by default. <a href="https://github.com/Ogrods/BAKLOG" target="_blank" rel="noopener noreferrer">MIT source on GitHub</a> with a published <a href="https://github.com/Ogrods/BAKLOG/blob/main/SECURITY.md" target="_blank" rel="noopener noreferrer">threat model</a> you can read before you trust us</li>
-            <li>baklog.app is separate from your library: Google Analytics for anonymous page views, waitlist email if you request an invite, a bug report only if you click Send, and a public free-games feed. Your catalog never uploads there.</li>
-            <li>We do not sell data because we do not host it. Optional invite login stores email only; your games stay in your local profile folder.</li>
+            <li>baklog.app is separate from your library: Google Analytics for anonymous page views, signup email if you get the beta, a bug report only if you click Send, and a public free-games feed. Your catalog never uploads there.</li>
+            <li>We do not sell data because we do not host it. Optional account login stores email only; your games stay in your local profile folder.</li>
           </ul>
         </article>
 
@@ -941,7 +941,7 @@
           </tbody>
         </table>
       </div>
-      <p class="section-invite"><a class="btn" href="#waitlist">Request an invite</a></p>
+      <p class="section-invite"><a class="btn" href="#waitlist">Get the beta</a></p>
     </div>
   </section>
 
@@ -970,7 +970,7 @@
           <p>Connect once and your new collection counts itself from day one.</p>
         </div>
       </div>
-      <p class="section-invite"><a class="btn" href="#waitlist">Request an invite</a></p>
+      <p class="section-invite"><a class="btn" href="#waitlist">Get the beta</a></p>
     </div>
   </section>
 
@@ -996,7 +996,7 @@
           <p>Backloggd is manual logging. BAKLOG auto-imports 12 libraries and 8 wishlist sources when you connect each store.</p>
         </article>
       </div>
-      <p class="section-invite"><a class="btn" href="#waitlist">Request an invite</a></p>
+      <p class="section-invite"><a class="btn" href="#waitlist">Get the beta</a></p>
     </div>
   </section>
 
@@ -1016,7 +1016,7 @@
         <div class="score-tile"><div class="num">$0</div><div class="lbl">free forever to import your library</div></div>
         <div class="score-tile"><div class="num">1-click</div><div class="lbl">queue every stale store (Pro)</div></div>
       </div>
-      <p class="section-invite"><a class="btn" href="#waitlist">Request an invite</a></p>
+      <p class="section-invite"><a class="btn" href="#waitlist">Get the beta</a></p>
     </div>
   </section>
 
@@ -1027,7 +1027,7 @@
       <h2>There is no BAKLOG server to breach.</h2>
       <p>Your library JSON and store credentials stay on your PC. Fetches go to each storefront from your IP, through your own browser session. We do not run a datacenter copy of anyone's catalog.</p>
       <p>Sign-in is not a remote container: Chrome or Edge opens locally, or BAKLOG downloads a one-time browser if neither is installed. Cookies land in a browser profile on disk, and nothing is shipped to us. Local-first is that architecture, not a trick about binding to localhost.</p>
-      <p>Skeptical? Read the published <a href="https://github.com/Ogrods/BAKLOG/blob/main/SECURITY.md" target="_blank" rel="noopener noreferrer">threat model</a> and <a href="https://github.com/Ogrods/BAKLOG/blob/main/PRIVACY.md" target="_blank" rel="noopener noreferrer">privacy inventory</a> before you trust us. The <a href="https://github.com/Ogrods/BAKLOG" target="_blank" rel="noopener noreferrer">full MIT tree</a> is public: server, fetchers, auth, dashboard. No telemetry by default on the desktop app; opt-in anonymous aggregate metrics only. baklog.app uses Google Analytics for anonymous page views on the marketing site, plus waitlist email, opt-in bug reports you send, and a public free-games feed. Your catalog never uploads there.</p>
+      <p>Skeptical? Read the published <a href="https://github.com/Ogrods/BAKLOG/blob/main/SECURITY.md" target="_blank" rel="noopener noreferrer">threat model</a> and <a href="https://github.com/Ogrods/BAKLOG/blob/main/PRIVACY.md" target="_blank" rel="noopener noreferrer">privacy inventory</a> before you trust us. The <a href="https://github.com/Ogrods/BAKLOG" target="_blank" rel="noopener noreferrer">full MIT tree</a> is public: server, fetchers, auth, dashboard. No telemetry by default on the desktop app; opt-in anonymous aggregate metrics only. baklog.app uses Google Analytics for anonymous page views on the marketing site, plus signup email for the open beta, opt-in bug reports you send, and a public free-games feed. Your catalog never uploads there.</p>
     </div>
   </section>
 
@@ -1039,11 +1039,11 @@
       <div class="faq" style="text-align:left">
         <details>
           <summary>Is it safe?</summary>
-          <p>Your credentials stay encrypted on your machine (AES-256-GCM, OS keychain). Store sign-in runs in your own local browser, not a container and not a shared cloud vault. Fetches go straight from your PC to each storefront, from your IP. There is no BAKLOG server holding your library. The full app is <a href="https://github.com/Ogrods/BAKLOG" target="_blank" rel="noopener noreferrer">open source (MIT)</a> with a published <a href="https://github.com/Ogrods/BAKLOG/blob/main/SECURITY.md" target="_blank" rel="noopener noreferrer">threat model</a> that lists what we defend and what we do not (local malware, storefront ToS, and the rest). baklog.app never receives your catalog. The marketing site uses Google Analytics for anonymous page views. Waitlist email if you request an invite, and a bug report only if you click Send.</p>
+          <p>Your credentials stay encrypted on your machine (AES-256-GCM, OS keychain). Store sign-in runs in your own local browser, not a container and not a shared cloud vault. Fetches go straight from your PC to each storefront, from your IP. There is no BAKLOG server holding your library. The full app is <a href="https://github.com/Ogrods/BAKLOG" target="_blank" rel="noopener noreferrer">open source (MIT)</a> with a published <a href="https://github.com/Ogrods/BAKLOG/blob/main/SECURITY.md" target="_blank" rel="noopener noreferrer">threat model</a> that lists what we defend and what we do not (local malware, storefront ToS, and the rest). baklog.app never receives your catalog. The marketing site uses Google Analytics for anonymous page views. Signup email if you get the beta, and a bug report only if you click Send.</p>
         </details>
         <details>
           <summary>Is it open source?</summary>
-          <p>Yes. BAKLOG is released under the <a href="https://github.com/Ogrods/BAKLOG/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT license</a>. The full app (server, fetchers, auth, and dashboard) lives in the <a href="https://github.com/Ogrods/BAKLOG" target="_blank" rel="noopener noreferrer">public GitHub repo</a>: clone it and run from source today. No hidden builds, no closed-source telemetry layer. The invite beta is packaged builds on top of the same tree. Optional paid features are conveniences on top of the same open codebase, not a fork of your data into our cloud.</p>
+          <p>Yes. BAKLOG is released under the <a href="https://github.com/Ogrods/BAKLOG/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT license</a>. The full app (server, fetchers, auth, and dashboard) lives in the <a href="https://github.com/Ogrods/BAKLOG" target="_blank" rel="noopener noreferrer">public GitHub repo</a>: clone it and run from source today. No hidden builds, no closed-source telemetry layer. The open beta is packaged builds on top of the same tree. Optional paid features are conveniences on top of the same open codebase, not a fork of your data into our cloud.</p>
         </details>
         <details>
           <summary>Is it free?</summary>
@@ -1075,11 +1075,11 @@
         </details>
         <details>
           <summary>Does it upload my library?</summary>
-          <p>No. Your catalog and credentials stay in your local profile folder. Store fetches go straight from your PC to each storefront. baklog.app never receives your library JSON. The marketing site uses Google Analytics for anonymous page views. Waitlist email if you request an invite, a bug report only if you click Send, and a public free-games metadata feed.</p>
+          <p>No. Your catalog and credentials stay in your local profile folder. Store fetches go straight from your PC to each storefront. baklog.app never receives your library JSON. The marketing site uses Google Analytics for anonymous page views. Signup email if you get the beta, a bug report only if you click Send, and a public free-games metadata feed.</p>
         </details>
         <details>
-          <summary>Can I run it without waiting for an invite?</summary>
-          <p>Yes. Clone <a href="https://github.com/Ogrods/BAKLOG" target="_blank" rel="noopener noreferrer">github.com/Ogrods/BAKLOG</a> and run from source on Windows, macOS, or Linux. The invite beta is optional packaged builds and update delivery on top of the same MIT tree.</p>
+          <summary>Can I run it from source instead of the beta installer?</summary>
+          <p>Yes. Clone <a href="https://github.com/Ogrods/BAKLOG" target="_blank" rel="noopener noreferrer">github.com/Ogrods/BAKLOG</a> and run from source on Windows, macOS, or Linux. The open beta is packaged builds and update delivery on top of the same MIT tree.</p>
         </details>
         <details>
           <summary>How is this different from Playnite?</summary>
@@ -1090,24 +1090,24 @@
           <p>BAKLOG automates requests you could make yourself, in your own browser, with your own credentials, on your own machine. Each storefront sees normal traffic from your IP, as you.</p>
         </details>
         <details>
-          <summary>Why invite-only right now?</summary>
-          <p>We are onboarding in small waves so we can fix what breaks on real setups before opening the doors. Request an invite and you are in line for the next wave.</p>
+          <summary>Is the beta open?</summary>
+          <p>Yes. BAKLOG is in open beta. Enter your email above and we send a confirmation with the download link to the latest GitHub release.</p>
         </details>
         <details>
           <summary>Do you sell my data?</summary>
-          <p>No. BAKLOG has no business model built on your library. We do not collect, host, or sell catalog data. There is no server holding it to sell. Optional invite login (Supabase) stores your email only; games stay local.</p>
+          <p>No. BAKLOG has no business model built on your library. We do not collect, host, or sell catalog data. There is no server holding it to sell. Optional account login (Supabase) stores your email only; games stay local.</p>
         </details>
       </div>
-      <p class="section-invite"><a href="https://github.com/Ogrods/BAKLOG/tree/main/guide" target="_blank" rel="noopener noreferrer">Full user guide on GitHub</a> · <a class="btn" href="#waitlist">Request an invite</a></p>
+      <p class="section-invite"><a href="https://github.com/Ogrods/BAKLOG/tree/main/guide" target="_blank" rel="noopener noreferrer">Full user guide on GitHub</a> · <a class="btn" href="#waitlist">Get the beta</a></p>
     </div>
   </section>
 
   <!-- ============ FINAL CTA ============ -->
   <section class="band cta-band">
     <div class="wrap">
-      <h2>Request your invite.</h2>
-      <p>Free forever to import your library. Optional paid tier to support BAKLOG. MIT source on GitHub if you want to verify the privacy claims before you install. Invite-only early access &middot; invites go out in small waves.</p>
-      <a class="btn" href="#waitlist">Request an invite</a>
+      <h2>Get the open beta.</h2>
+      <p>Free forever to import your library. Optional paid tier to support BAKLOG. MIT source on GitHub if you want to verify the privacy claims before you install. Open beta &middot; email gets the download link.</p>
+      <a class="btn" href="#waitlist">Get the beta</a>
     </div>
   </section>
 
@@ -1137,7 +1137,7 @@
             <span class="name">BAKLOG<sup class="tm" aria-hidden="true">&trade;</sup></span>
           </div>
           <p class="foot-tagline"><strong>baklog.app</strong>. One honest backlog across every store.</p>
-          <p class="foot-pricing">Free forever to import &middot; Support BAKLOG optional &middot; Invite-only early access. Invites go out in small waves.</p>
+          <p class="foot-pricing">Free forever to import &middot; Support BAKLOG optional &middot; Open beta.</p>
           <div class="foot-social" role="group" aria-label="Follow BAKLOG">
             <!-- Discord: keep in sync with shared/community.json discord_invite -->
             <a href="https://discord.gg/VFvxN5nCCB" target="_blank" rel="noopener noreferrer" aria-label="BAKLOG on Discord" title="Discord (community)">
@@ -1161,7 +1161,7 @@
           <div class="foot-col">
             <h3>Community</h3>
             <!-- Discord + GitHub: keep in sync with shared/community.json -->
-            <a href="#waitlist">Request an invite</a>
+            <a href="#waitlist">Get the beta</a>
             <a href="https://discord.gg/VFvxN5nCCB" target="_blank" rel="noopener noreferrer">Discord</a>
             <a href="https://github.com/Ogrods/BAKLOG" target="_blank" rel="noopener noreferrer">GitHub</a>
             <a href="https://github.com/Ogrods/BAKLOG/blob/main/SECURITY.md" target="_blank" rel="noopener noreferrer">Security model</a>

--- a/landing/llms.txt
+++ b/landing/llms.txt
@@ -11,14 +11,14 @@
 
 ## What baklog.app is
 
-baklog.app is the marketing site, invite waitlist, hosted auth pages, and public feeds (`/free-claims.json`, `/sponsors.json`). It does not host user libraries. The marketing site uses Google Analytics for anonymous page views.
+baklog.app is the marketing site, open-beta signup, hosted auth pages, and public feeds (`/free-claims.json`, `/sponsors.json`). It does not host user libraries. The marketing site uses Google Analytics for anonymous page views.
 
 ## Product facts
 
 - Runs on Windows, macOS, and Linux on the user's PC.
 - Imports 12 store libraries and 8 wishlists.
 - Free forever to import. Optional paid Pro tier for conveniences.
-- Invite-only packaged beta; anyone can clone and run from source.
+- Open beta packaged builds; anyone can also clone and run from source.
 - No telemetry by default. Optional opt-in anonymous aggregate metrics.
 
 ## Contact

--- a/landing/main.js
+++ b/landing/main.js
@@ -42,7 +42,7 @@
       form.querySelector(".form-reassure").remove();
       msg.className = "form-msg ok";
       msg.textContent =
-        "You're on the invite list. We send invites in small waves, so keep an eye on your inbox.";
+        "Check your inbox for the download link. The open beta is ready now.";
     } catch {
       btn.disabled = false;
       btn.textContent = original;

--- a/tests/landing-subscribe.test.js
+++ b/tests/landing-subscribe.test.js
@@ -187,7 +187,9 @@ describe("landing/api/subscribe.js", () => {
     const [, welcomeOpts] = fetchMock.mock.calls[1];
     const welcomePayload = JSON.parse(welcomeOpts.body);
     expect(welcomePayload.to).toBe("tester@example.com");
-    expect(welcomePayload.subject).toContain("invite list");
+    expect(welcomePayload.subject).toContain("open beta download");
+    expect(welcomePayload.text).toContain("https://github.com/Ogrods/BAKLOG/releases/latest");
+    expect(welcomePayload.html).toContain("https://github.com/Ogrods/BAKLOG/releases/latest");
   });
 
   it("sends founder notification and confirmation for a valid signup", async () => {
@@ -203,11 +205,13 @@ describe("landing/api/subscribe.js", () => {
     const founderPayload = JSON.parse(founderOpts.body);
     expect(founderPayload.to).toBe("founder@example.com");
     expect(founderPayload.reply_to).toBe("tester@example.com");
+    expect(founderPayload.subject).toContain("open beta signup");
 
     const [, welcomeOpts] = fetchMock.mock.calls[1];
     const welcomePayload = JSON.parse(welcomeOpts.body);
     expect(welcomePayload.to).toBe("tester@example.com");
-    expect(welcomePayload.subject).toContain("invite list");
+    expect(welcomePayload.subject).toContain("open beta download");
+    expect(welcomePayload.text).toContain("https://github.com/Ogrods/BAKLOG/releases/latest");
   });
 
   it("reports durable log NOT saved when Supabase is unconfigured", async () => {
@@ -233,5 +237,10 @@ describe("landing/api/subscribe.js", () => {
     const [, founderOpts] = fetchMock.mock.calls[1];
     const founderPayload = JSON.parse(founderOpts.body);
     expect(founderPayload.text).toContain("Durable log: saved to Supabase");
+    const [supabaseUrl, supabaseOpts] = fetchMock.mock.calls[0];
+    expect(supabaseUrl).toContain("/rest/v1/waitlist");
+    const insertBody = JSON.parse(supabaseOpts.body);
+    expect(insertBody.invited_at).toBeTruthy();
+    expect(insertBody.created_at).toBe(insertBody.invited_at);
   });
 });


### PR DESCRIPTION
## Summary
- Retarget baklog.app from invite-only waitlist to open beta; CTAs become **Get the beta**.
- Confirmation email includes the canonical GitHub Releases download link; new Supabase signups stamp `invited_at`.
- FAQ, meta/OG/JSON-LD, success toast, README, and llms.txt updated to match.

## Test plan
- [x] `node scripts/check-landing-seo.mjs`
- [x] `npx vitest run tests/landing-subscribe.test.js`
- [ ] After Vercel deploy: submit a test email and confirm download link + founder notify