### PR TITLE
Add Phase 2 claims refresh sticky PR

### DIFF
--- a/.github/workflows/claims-ingest.yml
+++ b/.github/workflows/claims-ingest.yml
@@ -1,5 +1,6 @@
-# Phase 1 claims cron: fetch scrapes + summarize. No landing writes, no artifacts,
-# no secrets. Soft-warn when baklog.app free-claims is stale (job stays green).
+# Phase 1: fetch + summarize (read-only). Soft-warn on stale baklog.app feed.
+# Phase 2: rebuild published ids → sticky PR only when fingerprint changes.
+# No artifacts, no secrets, no blind auto-approve of new scrapes.
 name: Claims ingest
 
 on:
@@ -20,6 +21,8 @@ jobs:
     name: Fetch + summarize
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -43,3 +46,124 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}
         run: python scripts/claims_ingest_summary.py
+
+  refresh:
+    name: Refresh PR (published ids)
+    needs: ingest
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Fetch claim sources
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: python fetchers/fetch_claim_sources.py
+
+      - name: Snapshot landing before rebuild
+        run: cp landing/free-claims.json /tmp/landing-before.json
+
+      - name: Synthesize ephemeral approved.json from landing
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: python scripts/synth_claims_approved_from_landing.py
+
+      - name: Stub empty free-claims.input.json
+        run: |
+          printf '%s\n' '{"items":[]}' > free-claims.input.json
+
+      - name: Build free-claims (no empty publish)
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: python fetchers/build_free_claims.py --no-profile
+
+      - name: Audit free-surface data
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: python scripts/audit_free_surface_data.py --fail-on high
+
+      - name: Fingerprint gate
+        id: gate
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          set +e
+          env -u GITHUB_STEP_SUMMARY python scripts/claims_feed_fingerprint.py \
+            --before /tmp/landing-before.json \
+            --after landing/free-claims.json \
+            --json-out /tmp/claims-fp-diff.json \
+            > /tmp/claims-fp-diff.md
+          code=$?
+          set -e
+          cat /tmp/claims-fp-diff.md
+          if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+            cat /tmp/claims-fp-diff.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ "$code" -eq 3 ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$code" -ne 0 ]; then
+            exit "$code"
+          fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update sticky refresh PR
+        if: steps.gate.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Never stage maintainer-private or scrape scratch files
+          rm -f curated/free_claims.approved.json curated/free_claims.auto.json free-claims.input.json
+
+          git checkout -B chore/claims-feed-refresh
+          git add -- landing/free-claims.json curated/free_claims.fallback.json
+          if git diff --cached --quiet; then
+            echo "Nothing staged after add - skip PR."
+            exit 0
+          fi
+          git commit -m "Refresh free-claims feed (published ids only)"
+
+          git push -u origin chore/claims-feed-refresh --force-with-lease
+
+          BODY_FILE=$(mktemp)
+          {
+            echo "## Summary"
+            echo
+            echo "Automated refresh of **already-published** free-claims ids from live sources."
+            echo "New scrapes are **not** auto-approved."
+            echo
+            cat /tmp/claims-fp-diff.md
+            echo
+            echo "Merge to publish to baklog.app via the normal landing deploy."
+          } > "$BODY_FILE"
+
+          EXISTING=$(gh pr list --head chore/claims-feed-refresh --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh pr edit "$EXISTING" --body-file "$BODY_FILE"
+            echo "Updated PR #$EXISTING"
+          else
+            gh pr create \
+              --base main \
+              --head chore/claims-feed-refresh \
+              --title "Refresh free-claims feed" \
+              --body-file "$BODY_FILE"
+          fi

--- a/landing/README.md
+++ b/landing/README.md
@@ -241,7 +241,12 @@ $env:PYTHONPATH = (Get-Location).Path
 .\scripts\check_claims_feed_age.ps1 -Live   # fetch https://baklog.app/free-claims.json
 ```
 
-**Scheduled ingest (Phase 1)** - GitHub Actions workflow `Claims ingest` (`.github/workflows/claims-ingest.yml`): daily ~15:00 UTC + `workflow_dispatch`. It runs `fetch_claim_sources.py`, then `scripts/claims_ingest_summary.py` (compares scrape ids to committed `landing/free-claims.json`, soft-warns if live baklog.app feed is older than 7 days). Job stays green on stale age. No landing writes, no artifacts, no secrets, `contents: read` only. Does **not** commit or unify gitignored `auto` / `approved` / `input` files. You still approve and publish by hand. Phase 2 refresh-PR is not enabled yet.
+**Scheduled ingest (Phase 1 + Phase 2)** - GitHub Actions workflow `Claims ingest` (`.github/workflows/claims-ingest.yml`): daily ~15:00 UTC + `workflow_dispatch`.
+
+- **Phase 1 (read-only job):** `fetch_claim_sources.py` → `scripts/claims_ingest_summary.py` (scrape vs committed `landing/free-claims.json`, soft-warn if live baklog.app feed is older than 7 days, landing-vs-live skew line). Job stays green on stale age. No landing writes, no artifacts, no secrets.
+- **Phase 2 (write job, after Phase 1):** synthesize ephemeral `approved.json` from landing ids (keeps `premium_only`), stub empty `free-claims.input.json`, `build_free_claims.py --no-profile`, audit, then open/update sticky PR `chore/claims-feed-refresh` **only** when a lean item fingerprint changes. Never `--allow-empty`. Never auto-approves new scrapes. Merge the PR to publish.
+
+Does **not** commit or unify gitignored `auto` / `approved` / `input` files. Manual approve + publish remains available via admin/CLI for adding new candidates.
 
 ### Admin console (optional)
 

--- a/scripts/claims_feed_fingerprint.py
+++ b/scripts/claims_feed_fingerprint.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Stable fingerprint + diff for free-claims feed items (Phase 2 PR gate).
+
+Ignores stamp/enrich churn so rebuilds without claimable changes do not open a PR.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Lean fields users care about for "did claimables change?"
+FINGERPRINT_FIELDS = (
+    "id",
+    "store",
+    "title",
+    "claim_url",
+    "claim_urls",
+    "ends_at",
+    "premium_only",
+    "source",
+)
+
+
+def _norm_value(key: str, raw: Any) -> Any:
+    if key == "premium_only":
+        return True if raw is True else False
+    if key == "claim_urls":
+        if not isinstance(raw, dict):
+            return None
+        return {str(k): str(v or "").strip() for k, v in sorted(raw.items()) if str(v or "").strip()}
+    if raw is None:
+        return None
+    if isinstance(raw, (int, float, bool)):
+        return raw
+    text = str(raw).strip()
+    return text or None
+
+
+def item_fingerprint(item: dict) -> tuple[Any, ...]:
+    item_id = str(item.get("id") or "").strip()
+    parts: list[Any] = [item_id]
+    for key in FINGERPRINT_FIELDS:
+        if key == "id":
+            continue
+        parts.append(_norm_value(key, item.get(key)))
+    return tuple(parts)
+
+
+def fingerprint_items(items: list[dict]) -> list[tuple[Any, ...]]:
+    fps = [item_fingerprint(row) for row in items if isinstance(row, dict) and str(row.get("id") or "").strip()]
+    return sorted(fps, key=lambda t: t[0] or "")
+
+
+def load_items(path: Path) -> list[dict]:
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(doc, dict):
+        raise ValueError(f"feed must be an object: {path}")
+    items = doc.get("items") or []
+    if not isinstance(items, list):
+        raise ValueError(f"items must be a list: {path}")
+    return [row for row in items if isinstance(row, dict)]
+
+
+def diff_fingerprints(
+    before: list[tuple[Any, ...]],
+    after: list[tuple[Any, ...]],
+) -> dict[str, list[str]]:
+    before_by_id = {str(fp[0]): fp for fp in before if fp and fp[0]}
+    after_by_id = {str(fp[0]): fp for fp in after if fp and fp[0]}
+    before_ids = set(before_by_id)
+    after_ids = set(after_by_id)
+    added = sorted(after_ids - before_ids)
+    removed = sorted(before_ids - after_ids)
+    changed = sorted(
+        item_id
+        for item_id in (before_ids & after_ids)
+        if before_by_id[item_id] != after_by_id[item_id]
+    )
+    return {"added": added, "removed": removed, "changed": changed}
+
+
+def changed(diff: dict[str, list[str]]) -> bool:
+    return bool(diff["added"] or diff["removed"] or diff["changed"])
+
+
+def format_diff_markdown(diff: dict[str, list[str]], *, limit: int = 40) -> str:
+    lines = [
+        "## Free-claims fingerprint diff",
+        "",
+        f"- Added: **{len(diff['added'])}**",
+        f"- Removed: **{len(diff['removed'])}**",
+        f"- Changed: **{len(diff['changed'])}**",
+        "",
+    ]
+    for label, key in (("Added", "added"), ("Removed", "removed"), ("Changed", "changed")):
+        ids = diff[key]
+        lines.append(f"### {label}")
+        lines.append("")
+        if not ids:
+            lines.append("- (none)")
+        else:
+            for item_id in ids[:limit]:
+                lines.append(f"- `{item_id}`")
+            if len(ids) > limit:
+                lines.append(f"- … and {len(ids) - limit} more")
+        lines.append("")
+    lines.append("_New scrape candidates are not auto-approved; this PR only refreshes previously published ids._")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--before", type=Path, required=True, help="Landing feed before rebuild")
+    parser.add_argument("--after", type=Path, required=True, help="Landing feed after rebuild")
+    parser.add_argument(
+        "--json-out",
+        type=Path,
+        help="Optional path to write diff JSON",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        before_fp = fingerprint_items(load_items(args.before))
+        after_fp = fingerprint_items(load_items(args.after))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    diff = diff_fingerprints(before_fp, after_fp)
+    if args.json_out:
+        args.json_out.write_text(json.dumps(diff, indent=2) + "\n", encoding="utf-8")
+
+    md = format_diff_markdown(diff)
+    print(md, end="")
+    summary = __import__("os").environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as fh:
+            fh.write(md)
+
+    if not changed(diff):
+        print("No claimable fingerprint changes — skip PR.", flush=True)
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/claims_ingest_summary.py
+++ b/scripts/claims_ingest_summary.py
@@ -6,6 +6,7 @@ live baklog.app feed age. Soft-warns on stale live feed (exit 0). Hard-fails onl
 when required local files are unreadable after a successful fetch.
 
 Public-safe output only: ids, titles, stores, ages. No secrets, no approved.json.
+No public ::notice::/::warning:: annotations (summary text only).
 """
 
 from __future__ import annotations
@@ -13,6 +14,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
@@ -25,15 +27,28 @@ LANDING_PATH = ROOT / "landing" / "free-claims.json"
 LIVE_URL = "https://baklog.app/free-claims.json"
 USER_AGENT = "BAKLOG-claims-ingest-summary/1.0"
 DEFAULT_MAX_AGE_DAYS = 7
+DEFAULT_SKEW_DAYS = 1.0
 SAMPLE_LIMIT = 25
+_WS_RE = re.compile(r"\s+")
 
 
-def _load_items(path: Path) -> list[dict]:
+def sanitize_title(raw: object) -> str:
+    """Collapse whitespace and strip backticks so markdown samples stay readable."""
+    text = _WS_RE.sub(" ", str(raw or "").replace("`", "'")).strip()
+    return text or "(no title)"
+
+
+def _load_doc(path: Path) -> dict:
     if not path.is_file():
         raise FileNotFoundError(f"missing feed: {path}")
     doc = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(doc, dict):
         raise ValueError(f"feed must be an object: {path}")
+    return doc
+
+
+def _load_items(path: Path) -> list[dict]:
+    doc = _load_doc(path)
     items = doc.get("items") or []
     if not isinstance(items, list):
         raise ValueError(f"items must be a list: {path}")
@@ -61,7 +76,7 @@ def _sample_lines(ids: set[str], by_id: dict[str, dict], *, limit: int = SAMPLE_
     lines: list[str] = []
     for item_id in sorted(ids)[:limit]:
         row = by_id.get(item_id) or {}
-        title = str(row.get("title") or "").strip() or "(no title)"
+        title = sanitize_title(row.get("title"))
         store = str(row.get("store") or row.get("source") or "").strip()
         suffix = f" [{store}]" if store else ""
         lines.append(f"- `{item_id}`{suffix}: {title}")
@@ -86,31 +101,64 @@ def _parse_generated_at(raw: object) -> datetime | None:
     return dt.astimezone(UTC)
 
 
-def check_live_age(url: str, *, max_age_days: float) -> tuple[str, bool]:
-    """Return (summary line, stale). Network errors are warnings, not failures."""
+def _fmt_ts(dt: datetime) -> str:
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def fetch_live_doc(url: str) -> tuple[dict | None, str | None]:
+    """Return (payload, error_message)."""
     req = Request(url, headers={"User-Agent": USER_AGENT, "Accept": "application/json"})
     try:
         with urlopen(req, timeout=30) as resp:  # noqa: S310 — fixed HTTPS URL
             payload = json.loads(resp.read().decode("utf-8"))
     except (HTTPError, URLError, TimeoutError, json.JSONDecodeError, OSError) as exc:
-        return (f"WARN: could not fetch live feed ({exc})", False)
-
+        return None, f"could not fetch live feed ({exc})"
     if not isinstance(payload, dict):
-        return ("WARN: live feed is not a JSON object", False)
+        return None, "live feed is not a JSON object"
+    return payload, None
+
+
+def check_live_age(url: str, *, max_age_days: float) -> tuple[str, bool, datetime | None]:
+    """Return (summary line, stale, live_generated_at)."""
+    payload, err = fetch_live_doc(url)
+    if err or payload is None:
+        return (f"WARN: {err}", False, None)
 
     generated = _parse_generated_at(payload.get("generated_at"))
     if generated is None:
-        return ("WARN: live feed has no parseable generated_at", False)
+        return ("WARN: live feed has no parseable generated_at", False, None)
 
     age_days = (datetime.now(UTC) - generated).total_seconds() / 86400.0
     item_count = len(payload.get("items") or []) if isinstance(payload.get("items"), list) else "?"
     line = (
-        f"live generated_at={generated.isoformat().replace('+00:00', 'Z')} "
+        f"live generated_at={_fmt_ts(generated)} "
         f"age={age_days:.2f}d (limit={max_age_days:g}d) items={item_count}"
     )
     if age_days > max_age_days:
-        return (f"WARN: {line} - refresh and republish", True)
-    return (f"OK: {line}", False)
+        return (f"WARN: {line} - refresh and republish", True, generated)
+    return (f"OK: {line}", False, generated)
+
+
+def landing_vs_live_skew_line(
+    landing_generated: datetime | None,
+    live_generated: datetime | None,
+    *,
+    skew_days: float = DEFAULT_SKEW_DAYS,
+) -> str | None:
+    """Return a summary line when committed landing and live clocks diverge."""
+    if landing_generated is None or live_generated is None:
+        return None
+    delta_days = abs((landing_generated - live_generated).total_seconds()) / 86400.0
+    if delta_days <= skew_days:
+        return (
+            f"OK: landing vs live skew={delta_days:.2f}d "
+            f"(landing={_fmt_ts(landing_generated)}, live={_fmt_ts(live_generated)})"
+        )
+    return (
+        f"WARN: landing vs live skew={delta_days:.2f}d "
+        f"(limit={skew_days:g}d; landing={_fmt_ts(landing_generated)}, "
+        f"live={_fmt_ts(live_generated)}) - committed feed and baklog.app differ"
+    )
 
 
 def build_markdown(
@@ -119,6 +167,7 @@ def build_markdown(
     landing_items: list[dict],
     live_line: str,
     live_stale: bool,
+    skew_line: str | None = None,
 ) -> str:
     auto_by_id = _id_map(auto_items)
     land_by_id = _id_map(landing_items)
@@ -151,6 +200,9 @@ def build_markdown(
     if live_stale:
         lines.append("_Soft warn only - job stays green. Publish when ready._")
         lines.append("")
+
+    if skew_line:
+        lines.extend(["### Landing vs live skew", "", skew_line, ""])
 
     lines.extend(["### New scrape candidates (sample)", ""])
     if new_ids:
@@ -193,6 +245,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--landing", type=Path, default=LANDING_PATH)
     parser.add_argument("--live-url", default=LIVE_URL)
     parser.add_argument("--max-age-days", type=float, default=DEFAULT_MAX_AGE_DAYS)
+    parser.add_argument("--skew-days", type=float, default=DEFAULT_SKEW_DAYS)
     parser.add_argument(
         "--skip-live",
         action="store_true",
@@ -201,22 +254,38 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
+        landing_doc = _load_doc(args.landing)
+        landing_items = [
+            row for row in (landing_doc.get("items") or []) if isinstance(row, dict)
+        ]
+        if not isinstance(landing_doc.get("items") or [], list):
+            raise ValueError(f"items must be a list: {args.landing}")
         auto_items = _load_items(args.auto)
-        landing_items = _load_items(args.landing)
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
 
+    landing_generated = _parse_generated_at(landing_doc.get("generated_at"))
+
     if args.skip_live:
-        live_line, live_stale = ("SKIP: live age check disabled", False)
+        live_line, live_stale, live_generated = ("SKIP: live age check disabled", False, None)
+        skew_line = None
     else:
-        live_line, live_stale = check_live_age(args.live_url, max_age_days=args.max_age_days)
+        live_line, live_stale, live_generated = check_live_age(
+            args.live_url, max_age_days=args.max_age_days
+        )
+        skew_line = landing_vs_live_skew_line(
+            landing_generated,
+            live_generated,
+            skew_days=args.skew_days,
+        )
 
     md = build_markdown(
         auto_items=auto_items,
         landing_items=landing_items,
         live_line=live_line,
         live_stale=live_stale,
+        skew_line=skew_line,
     )
     _write_summary(md)
     return 0

--- a/scripts/synth_claims_approved_from_landing.py
+++ b/scripts/synth_claims_approved_from_landing.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Synthesize ephemeral free_claims.approved.json from committed landing feed.
+
+Used by Phase 2 CI so rebuilds keep previously published ids (and premium_only)
+without committing maintainer approved.json. Never commit the output file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LANDING_PATH = ROOT / "landing" / "free-claims.json"
+AUTO_PATH = ROOT / "curated" / "free_claims.auto.json"
+APPROVED_OUT = ROOT / "curated" / "free_claims.approved.json"
+
+
+def _load_items(path: Path) -> list[dict]:
+    if not path.is_file():
+        raise FileNotFoundError(f"missing feed: {path}")
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(doc, dict):
+        raise ValueError(f"feed must be an object: {path}")
+    items = doc.get("items") or []
+    if not isinstance(items, list):
+        raise ValueError(f"items must be a list: {path}")
+    return [row for row in items if isinstance(row, dict)]
+
+
+def _id_map(items: list[dict]) -> dict[str, dict]:
+    out: dict[str, dict] = {}
+    for row in items:
+        item_id = str(row.get("id") or "").strip()
+        if item_id:
+            out[item_id] = row
+    return out
+
+
+def synthesize_approved(
+    landing_items: list[dict],
+    *,
+    auto_items: list[dict] | None = None,
+) -> dict:
+    """Build approved payload from landing rows (+ optional store overrides vs auto)."""
+    ids: list[str] = []
+    premium_only_ids: list[str] = []
+    landing_by_id = _id_map(landing_items)
+    for item_id, row in sorted(landing_by_id.items()):
+        ids.append(item_id)
+        if row.get("premium_only") is True:
+            premium_only_ids.append(item_id)
+
+    store_overrides: dict[str, str] = {}
+    if auto_items:
+        auto_by_id = _id_map(auto_items)
+        for item_id, land in landing_by_id.items():
+            auto = auto_by_id.get(item_id)
+            if not auto:
+                continue
+            land_store = str(land.get("store") or "").strip().lower()
+            auto_store = str(auto.get("store") or "").strip().lower()
+            if land_store and auto_store and land_store != auto_store:
+                store_overrides[item_id] = land_store
+
+    out: dict = {"ids": ids}
+    if premium_only_ids:
+        out["premium_only_ids"] = premium_only_ids
+    if store_overrides:
+        out["store_overrides"] = store_overrides
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--landing", type=Path, default=LANDING_PATH)
+    parser.add_argument("--auto", type=Path, default=AUTO_PATH)
+    parser.add_argument("--output", type=Path, default=APPROVED_OUT)
+    parser.add_argument(
+        "--no-auto",
+        action="store_true",
+        help="Skip reading auto feed (no store_overrides).",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        landing_items = _load_items(args.landing)
+        auto_items: list[dict] | None = None
+        if not args.no_auto and args.auto.is_file():
+            auto_items = _load_items(args.auto)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    payload = synthesize_approved(landing_items, auto_items=auto_items)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(
+        f"Wrote {args.output} with {len(payload.get('ids') or [])} id(s), "
+        f"{len(payload.get('premium_only_ids') or [])} premium_only, "
+        f"{len(payload.get('store_overrides') or {})} store_override(s)",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_claims_cron_helpers.py
+++ b/tests/test_claims_cron_helpers.py
@@ -1,0 +1,127 @@
+"""Tests for synth_claims_approved_from_landing and claims_feed_fingerprint."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import scripts.claims_feed_fingerprint as cff
+import scripts.synth_claims_approved_from_landing as synth
+
+
+def test_synthesize_approved_ids_and_premium() -> None:
+    landing = [
+        {"id": "a", "store": "epic", "title": "A", "premium_only": True},
+        {"id": "b", "store": "steam", "title": "B"},
+    ]
+    payload = synth.synthesize_approved(landing)
+    assert payload["ids"] == ["a", "b"]
+    assert payload["premium_only_ids"] == ["a"]
+    assert "store_overrides" not in payload
+
+
+def test_synthesize_store_overrides_when_auto_differs() -> None:
+    landing = [{"id": "m1", "store": "epic_mobile", "title": "M"}]
+    auto = [{"id": "m1", "store": "epic", "title": "M", "source": "itad"}]
+    payload = synth.synthesize_approved(landing, auto_items=auto)
+    assert payload["store_overrides"] == {"m1": "epic_mobile"}
+
+
+def test_synthesize_cli_writes_file(tmp_path: Path) -> None:
+    landing = tmp_path / "landing.json"
+    out = tmp_path / "approved.json"
+    landing.write_text(
+        json.dumps({"items": [{"id": "x", "store": "epic", "premium_only": True}]}),
+        encoding="utf-8",
+    )
+    code = synth.main(
+        ["--landing", str(landing), "--output", str(out), "--no-auto"]
+    )
+    assert code == 0
+    doc = json.loads(out.read_text(encoding="utf-8"))
+    assert doc["ids"] == ["x"]
+    assert doc["premium_only_ids"] == ["x"]
+
+
+def test_fingerprint_ignores_enrich_churn() -> None:
+    a = {
+        "id": "epic-1",
+        "store": "epic",
+        "title": "Game",
+        "claim_url": "https://example.com/a",
+        "ends_at": "2026-09-01T00:00:00Z",
+        "source": "epic",
+        "header_image": "https://cdn/old.jpg",
+        "review_percent": 80,
+        "generated_at": "2026-01-01T00:00:00Z",
+    }
+    b = {
+        **a,
+        "header_image": "https://cdn/new.jpg",
+        "review_percent": 90,
+        "blurb": "new blurb",
+        "generated_at": "2026-08-24T00:00:00Z",
+    }
+    assert cff.item_fingerprint(a) == cff.item_fingerprint(b)
+
+
+def test_fingerprint_detects_ends_at_change() -> None:
+    a = {"id": "epic-1", "store": "epic", "title": "Game", "ends_at": "2026-09-01T00:00:00Z"}
+    b = {"id": "epic-1", "store": "epic", "title": "Game", "ends_at": "2026-09-02T00:00:00Z"}
+    assert cff.item_fingerprint(a) != cff.item_fingerprint(b)
+
+
+def test_diff_fingerprints_added_removed_changed() -> None:
+    before = cff.fingerprint_items(
+        [
+            {"id": "keep", "store": "epic", "title": "Keep", "ends_at": "a"},
+            {"id": "gone", "store": "epic", "title": "Gone"},
+            {"id": "chg", "store": "epic", "title": "Old"},
+        ]
+    )
+    after = cff.fingerprint_items(
+        [
+            {"id": "keep", "store": "epic", "title": "Keep", "ends_at": "a"},
+            {"id": "new", "store": "epic", "title": "New"},
+            {"id": "chg", "store": "epic", "title": "NewTitle"},
+        ]
+    )
+    diff = cff.diff_fingerprints(before, after)
+    assert diff["added"] == ["new"]
+    assert diff["removed"] == ["gone"]
+    assert diff["changed"] == ["chg"]
+    assert cff.changed(diff)
+
+
+def test_fingerprint_cli_exit_codes(tmp_path: Path, capsys) -> None:
+    before = tmp_path / "before.json"
+    after_same = tmp_path / "after_same.json"
+    after_diff = tmp_path / "after_diff.json"
+    payload = {
+        "generated_at": "2026-08-01T00:00:00Z",
+        "items": [{"id": "a", "store": "epic", "title": "A", "claim_url": "https://x"}],
+    }
+    before.write_text(json.dumps(payload), encoding="utf-8")
+    after_same.write_text(
+        json.dumps({**payload, "generated_at": "2026-08-24T00:00:00Z"}),
+        encoding="utf-8",
+    )
+    after_diff.write_text(
+        json.dumps(
+            {
+                "items": [
+                    {
+                        "id": "a",
+                        "store": "epic",
+                        "title": "A2",
+                        "claim_url": "https://x",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert cff.main(["--before", str(before), "--after", str(after_same)]) == 3
+    assert cff.main(["--before", str(before), "--after", str(after_diff)]) == 0
+    out = capsys.readouterr().out
+    assert "fingerprint diff" in out.lower() or "Changed" in out

--- a/tests/test_claims_ingest_summary.py
+++ b/tests/test_claims_ingest_summary.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import scripts.claims_ingest_summary as cis
 
 
-def test_build_markdown_classifies_new_and_gone(tmp_path: Path) -> None:
+def test_sanitize_title_strips_backticks_and_newlines() -> None:
+    assert cis.sanitize_title("Foo\n`bar`  baz") == "Foo 'bar' baz"
+    assert cis.sanitize_title("   ") == "(no title)"
+
+
+def test_build_markdown_classifies_new_and_gone() -> None:
     auto = [
         {"id": "epic-new", "title": "New Game", "store": "epic", "source": "epic"},
         {"id": "epic-keep", "title": "Keep", "store": "epic", "source": "epic"},
@@ -22,12 +28,25 @@ def test_build_markdown_classifies_new_and_gone(tmp_path: Path) -> None:
         landing_items=landing,
         live_line="OK: age=1.0d",
         live_stale=False,
+        skew_line="WARN: landing vs live skew=10.00d",
     )
     assert "New scrape candidates (not in landing): **1**" in md
     assert "Landing ids missing from scrape: **1**" in md
     assert "`epic-new`" in md
     assert "`epic-gone`" in md
     assert "Phase 1: notify only" in md
+    assert "Landing vs live skew" in md
+
+
+def test_landing_vs_live_skew_line() -> None:
+    land = datetime(2026, 8, 24, tzinfo=UTC)
+    live = datetime(2026, 8, 7, tzinfo=UTC)
+    line = cis.landing_vs_live_skew_line(land, live, skew_days=1.0)
+    assert line is not None
+    assert line.startswith("WARN:")
+    ok = cis.landing_vs_live_skew_line(land, land + timedelta(hours=12), skew_days=1.0)
+    assert ok is not None
+    assert ok.startswith("OK:")
 
 
 def test_main_skip_live_writes_summary(tmp_path: Path, monkeypatch, capsys) -> None:
@@ -38,7 +57,12 @@ def test_main_skip_live_writes_summary(tmp_path: Path, monkeypatch, capsys) -> N
         encoding="utf-8",
     )
     landing_path.write_text(
-        json.dumps({"items": [{"id": "a1", "title": "A", "store": "epic"}]}),
+        json.dumps(
+            {
+                "generated_at": "2026-08-24T00:00:00Z",
+                "items": [{"id": "a1", "title": "A", "store": "epic"}],
+            }
+        ),
         encoding="utf-8",
     )
     summary = tmp_path / "summary.md"


### PR DESCRIPTION
## Summary
- Phase 1 hardening: landing-vs-live skew line + sanitized titles in the public job summary (no `::notice::`)
- Phase 2 refresh job: synthesize ephemeral approved.json from landing (keeps premium_only), build published ids only, audit, fingerprint gate
- Sticky PR `chore/claims-feed-refresh` only when claimable fingerprint changes; never auto-approves new scrapes; never `--allow-empty`

## Test plan
- [ ] CI green
- [ ] After merge: Actions → Claims ingest → Run workflow
- [ ] Confirm ingest summary + refresh job; PR opened or skipped cleanly when unchanged
- [ ] Confirm gitignored auto/approved/input are not committed
