### PR TITLE
Pre-release review B (security + gaps follow-up)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,6 @@ jobs:
         env:
           BAKLOG_SUPABASE_URL: ${{ secrets.BAKLOG_SUPABASE_URL }}
           BAKLOG_SUPABASE_ANON_KEY: ${{ secrets.BAKLOG_SUPABASE_ANON_KEY }}
-          BAKLOG_SUPABASE_JWT_SECRET: ${{ secrets.BAKLOG_SUPABASE_JWT_SECRET }}
           BAKLOG_REQUIRE_INSTALLER: "1"
         run: powershell -ExecutionPolicy Bypass -File packaging/build_windows.ps1
 

--- a/.gitignore
+++ b/.gitignore
@@ -120,4 +120,7 @@ scripts/responsive-overflow-last-run.json
 seo/
 
 .vercel
-.env*
+.env
+.env.*
+!.env.example
+!.env*.example

--- a/auth/manager.py
+++ b/auth/manager.py
@@ -185,8 +185,15 @@ def profile_credentials_env(profile_id: str) -> dict[str, str]:
     return out
 
 
-def subprocess_env_for_profile(profile_id: str) -> dict[str, str]:
-    """Minimal subprocess environment: system paths + profile-scoped credentials only."""
+def subprocess_env_for_profile(
+    profile_id: str, *, fetcher_key: str | None = None
+) -> dict[str, str]:
+    """Minimal subprocess environment: system paths + profile-scoped credentials.
+
+    When ``fetcher_key`` is set, only credential env keys for providers that
+    satisfy that fetcher are injected (least privilege). Omit ``fetcher_key``
+    to pass all profile credentials (CLI / connection probes).
+    """
     env: dict[str, str] = {
         "PYTHONUNBUFFERED": "1",
         "PYTHONIOENCODING": "utf-8",
@@ -208,7 +215,12 @@ def subprocess_env_for_profile(profile_id: str) -> dict[str, str]:
         v = os.environ.get(k)
         if v:
             env[k] = v
-    env.update(profile_credentials_env(profile_id))
+    creds = profile_credentials_env(profile_id)
+    if fetcher_key:
+        allow = _credential_env_keys_for_fetcher(fetcher_key)
+        if allow is not None:
+            creds = {k: v for k, v in creds.items() if k in allow}
+    env.update(creds)
     from shared.install_paths import bundle_root, data_root
 
     env["BAKLOG_DATA_DIR"] = str(data_root().resolve())
@@ -216,6 +228,50 @@ def subprocess_env_for_profile(profile_id: str) -> dict[str, str]:
     existing = env.get("PYTHONPATH", "").strip()
     env["PYTHONPATH"] = root if not existing else f"{root}{os.pathsep}{existing}"
     return env
+
+
+def _credential_env_keys_for_fetcher(fetcher_key: str) -> set[str] | None:
+    """Allowed secret env keys for a fetcher run, or None to pass all credentials.
+
+    Returns an empty set for known no-credential jobs (claims builders, HLTB).
+    Returns None only when the key is unrecognized so we do not break custom/admin jobs.
+    """
+    from auth.registry import PROVIDERS
+    from fetchers.registry import AUTH_PROVIDER_BY_KEY, ENRICH_FETCHER_KEYS
+
+    key = (fetcher_key or "").strip()
+    if not key:
+        return None
+
+    # Enrich / claims jobs that do not need store secrets.
+    if key in ("hltb", "freeClaims", "claimSources", "buildFreeClaims"):
+        return set()
+
+    providers: list[str] = []
+    primary = AUTH_PROVIDER_BY_KEY.get(key)
+    if primary:
+        providers.append(primary)
+    for pid, spec in PROVIDERS.items():
+        if key in (spec.fetcher_keys or ()) and pid not in providers:
+            providers.append(pid)
+
+    # Steam enrich scripts share the Steam Web API key.
+    if key in ENRICH_FETCHER_KEYS and key.startswith("steam"):
+        if "steam" not in providers:
+            providers.append("steam")
+    if key == "protondb" and "steam" not in providers:
+        providers.append("steam")
+
+    if not providers:
+        # Unknown key: keep prior behavior (all creds) rather than break a run.
+        return None
+
+    allowed: set[str] = set()
+    for pid in providers:
+        spec = PROVIDERS.get(pid)
+        if spec:
+            allowed.update(spec.env_keys)
+    return allowed
 
 
 def _local_data_present(provider: str, blob: dict[str, Any]) -> bool:

--- a/auth/runner.py
+++ b/auth/runner.py
@@ -36,6 +36,23 @@ POLL_SEC = 0.5
 PSN_STORE_URL = "https://store.playstation.com/en-us/"
 
 
+def _safe_connect_log_url(url: str) -> str:
+    """Host + path only — strip query/fragment (OAuth codes)."""
+    try:
+        parts = urlparse(str(url or ""))
+        if not parts.scheme and not parts.netloc:
+            return "(url)"
+        path = parts.path or "/"
+        return f"{parts.scheme}://{parts.netloc}{path}"
+    except Exception:  # noqa: BLE001
+        return "(url)"
+
+
+def _signed_in_payload(url: str) -> dict[str, Any]:
+    host = urlparse(url or "").hostname or ""
+    return {"ok": True, "host": host}
+
+
 def _connect_pages(page, context) -> list:
     """Live tabs for a connect session: primary page first, then others."""
     out: list = []
@@ -204,7 +221,7 @@ def _extract_battlenet_inline(page, context, session: AuthSession | None = None)
     def _on_signed_in(_creds: dict[str, str]) -> None:
         if session:
             live = _battlenet_live_page(page, context)
-            session.emit("signed_in", {"url": getattr(live, "url", None) or BATTLENET_GAMES_URL})
+            session.emit("signed_in", _signed_in_payload(getattr(live, "url", None) or BATTLENET_GAMES_URL))
 
     return run_connect_poll(
         context=context,
@@ -503,7 +520,8 @@ def _extract_gog_inline(page, context, session: AuthSession | None = None) -> di
 
     def _on_signed_in(creds: dict[str, str]) -> None:
         if session:
-            session.emit("signed_in", {"url": page.url or "https://www.gog.com/"})
+            host = urlparse(page.url or "https://www.gog.com/").hostname or ""
+            session.emit("signed_in", _signed_in_payload(page.url or "https://www.gog.com/"))
 
     return run_connect_poll(
         context=context,
@@ -658,7 +676,7 @@ def _extract_psn(page, context, session: AuthSession | None = None) -> dict[str,
             body = ""
 
         if _psn_on_blocked_account_page(url, body):
-            connect_log("psn", f"blocked account page url={(url or '')[:120]}", key="blocked")
+            connect_log("psn", f"blocked account page url={_safe_connect_log_url(url)[:120]}", key="blocked")
             if now - last_blocked_nav[0] > 6:
                 last_blocked_nav[0] = now
                 try:
@@ -1135,7 +1153,7 @@ def _extract_xbox_wishlist_inline(page, context, session) -> dict[str, str]:
         msa_ready = _xbox_has_msa_session(context)
         connect_log(
             "xbox_wishlist",
-            f"poll url={url!r} login={on_login} wishlist={on_wishlist} "
+            f"poll url={_safe_connect_log_url(url)!r} login={on_login} wishlist={on_wishlist} "
             f"handoff={on_handoff} mid={mid_exchange} done={handoff_done} "
             f"dom_signed_in={dom_signed_in_any} msa={msa_ready} token={token_ready}",
             key="poll",
@@ -1322,7 +1340,7 @@ def _extract_nintendo_wishlist_inline(page, context, session) -> dict[str, str]:
         ready = _nintendo_wishlist_session_ready(html, url, api_payloads)
         connect_log(
             "nintendo_wishlist",
-            f"poll url={url!r} signed_out={signed_out} graphql_ok={graphql_ok} "
+            f"poll url={_safe_connect_log_url(url)!r} signed_out={signed_out} graphql_ok={graphql_ok} "
             f"customer_ok={customer_ok} ready={ready}",
             key="poll",
         )
@@ -1465,7 +1483,7 @@ def _extract_ubisoft(page, context, session: AuthSession | None = None) -> dict[
         if on_success and not seen_success:
             seen_success = True
             if session:
-                session.emit("signed_in", {"url": UBISOFT_SUCCESS_URL})
+                session.emit("signed_in", _signed_in_payload(UBISOFT_SUCCESS_URL))
 
         if (on_success or seen_success) and nudged < len(UBISOFT_LIBRARY_URLS):
             try:
@@ -1678,7 +1696,7 @@ def _extract_ea(page, context, session: AuthSession | None = None) -> dict[str, 
             else:
                 nudged = True
                 if session:
-                    session.emit("signed_in", {"url": page.url or EA_LOGIN_URL})
+                    session.emit("signed_in", _signed_in_payload(page.url or EA_LOGIN_URL))
                 try:
                     page.bring_to_front()
                 except Exception:

--- a/auth/runner.py
+++ b/auth/runner.py
@@ -520,7 +520,6 @@ def _extract_gog_inline(page, context, session: AuthSession | None = None) -> di
 
     def _on_signed_in(creds: dict[str, str]) -> None:
         if session:
-            host = urlparse(page.url or "https://www.gog.com/").hostname or ""
             session.emit("signed_in", _signed_in_payload(page.url or "https://www.gog.com/"))
 
     return run_connect_poll(

--- a/auth/secrets.py
+++ b/auth/secrets.py
@@ -447,6 +447,9 @@ def _atomic_write_secrets(data: bytes) -> None:
             fh.flush()
             os.fsync(fh.fileno())
         os.replace(tmp, path)
+        _restrict_file_permissions(path)
+        if bak.exists():
+            _restrict_file_permissions(bak)
     except Exception:
         try:
             if tmp.exists():

--- a/fetchers/fetch_epic.py
+++ b/fetchers/fetch_epic.py
@@ -652,6 +652,13 @@ def main() -> int:
                 playtime_applied += 1
         print(f"  applied playtime to {playtime_applied} games", flush=True)
 
+    empty_exit = refuse_empty_result(
+        catalog_game_count(games_out),
+        label="Epic playable library rows",
+    )
+    if empty_exit is not None:
+        return stats.finish("fetch_epic", t0, exit_code=empty_exit)
+
     payload = {
         "fetched_at": datetime.now(UTC).isoformat(),
         "store": "epic",

--- a/js/bind-events.js
+++ b/js/bind-events.js
@@ -81,6 +81,7 @@ import { recordSponsoredClick } from './anon-metrics.js';
 import { dismissSponsoredDeal, isProPromoSponsorId, refreshSponsoredSurfaces } from './sponsored-deals.js';
 import { goToProView, isProActivationPending } from './pro-view.js';
 import { isPro } from './auth-gate.js';
+import { baklogFetch } from './api-client.js';
 import { openCoverGallery } from './cover-gallery.js';
 import { initTrophyPopover } from './trophy-popover.js';
 import {
@@ -937,7 +938,7 @@ export function bindEvents() {
   document.getElementById("copyDiagnostics")?.addEventListener("click", async () => {
     kebabMenu.classList.remove("open");
     try {
-      const res = await fetch('/api/diagnostics');
+      const res = await baklogFetch('/api/diagnostics');
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'Diagnostics request failed');
       await navigator.clipboard.writeText(JSON.stringify(data, null, 2));

--- a/js/error-boundary.js
+++ b/js/error-boundary.js
@@ -590,8 +590,13 @@ function scrubErrorText(text) {
   if (typeof text !== 'string' || !text) return text;
   return text
     .replace(/Bearer\s+[A-Za-z0-9._\-]+/gi, 'Bearer [redacted]')
-    .replace(/(Cookie:\s*)([^\s;]+)/gi, '$1[redacted]')
-    .replace(/api[_-]?key["']?\s*[:=]\s*["']?[\w\-]+/gi, 'api_key=[redacted]');
+    .replace(/(Cookie:\s*)(.+)$/gim, '$1[redacted]')
+    .replace(/(set-cookie:\s*)(.+)$/gim, '$1[redacted]')
+    .replace(/api[_-]?key["']?\s*[:=]\s*["']?[\w\-]+/gi, 'api_key=[redacted]')
+    .replace(/(NPSSO[=:\s]+)[\w\-\.]+/gi, '$1[redacted]')
+    .replace(/(refresh_token[=:\s"']+)[\w\-\.]+/gi, '$1[redacted]')
+    .replace(/([?&]ticket=)[^&\s]+/gi, '$1[redacted]')
+    .replace(/([?&#](?:code|access_token|authorizationCode)=)[^&\s#'"]+/gi, '$1[redacted]');
 }
 
 function safeCount() {

--- a/landing/api/auth-config.js
+++ b/landing/api/auth-config.js
@@ -42,6 +42,26 @@ export default {
     if (!supabaseUrl || !supabaseAnonKey) {
       return Response.json({ error: "Auth not configured" }, { status: 503 });
     }
+    // Footgun guard: never publish a service_role / secret key as "anon".
+    const keyLower = supabaseAnonKey.toLowerCase();
+    let jwtRoleService = false;
+    try {
+      const part = supabaseAnonKey.split(".")[1] || "";
+      const b64 = part.replace(/-/g, "+").replace(/_/g, "/");
+      const pad = b64 + "=".repeat((4 - (b64.length % 4)) % 4);
+      const json = atob(pad);
+      jwtRoleService = /"role"\s*:\s*"service_role"/.test(json);
+    } catch {
+      jwtRoleService = false;
+    }
+    if (
+      keyLower.includes("service_role") ||
+      keyLower.startsWith("sb_secret_") ||
+      jwtRoleService
+    ) {
+      console.error("auth-config: refusing to return non-anon key");
+      return Response.json({ error: "Auth misconfigured" }, { status: 503 });
+    }
     return Response.json(
       { supabaseUrl, supabaseAnonKey },
       {

--- a/landing/api/polar-webhook.js
+++ b/landing/api/polar-webhook.js
@@ -144,6 +144,19 @@ async function findSupabaseUserId({ url, key, externalId, email }) {
 }
 
 async function setUserPlan({ url, key, userId, plan }) {
+  const getR = await fetch(`${url}/auth/v1/admin/users/${userId}`, {
+    headers: {
+      apikey: key,
+      Authorization: `Bearer ${key}`,
+    },
+  });
+  if (!getR.ok) {
+    const detail = await getR.text().catch(() => "");
+    throw new Error(`Supabase admin GET ${getR.status}: ${detail}`);
+  }
+  const user = await getR.json().catch(() => ({}));
+  const meta = { ...(user?.app_metadata || {}) };
+  meta.plan = plan;
   const r = await fetch(`${url}/auth/v1/admin/users/${userId}`, {
     method: "PUT",
     headers: {
@@ -151,7 +164,7 @@ async function setUserPlan({ url, key, userId, plan }) {
       Authorization: `Bearer ${key}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ app_metadata: { plan } }),
+    body: JSON.stringify({ app_metadata: meta }),
   });
   if (!r.ok) {
     const detail = await r.text().catch(() => "");
@@ -175,6 +188,9 @@ export default {
 
     // Raw body is required for signature verification — do not parse first.
     const body = await request.text();
+    if (body.length > 1024 * 1024) {
+      return Response.json({ error: "Payload too large" }, { status: 413 });
+    }
     const ok = await verifySignature({
       secret,
       id: request.headers.get("webhook-id"),

--- a/landing/api/report.js
+++ b/landing/api/report.js
@@ -208,7 +208,7 @@ export default {
     const view = bundle.runtime?.view || "unknown";
     const appVersion = bundle.app_version || "unknown";
 
-    console.log(`bug_report\t${reportTime}\t${appVersion}\t${view}\t${contact || "(no contact)"}`);
+    console.log(`bug_report\t${reportTime}\t${appVersion}\t${view}\t${contact ? "contact=yes" : "contact=no"}`);
 
     try {
       await logToSupabase({ bundle, contact, note, ip, time: reportTime });

--- a/landing/api/subscribe.js
+++ b/landing/api/subscribe.js
@@ -170,14 +170,28 @@ export default {
       });
     }
 
-    const rawText = await request.text();
-    if (rawText.length > MAX_BODY_BYTES) {
+    const contentLength = Number(request.headers.get("content-length") || 0);
+    if (contentLength > MAX_BODY_BYTES) {
       return Response.json({ error: "Payload too large" }, { status: 413 });
+    }
+
+    let rawText = "";
+    if (typeof request.text === "function") {
+      rawText = await request.text();
+      if (rawText.length > MAX_BODY_BYTES) {
+        return Response.json({ error: "Payload too large" }, { status: 413 });
+      }
     }
 
     let body;
     try {
-      body = rawText ? JSON.parse(rawText) : {};
+      if (rawText) {
+        body = JSON.parse(rawText);
+      } else if (typeof request.json === "function") {
+        body = await request.json();
+      } else {
+        body = {};
+      }
     } catch {
       body = {};
     }

--- a/landing/api/subscribe.js
+++ b/landing/api/subscribe.js
@@ -11,6 +11,19 @@ import { checkRateLimit } from "./_rate-limit.js";
 const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
 const MAX_BODY_BYTES = 8 * 1024;
 
+function isAllowedSubscribeOrigin(origin) {
+  if (!origin || typeof origin !== "string") return false;
+  if (origin === "https://baklog.app") return true;
+  try {
+    const u = new URL(origin);
+    if (u.protocol !== "http:") return false;
+    if (u.hostname !== "127.0.0.1" && u.hostname !== "localhost") return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function sanitizeEmail(raw) {
   if (typeof raw !== "string") return "";
   return raw.replace(/[\x00-\x1f\x7f]/g, "").trim();
@@ -137,6 +150,13 @@ export default {
       return Response.json({ error: "Method not allowed" }, { status: 405 });
     }
 
+    const origin = request.headers.get("Origin") || "";
+    // Browser posts must come from the landing origin (bots can still forge Origin;
+    // this blocks casual CSRF from other sites).
+    if (origin && !isAllowedSubscribeOrigin(origin)) {
+      return Response.json({ error: "Origin not allowed" }, { status: 403 });
+    }
+
     const ip = clientIp(request);
     const rate = await checkRateLimit(ip, { namespace: "subscribe" });
     if (rate.misconfigured) {
@@ -150,14 +170,14 @@ export default {
       });
     }
 
-    const contentLength = Number(request.headers.get("content-length") || 0);
-    if (contentLength > MAX_BODY_BYTES) {
+    const rawText = await request.text();
+    if (rawText.length > MAX_BODY_BYTES) {
       return Response.json({ error: "Payload too large" }, { status: 413 });
     }
 
     let body;
     try {
-      body = await request.json();
+      body = rawText ? JSON.parse(rawText) : {};
     } catch {
       body = {};
     }

--- a/packaging/apply_update.ps1
+++ b/packaging/apply_update.ps1
@@ -100,10 +100,36 @@ function Get-FileSha256([string]$Path) {
 
 function Expand-ZipDotNet([string]$ZipPath, [string]$Destination) {
     Add-Type -AssemblyName System.IO.Compression.FileSystem
-    if (Test-Path -LiteralPath $Destination) {
+    if (-not (Test-Path -LiteralPath $Destination)) {
         [System.IO.Directory]::CreateDirectory($Destination) | Out-Null
     }
-    [System.IO.Compression.ZipFile]::ExtractToDirectory($ZipPath, $Destination)
+    $destFull = [System.IO.Path]::GetFullPath($Destination).TrimEnd("\", "/") + [System.IO.Path]::DirectorySeparatorChar
+    $zip = [System.IO.Compression.ZipFile]::OpenRead($ZipPath)
+    try {
+        foreach ($entry in $zip.Entries) {
+            $name = $entry.FullName
+            if ([string]::IsNullOrWhiteSpace($name)) { continue }
+            # Zip-slip: reject absolute / parent traversal members.
+            if ($name.StartsWith("/") -or $name.StartsWith("\") -or $name -match '^[A-Za-z]:' -or $name.Contains("..")) {
+                throw "Refusing zip entry with unsafe path: $name"
+            }
+            $target = [System.IO.Path]::GetFullPath((Join-Path $Destination $name))
+            if (-not $target.StartsWith($destFull, [System.StringComparison]::OrdinalIgnoreCase)) {
+                throw "Refusing zip-slip entry: $name -> $target"
+            }
+            if ($name.EndsWith("/") -or $name.EndsWith("\")) {
+                [System.IO.Directory]::CreateDirectory($target) | Out-Null
+                continue
+            }
+            $parent = Split-Path -Parent $target
+            if ($parent -and -not (Test-Path -LiteralPath $parent)) {
+                [System.IO.Directory]::CreateDirectory($parent) | Out-Null
+            }
+            [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $target, $true)
+        }
+    } finally {
+        $zip.Dispose()
+    }
 }
 
 function Restore-InstallFromBackup([string]$InstallDir, [string]$BackupDir) {

--- a/packaging/bundle-auth.env.example
+++ b/packaging/bundle-auth.env.example
@@ -3,5 +3,6 @@
 #
 # BAKLOG_SUPABASE_URL=https://xxxx.supabase.co
 # BAKLOG_SUPABASE_ANON_KEY=eyJ...
-# BAKLOG_SUPABASE_JWT_SECRET=   # optional legacy HS256; omit if JWKS-only
+# Do NOT put BAKLOG_SUPABASE_JWT_SECRET here — it must never ship in release zips.
+# Frozen builds verify via JWKS. Keep JWT secret in GitHub Actions / local .env for HS256 dev only.
 # BAKLOG_LOCAL_PROFILES=0       # optional; default off for hosted accounts

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -12,11 +12,16 @@ run_ps1() {
   elif command -v powershell >/dev/null 2>&1; then
     powershell -NoProfile -ExecutionPolicy Bypass -File "$1"
   else
-    echo "[pre-push] PowerShell not found — skipping $1." >&2
-    return 0
+    echo "[pre-push] PowerShell not found — cannot run leakcheck. Install pwsh or powershell." >&2
+    return 1
   fi
 }
 
 run_ps1 "$LEAK_PS1" || exit $?
-run_ps1 "$SYNC_PS1"
-exit $?
+# Sync is best-effort on machines without PowerShell for the sync script only —
+# but leakcheck above already failed closed.
+if command -v pwsh >/dev/null 2>&1 || command -v powershell >/dev/null 2>&1; then
+  run_ps1 "$SYNC_PS1"
+  exit $?
+fi
+exit 0

--- a/scripts/hooks/pre-push-leakcheck.ps1
+++ b/scripts/hooks/pre-push-leakcheck.ps1
@@ -11,9 +11,17 @@ $patterns = @(
     "profiles/",
     "data/",
     ".env",
+    ".env.local",
+    ".env.production",
+    ".env.imported",
+    "packaging/bundle-auth.env",
     "secrets.bin",
     "tracker.html",
-    "cache/auth/"
+    "cache/auth/",
+    "admin/",
+    "marketing/",
+    "docs/",
+    "audit/"
 )
 
 $tracked = git -C $repoRoot ls-files 2>$null

--- a/scripts/release_preflight.ps1
+++ b/scripts/release_preflight.ps1
@@ -64,7 +64,7 @@ if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
     }
     Write-Host "    BAKLOG_SUPABASE_URL + BAKLOG_SUPABASE_ANON_KEY present"
     if ($secrets -contains "BAKLOG_SUPABASE_JWT_SECRET") {
-        Write-Host "    BAKLOG_SUPABASE_JWT_SECRET present (optional but recommended)"
+        Write-Host "    BAKLOG_SUPABASE_JWT_SECRET present in GitHub (dev/HS256 only - never bundled into release zips)"
     }
 }
 

--- a/scripts/replace_release_tag.ps1
+++ b/scripts/replace_release_tag.ps1
@@ -27,7 +27,22 @@ if ($pyVer -ne $bare) {
     throw "pyproject.toml version '$pyVer' does not match -Version '$bare'. Bump or fix version files first."
 }
 
-Write-Host "Replace release $tag from HEAD $(git rev-parse --short HEAD)"
+$branch = (git rev-parse --abbrev-ref HEAD).Trim()
+if ($branch -ne "main") {
+    throw "Refuse replace_release_tag: HEAD is '$branch' (must be on main)."
+}
+$status = git status --porcelain
+if ($status) {
+    throw "Refuse replace_release_tag: working tree is dirty. Commit or stash first."
+}
+git fetch origin main --quiet
+$head = (git rev-parse HEAD).Trim()
+$originMain = (git rev-parse origin/main).Trim()
+if ($head -ne $originMain) {
+    throw "Refuse replace_release_tag: HEAD ($head) is not origin/main ($originMain). Push/pull first."
+}
+
+Write-Host "Replace release $tag from HEAD $(git rev-parse --short HEAD) on main"
 Write-Host "This deletes remote tag + GitHub Release, then re-pushes $tag (release.yml re-builds assets)."
 
 if ($DryRun) {
@@ -44,6 +59,8 @@ if (-not $Force) {
     if ($confirm -ne "REPLACE $tag") {
         Write-Error "Aborted."
     }
+} else {
+    Write-Host "WARNING: -Force skips interactive confirm but still requires main + clean + origin/main tip."
 }
 
 $releaseExists = $false

--- a/scripts/sync-internal-repo.ps1
+++ b/scripts/sync-internal-repo.ps1
@@ -113,9 +113,40 @@ function Assert-SafeInternalDestination([string]$SourceRoot, [string]$DestRoot) 
 }
 
 function Copy-InternalPath([string]$RepoRoot, [string]$InternalRepo, [string]$rel) {
+    if ([string]::IsNullOrWhiteSpace($rel)) {
+        throw "Refusing empty internal-manifest path."
+    }
+    if ([System.IO.Path]::IsPathRooted($rel) -or $rel.Contains("..")) {
+        throw "Refusing unsafe internal-manifest path: $rel"
+    }
     $src = Join-Path $RepoRoot $rel
     if (-not (Test-Path -LiteralPath $src)) { return $false }
     $dest = Join-Path $InternalRepo $rel
+    $repoRootFull = [System.IO.Path]::GetFullPath($RepoRoot).TrimEnd("\", "/") + [System.IO.Path]::DirectorySeparatorChar
+    $internalFull = [System.IO.Path]::GetFullPath($InternalRepo).TrimEnd("\", "/") + [System.IO.Path]::DirectorySeparatorChar
+    $srcFull = [System.IO.Path]::GetFullPath($src)
+    $destFull = [System.IO.Path]::GetFullPath($dest)
+    $srcOk = $srcFull.StartsWith($repoRootFull, [System.StringComparison]::OrdinalIgnoreCase) -or
+        ($srcFull.TrimEnd("\", "/") -ieq $repoRootFull.TrimEnd("\", "/"))
+    $destOk = $destFull.StartsWith($internalFull, [System.StringComparison]::OrdinalIgnoreCase) -or
+        ($destFull.TrimEnd("\", "/") -ieq $internalFull.TrimEnd("\", "/"))
+    if (-not $srcOk -or -not $destOk) {
+        throw "Refusing path escape in internal sync: rel=$rel src=$srcFull dest=$destFull"
+    }
+    # Block Discord webhook URLs from being re-synced into the private repo.
+    if ($srcItem = Get-Item -LiteralPath $src -ErrorAction SilentlyContinue) {
+        $scanRoots = @()
+        if ($srcItem.PSIsContainer) { $scanRoots = @(Get-ChildItem -LiteralPath $src -Recurse -File -Force -ErrorAction SilentlyContinue) }
+        else { $scanRoots = @($srcItem) }
+        foreach ($f in $scanRoots) {
+            if ($f.Extension -match '\.(js|ts|md|json|txt|html)$') {
+                $hit = Select-String -LiteralPath $f.FullName -Pattern "discord.com/api/webhooks/" -SimpleMatch -ErrorAction SilentlyContinue
+                if ($hit) {
+                    throw "Refusing sync: Discord webhook URL found in $($f.FullName). Move webhooks to BAKLOG_DISCORD_WEBHOOK_URLS env."
+                }
+            }
+        }
+    }
     $srcItem = Get-Item -LiteralPath $src
     if ($srcItem.PSIsContainer) {
         if (-not (Test-Path -LiteralPath $dest)) {

--- a/scripts/write_bundle_auth_env.py
+++ b/scripts/write_bundle_auth_env.py
@@ -15,10 +15,11 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+# Never ship BAKLOG_SUPABASE_JWT_SECRET in public release zips — that secret
+# can forge HS256 JWTs. Frozen builds verify via JWKS (anon key + URL only).
 BUNDLE_KEYS = (
     "BAKLOG_SUPABASE_URL",
     "BAKLOG_SUPABASE_ANON_KEY",
-    "BAKLOG_SUPABASE_JWT_SECRET",
     "BAKLOG_LOCAL_PROFILES",
 )
 REQUIRED_KEYS = ("BAKLOG_SUPABASE_URL", "BAKLOG_SUPABASE_ANON_KEY")

--- a/server.py
+++ b/server.py
@@ -196,7 +196,6 @@ from shared.server_stream_tickets import (  # noqa: E402, I001
     STREAM_ATTACH_POLL_SEC as _STREAM_ATTACH_POLL_SEC,
     STREAM_ATTACH_SHORT_WAIT_SEC as _STREAM_ATTACH_SHORT_WAIT_SEC,
     commit_stream_ticket as _commit_stream_ticket,
-    consume_stream_ticket as _consume_stream_ticket,
     mint_stream_ticket as _mint_stream_ticket,
     peek_stream_ticket as _peek_stream_ticket,
     stream_ticket_from_handler as _stream_ticket_from_handler,

--- a/server.py
+++ b/server.py
@@ -42,6 +42,7 @@ import atexit
 import json
 import os
 import queue
+import re
 import secrets
 import signal
 import subprocess
@@ -203,12 +204,26 @@ from shared.server_stream_tickets import (  # noqa: E402, I001
 
 
 def _authorize_stream(handler: SimpleHTTPRequestHandler) -> bool:
-    """EventSource cannot send Authorization — validate single-use ?ticket= instead."""
+    """Legacy helper: prefer peek+commit inside stream handlers (see auth stream)."""
     from shared.supabase_auth import auth_enabled
 
     if not auth_enabled():
         return True
-    profile_id = _consume_stream_ticket(_stream_ticket_from_handler(handler))
+    profile_id = _peek_stream_ticket(_stream_ticket_from_handler(handler))
+    if not profile_id:
+        _send_auth_required(handler)
+        return False
+    set_request_profile_id(profile_id)
+    return True
+
+
+def _commit_auth_stream_ticket(handler: SimpleHTTPRequestHandler) -> bool:
+    """Consume one ticket use only after the auth session is confirmed present."""
+    from shared.supabase_auth import auth_enabled
+
+    if not auth_enabled():
+        return True
+    profile_id = _commit_stream_ticket(_stream_ticket_from_handler(handler))
     if not profile_id:
         _send_auth_required(handler)
         return False
@@ -1234,8 +1249,6 @@ class Handler(SimpleHTTPRequestHandler):
             self._handle_stream(path[len("/api/stream/"):])
             return
         if path.startswith("/api/auth/") and path.endswith("/stream"):
-            if not _authorize_stream(self):
-                return
             rest = path[len("/api/auth/") : -len("/stream")].strip("/")
             self._handle_auth_stream(rest)
             return
@@ -1579,6 +1592,9 @@ class Handler(SimpleHTTPRequestHandler):
         appid = (qs.get("appid") or [""])[0].strip()
         if not appid:
             _send_json(self, HTTPStatus.BAD_REQUEST, {"error": "missing appid"})
+            return
+        if not re.fullmatch(r"\d{1,10}", appid):
+            _send_json(self, HTTPStatus.BAD_REQUEST, {"error": "invalid appid"})
             return
         import urllib.request
 
@@ -2159,12 +2175,12 @@ class Handler(SimpleHTTPRequestHandler):
             _api_error(self, HTTPStatus.INTERNAL_SERVER_ERROR, "auth_start_failed", exc)
 
     def _public_callback_url(self, path: str) -> str:
-        """Build an absolute URL to ``path`` from the request Host (tunnel-aware)."""
-        host = self.headers.get("Host") or f"{HOST}:{PORT}"
-        proto = (self.headers.get("X-Forwarded-Proto") or "http").strip().lower()
-        if proto not in ("http", "https"):
-            proto = "http"
-        return f"{proto}://{host}{path}"
+        """Build an absolute callback URL (loopback by default; tunnel via env)."""
+        base = (os.environ.get("BAKLOG_PUBLIC_BASE_URL") or "").strip().rstrip("/")
+        if base.startswith("http://") or base.startswith("https://"):
+            return f"{base}{path}"
+        # Prefer fixed loopback over Host / X-Forwarded-* (spoofable via proxy).
+        return f"http://127.0.0.1:{PORT}{path}"
 
     def _handle_epic_oauth_url(self) -> None:
         """Mint a profile-bound OAuth state and return the Epic browser sign-in URL."""
@@ -2316,6 +2332,8 @@ class Handler(SimpleHTTPRequestHandler):
     def _handle_auth_stream(self, session_id: str) -> None:
         global _sse_connections
         session_id = session_id.strip("/").split("/", 1)[0]
+        if not _authorize_stream(self):
+            return
         try:
             from auth.manager import get_auth_session
         except ImportError as exc:
@@ -2324,6 +2342,8 @@ class Handler(SimpleHTTPRequestHandler):
         session = get_auth_session(session_id)
         if session is None:
             self.send_error(HTTPStatus.NOT_FOUND, "Unknown auth session")
+            return
+        if not _commit_auth_stream_ticket(self):
             return
 
         with _sse_lock:

--- a/shared/log_redact.py
+++ b/shared/log_redact.py
@@ -26,7 +26,12 @@ LOG_REDACT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"(XBL_API_KEY[\"']?\s*[=:]\s*)[\"']?[\w\-\.]+", re.I), r"\1[redacted]"),
     (re.compile(r"(UBISOFT_SESSION_ID[\"']?\s*[=:]\s*)[\"']?[\w\-\.]+", re.I), r"\1[redacted]"),
     (re.compile(r"(STEAM_API_KEY[\"']?\s*[=:]\s*)[\"']?[\w\-\.]+", re.I), r"\1[redacted]"),
+    (re.compile(r"(ITAD_API_KEY[\"']?\s*[=:]\s*)[\"']?[\w\-\.]+", re.I), r"\1[redacted]"),
+    (re.compile(r"(ITCH_API_KEY[\"']?\s*[=:]\s*)[\"']?[\w\-\.]+", re.I), r"\1[redacted]"),
     (re.compile(r"(Authorization:\s*)(?!Bearer\s)([^\s,]+)", re.I), r"\1[redacted]"),
+    # OAuth / Connect URL fragments that may land in connect-*.log.
+    (re.compile(r"([?&#](?:code|access_token|authorizationCode)=)[^&\s#'\"]+", re.I), r"\1[redacted]"),
+    (re.compile(r"(#code=)[^&\s#'\"]+", re.I), r"\1[redacted]"),
 ]
 
 
@@ -37,12 +42,24 @@ def redact_log_line(text: str) -> str:
     return out
 
 
+def _redact_tail_field(value: Any) -> Any:
+    """Redact a log-tail field that may be a string or list[str]."""
+    if isinstance(value, str) and value:
+        return "\n".join(redact_log_line(line) for line in value.splitlines())
+    if isinstance(value, list):
+        return [redact_log_line(str(line)) for line in value]
+    return value
+
+
 def redact_diagnostics_payload(payload: dict[str, Any]) -> dict[str, Any]:
     """Redact sensitive tokens from diagnostics fields before serving over HTTP."""
-    tail = payload.get("refresh_log_tail")
-    if isinstance(tail, str) and tail:
-        payload = dict(payload)
-        payload["refresh_log_tail"] = "\n".join(
-            redact_log_line(line) for line in tail.splitlines()
-        )
-    return payload
+    out = dict(payload)
+    for key in ("refresh_log_tail", "apply_log_tail"):
+        if key in out:
+            out[key] = _redact_tail_field(out.get(key))
+    tails = out.get("connect_log_tails")
+    if isinstance(tails, dict) and tails:
+        out["connect_log_tails"] = {
+            str(name): _redact_tail_field(lines) for name, lines in tails.items()
+        }
+    return out

--- a/shared/run_manager.py
+++ b/shared/run_manager.py
@@ -1469,7 +1469,7 @@ class RunManager:
         try:
             from auth.manager import subprocess_env_for_profile
 
-            env = subprocess_env_for_profile(run.profile_id)
+            env = subprocess_env_for_profile(run.profile_id, fetcher_key=run.key)
         except Exception as exc:
             run.status = "failed"
             run.exit_code = -1

--- a/tests/polar-webhook.test.js
+++ b/tests/polar-webhook.test.js
@@ -29,6 +29,13 @@ async function postWebhook(event, { secret = WEBHOOK_SECRET, env = {} } = {}) {
       return { ok: true, json: async () => '11111111-1111-4111-8111-111111111111' };
     }
     if (String(url).includes('/auth/v1/admin/users/')) {
+      const method = (init?.method || 'GET').toUpperCase();
+      if (method === 'GET') {
+        return {
+          ok: true,
+          json: async () => ({ id: 'u1', app_metadata: { beta: true } }),
+        };
+      }
       return { ok: true, json: async () => ({}) };
     }
     throw new Error(`unexpected fetch ${url} ${init?.method || ''}`);
@@ -122,8 +129,13 @@ describe('polar-webhook', () => {
     expect(res.status).toBe(202);
     expect(json.plan).toBe('pro');
     expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/rpc/get_user_id_by_email'))).toBe(false);
-    const adminCall = fetchMock.mock.calls.find(([url]) => String(url).includes('/auth/v1/admin/users/'));
-    expect(adminCall?.[1]?.body).toContain('"plan":"pro"');
+    const putCall = fetchMock.mock.calls.find(
+      ([url, init]) =>
+        String(url).includes('/auth/v1/admin/users/') &&
+        String(init?.method || '').toUpperCase() === 'PUT',
+    );
+    expect(putCall?.[1]?.body).toContain('"plan":"pro"');
+    expect(putCall?.[1]?.body).toContain('"beta":true');
   });
 
   it('downgrades to free on subscription.revoked', async () => {
@@ -136,8 +148,13 @@ describe('polar-webhook', () => {
     });
     expect(res.status).toBe(202);
     expect(json.plan).toBe('free');
-    const adminCall = fetchMock.mock.calls.find(([url]) => String(url).includes('/auth/v1/admin/users/'));
-    expect(adminCall?.[1]?.body).toContain('"plan":"free"');
+    const putCall = fetchMock.mock.calls.find(
+      ([url, init]) =>
+        String(url).includes('/auth/v1/admin/users/') &&
+        String(init?.method || '').toUpperCase() === 'PUT',
+    );
+    expect(putCall?.[1]?.body).toContain('"plan":"free"');
+    expect(putCall?.[1]?.body).toContain('"beta":true');
   });
 
   it('acknowledges unmatched buyers without updating Supabase', async () => {

--- a/tests/test_apply_update_ps1.py
+++ b/tests/test_apply_update_ps1.py
@@ -190,7 +190,11 @@ def test_apply_update_ps1_avoids_module_cmdlets() -> None:
     assert "taskkill" not in text.lower()
     assert "$PID" in text
     assert "apply-started.json" in text
-    assert "ExtractToDirectory" in text
+    # Prefer entry-by-entry extract (zip-slip checks) over ExtractToDirectory.
+    assert "Expand-ZipDotNet" in text
+    assert "zip-slip" in text
+    assert "ExtractToFile" in text
+    assert "ExtractToDirectory" not in text
 
 
 def test_apply_update_ps1_kill_helper_excludes_self() -> None:

--- a/tests/test_log_redact_diagnostics.py
+++ b/tests/test_log_redact_diagnostics.py
@@ -1,0 +1,33 @@
+"""Diagnostics redaction must scrub list tails and connect logs."""
+
+from __future__ import annotations
+
+from shared.log_redact import redact_diagnostics_payload, redact_log_line
+
+
+def test_redact_log_line_oauth_and_itad() -> None:
+    line = "poll url='https://login.live.com/oauth20?code=SECRET123&x=1' ITAD_API_KEY=abcd"
+    out = redact_log_line(line)
+    assert "SECRET123" not in out
+    assert "abcd" not in out
+    assert "[redacted]" in out
+
+
+def test_redact_diagnostics_payload_list_tails() -> None:
+    payload = {
+        "refresh_log_tail": ["Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig", "ok"],
+        "apply_log_tail": "NPSSO=deadbeefcookie\nnext",
+        "connect_log_tails": {
+            "connect-xbox.log": [
+                "poll url='https://x.com/auth#code=oauth_secret_value' token=True",
+            ],
+        },
+        "version": "0.9.00",
+    }
+    out = redact_diagnostics_payload(payload)
+    assert isinstance(out["refresh_log_tail"], list)
+    assert "eyJhbGciOiJIUzI1NiJ9" not in out["refresh_log_tail"][0]
+    assert "Bearer [redacted]" in out["refresh_log_tail"][0]
+    assert "deadbeefcookie" not in out["apply_log_tail"]
+    assert "oauth_secret_value" not in out["connect_log_tails"]["connect-xbox.log"][0]
+    assert out["version"] == "0.9.00"

--- a/tests/test_profile_env_isolation.py
+++ b/tests/test_profile_env_isolation.py
@@ -161,3 +161,35 @@ def test_subprocess_env_omits_unset_provider_keys(
     assert "STEAM_API_KEY" not in env
     assert env.get("ITAD_COUNTRY") is None  # non-credential settings not injected
     assert env.get("BAKLOG_PROFILE") == "work"
+
+
+def test_subprocess_env_scopes_credentials_to_fetcher(
+    isolated_profiles: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    create_profile("Work")
+    set_active_profile("work")
+    monkeypatch.setenv("BAKLOG_PROFILE", "work")
+    set_provider_blob("steam", {"STEAM_API_KEY": "steam-key", "STEAM_ID": "1", "status": "connected"})
+    set_provider_blob("itad", {"ITAD_API_KEY": "itad-key", "status": "connected"})
+    set_provider_blob("psn", {"PSN_NPSSO": "npsso-secret", "status": "connected"})
+
+    steam_env = subprocess_env_for_profile("work", fetcher_key="steam")
+    assert steam_env.get("STEAM_API_KEY") == "steam-key"
+    assert "ITAD_API_KEY" not in steam_env
+    assert "PSN_NPSSO" not in steam_env
+
+    itad_env = subprocess_env_for_profile("work", fetcher_key="itad")
+    assert itad_env.get("ITAD_API_KEY") == "itad-key"
+    assert "STEAM_API_KEY" not in itad_env
+
+    hltb_env = subprocess_env_for_profile("work", fetcher_key="hltb")
+    assert "STEAM_API_KEY" not in hltb_env
+    assert "ITAD_API_KEY" not in hltb_env
+    assert "PSN_NPSSO" not in hltb_env
+
+    # No fetcher_key keeps prior all-creds behavior for probes/CLI.
+    all_env = subprocess_env_for_profile("work")
+    assert all_env.get("STEAM_API_KEY") == "steam-key"
+    assert all_env.get("ITAD_API_KEY") == "itad-key"
+    assert all_env.get("PSN_NPSSO") == "npsso-secret"

--- a/tests/test_run_manager.py
+++ b/tests/test_run_manager.py
@@ -960,7 +960,7 @@ def test_execute_runs_from_repo_root_for_nondefault_profile(
     monkeypatch.setattr(
         auth.manager,
         "subprocess_env_for_profile",
-        lambda pid: {"BAKLOG_PROFILE": pid, "PYTHONUNBUFFERED": "1"},
+        lambda pid, fetcher_key=None: {"BAKLOG_PROFILE": pid, "PYTHONUNBUFFERED": "1"},
     )
 
     captured: dict[str, object] = {}

--- a/tests/test_write_bundle_auth_env.py
+++ b/tests/test_write_bundle_auth_env.py
@@ -22,12 +22,15 @@ def test_main_writes_env_file(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(bundle_env, "ROOT", tmp_path)
     monkeypatch.setenv("BAKLOG_SUPABASE_URL", "https://demo.supabase.co")
     monkeypatch.setenv("BAKLOG_SUPABASE_ANON_KEY", "anon-key")
+    monkeypatch.setenv("BAKLOG_SUPABASE_JWT_SECRET", "must-not-ship")
     rc = bundle_env.main([str(tmp_path / "bundle")])
     assert rc == 0
     text = (tmp_path / "bundle" / ".env").read_text(encoding="utf-8")
     assert "BAKLOG_SUPABASE_URL=https://demo.supabase.co" in text
     assert "BAKLOG_SUPABASE_ANON_KEY=anon-key" in text
     assert "SERVICE_ROLE" not in text
+    assert "BAKLOG_SUPABASE_JWT_SECRET" not in text
+    assert "must-not-ship" not in text
 
 
 def test_main_fails_without_required_keys(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Stop shipping `BAKLOG_SUPABASE_JWT_SECRET` in release zips; JWKS-only for frozen auth
- Fix diagnostics redaction (list/connect tails), Steam `appid` validation, least-privilege fetcher env
- Scrub Connect OAuth URLs in logs; ACL `secrets.bin`; Epic playable empty guard; auth SSE ticket peek/commit
- Harden pre-push leakcheck (fail-closed), sync path confinement + webhook scan, release retag gates, zip-slip extract
- Landing: subscribe Origin + body size; Polar `app_metadata` merge; auth-config service_role guard; report contact not logged

## Test plan
- [x] `pytest` focused: log_redact, write_bundle_auth_env, profile_env_isolation, run_manager execute cwd
- [x] `vitest` error-boundary
- [ ] CI green on this PR
- [ ] Ops: rotate Supabase JWT if prior releases bundled it; confirm old Discord webhooks deleted

## Ops follow-up
See PR comment / agent handoff for full ops checklist.