### PR TITLE
Add experimental Linux frozen zip and CI preview

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,148 @@
+# Experimental Linux frozen build (workflow_dispatch preview).
+# Builds BAKLOG-linux64.zip on ubuntu-22.04 (glibc 2.35 baseline), runs frozen
+# smokes headlessly, then uploads zip + sha256 + SBOM as workflow artifacts.
+# Promote into release.yml on v* tags only after 2-3 clean dispatch runs.
+name: Build Linux (preview)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+  attestations: write
+
+concurrency:
+  group: build-linux-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-linux:
+    name: Build and smoke Linux zip
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    env:
+      BAKLOG_NO_BROWSER: "1"
+      BAKLOG_NO_CHROMIUM_DOWNLOAD: "1"
+      BAKLOG_IDLE_SHUTDOWN_MINUTES: "0"
+      BAKLOG_PROFILE: smoke
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install zip utility
+        run: sudo apt-get update && sudo apt-get install -y zip
+
+      - name: Verify release auth secrets (fail fast)
+        env:
+          BAKLOG_SUPABASE_URL: ${{ secrets.BAKLOG_SUPABASE_URL }}
+          BAKLOG_SUPABASE_ANON_KEY: ${{ secrets.BAKLOG_SUPABASE_ANON_KEY }}
+        run: |
+          if [ -z "$BAKLOG_SUPABASE_URL" ] || [ -z "$BAKLOG_SUPABASE_ANON_KEY" ]; then
+            echo "::error::GitHub repo secrets BAKLOG_SUPABASE_URL and BAKLOG_SUPABASE_ANON_KEY must be set."
+            exit 1
+          fi
+          echo "Release auth secrets present (values not printed)."
+
+      - name: Build Linux bundle
+        env:
+          BAKLOG_SUPABASE_URL: ${{ secrets.BAKLOG_SUPABASE_URL }}
+          BAKLOG_SUPABASE_ANON_KEY: ${{ secrets.BAKLOG_SUPABASE_ANON_KEY }}
+        run: bash packaging/build_linux.sh
+
+      - name: Isolate smoke home (XDG)
+        run: |
+          mkdir -p "$RUNNER_TEMP/baklog-home/.local/share"
+          echo "HOME=$RUNNER_TEMP/baklog-home" >> "$GITHUB_ENV"
+          echo "XDG_DATA_HOME=$RUNNER_TEMP/baklog-home/.local/share" >> "$GITHUB_ENV"
+
+      - name: Chromium pin smoke (linux64)
+        run: |
+          python - <<'PY'
+          from shared.chromium_runtime import is_allowed_cft_url, load_pin, platform_key
+          assert platform_key() == "linux64", platform_key()
+          pin = load_pin()
+          entry = (pin.get("platforms") or {}).get("linux64")
+          assert isinstance(entry, dict), entry
+          url = str(entry.get("url") or "")
+          sha = str(entry.get("sha256") or "")
+          assert is_allowed_cft_url(url), url
+          assert len(sha) == 64, sha
+          print("chromium pin linux64 ok")
+          PY
+
+      - name: XDG data-dir smoke
+        run: |
+          python - <<'PY'
+          import os
+          from pathlib import Path
+          from shared.install_paths import default_frozen_data_dir
+          home = Path(os.environ["HOME"]).resolve()
+          xdg = Path(os.environ["XDG_DATA_HOME"]).resolve()
+          got = default_frozen_data_dir()
+          expect = (xdg / "baklog").resolve()
+          assert got == expect, (got, expect, home)
+          print(f"default_frozen_data_dir ok: {got}")
+          PY
+
+      - name: Frozen import smoke
+        run: python scripts/frozen_import_smoke.py --exe release/BAKLOG/BAKLOG
+
+      - name: Frozen bundle smoke
+        run: python scripts/frozen_bundle_smoke.py release/BAKLOG
+
+      - name: Frozen connect smoke
+        run: python scripts/frozen_connect_smoke.py --exe release/BAKLOG/BAKLOG
+
+      - name: Verify Linux artifacts exist
+        run: |
+          test -f release/BAKLOG-linux64.zip
+          test -f release/BAKLOG-linux64.sha256
+          test -x release/BAKLOG/BAKLOG
+          test -x "release/BAKLOG/Start BAKLOG.sh"
+          test ! -e "release/BAKLOG/BAKLOG Tray"
+          (
+            cd release
+            sha256sum -c BAKLOG-linux64.sha256
+          )
+          ls -lh release/BAKLOG-linux64.zip release/BAKLOG-linux64.sha256
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: release/BAKLOG
+          format: spdx-json
+          output-file: release/BAKLOG-linux64.sbom.spdx.json
+
+      - name: Generate build provenance attestation
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: release/BAKLOG-linux64.zip
+
+      - name: Attest SBOM
+        uses: actions/attest-sbom@v2
+        with:
+          subject-path: release/BAKLOG-linux64.zip
+          sbom-path: release/BAKLOG-linux64.sbom.spdx.json
+
+      - name: Upload preview artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: BAKLOG-linux64-preview
+          path: |
+            release/BAKLOG-linux64.zip
+            release/BAKLOG-linux64.sha256
+            release/BAKLOG-linux64.sbom.spdx.json
+          if-no-files-found: error
+          retention-days: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [Unreleased]
 
+### Added
+
+- Experimental Linux zip build (`BAKLOG-linux64.zip`) for testers who prefer a packaged app to running from source (server + Start script; no tray yet).
+
 ### Changed
 
 - baklog.app is open beta: signup email still collected, confirmation includes the GitHub Releases download link.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ See [PRIVACY.md](PRIVACY.md) for the data-handling story (TL;DR: library and cre
 |----|--------|
 | **Windows 10/11** | Fully supported (primary development target) |
 | **macOS** | Supported with limits — **Amazon Games (launcher)** and **GOG Galaxy (local)** are Windows/macOS-only local sources |
-| **Linux** | Supported with limits — **Amazon Games (launcher)** and **GOG Galaxy (local)** are unavailable; use web Connect instead |
+| **Linux** | Supported with limits - Amazon Games (launcher) and GOG Galaxy (local) unavailable (use web Connect). Experimental frozen zip (`BAKLOG-linux64.zip`) available via CI preview; source-run still recommended |
 
 The app itself (dashboard, `server.py`, secret storage, browser sign-in) is OS-agnostic. **Windows-only local source:** **Amazon Games (launcher)** reads the desktop launcher's DPAPI-encrypted SQLite (no portable equivalent) — on macOS/Linux use **Amazon (Prime Gaming, web)** Connect instead; the Amazon fetcher still runs and auto-picks the web session. **GOG Galaxy (local)** reads `galaxy-2.0.db` from the Galaxy install (Windows ProgramData or macOS Shared) — there is no supported Linux path, so Linux users use **GOG (web)** instead. Platform-restricted local providers show as **Unavailable** on unsupported OSes; their fetcher chips stay enabled when a web fallback exists.
 

--- a/guide/faq.md
+++ b/guide/faq.md
@@ -58,7 +58,7 @@ We are onboarding in small waves so we can fix what breaks on real setups before
 |----|--------|
 | **Windows 10/11** | Fully supported (primary development target) |
 | **macOS** | Supported with limits - Amazon Games (launcher) and GOG Galaxy (local) are Windows/macOS-only local sources |
-| **Linux** | Supported with limits - Amazon Games (launcher) and GOG Galaxy (local) are unavailable; use web Connect instead |
+| **Linux** | Supported with limits - Amazon Games (launcher) and GOG Galaxy (local) unavailable (use web Connect). Experimental `BAKLOG-linux64.zip` packaged build in preview |
 
 The app itself (dashboard, server, secret storage, browser sign-in) is OS-agnostic. Platform-restricted local providers show as **Unavailable** on unsupported OSes; web fallbacks remain available.
 

--- a/guide/getting-started.md
+++ b/guide/getting-started.md
@@ -41,6 +41,23 @@ Portable zip builds work too: unzip to a normal folder, then run `Start BAKLOG.b
 3. If macOS blocks the app ("cannot be opened"), right-click **BAKLOG Tray** → **Open** once, or run `xattr -cr /path/to/BAKLOG` in Terminal. See [Unsigned beta builds](troubleshooting.md#unsigned-beta-builds-no-code-signing).
 4. Library data lives in `~/Library/Application Support/BAKLOG-Data` (or beside the app when `portable.txt` is present). In-app updates use `apply_update.sh` once a mac zip is on the release.
 
+## Beta (Linux)
+
+Experimental packaged zip (no tray icon yet). Prefer a desktop session or GUI VM - Connect needs a headed browser.
+
+1. Download **BAKLOG-linux64.zip** from [GitHub Releases](https://github.com/Ogrods/BAKLOG/releases/latest) when published, or from a CI preview artifact while it is still experimental.
+2. Unzip to a normal folder, then run:
+
+   ```bash
+   chmod +x "BAKLOG/Start BAKLOG.sh" BAKLOG/BAKLOG
+   ./BAKLOG/Start\ BAKLOG.sh
+   ```
+
+3. Your browser should open **http://127.0.0.1:8765**. Closing the terminal stops the server (there is no tray menu on Linux yet).
+4. Library data lives in `~/.local/share/baklog` (or `$XDG_DATA_HOME/baklog`). Optional login autostart uses `~/.config/autostart/BAKLOG.desktop` when enabled from the app.
+5. Install Google Chrome or Chromium for Connections, or set `BAKLOG_CHROME_PATH`. If neither is installed, first Connect can download a one-time browser (~150 MB) when online.
+6. Use **GOG (web)** and **Amazon (Prime Gaming, web)** - Galaxy local and Amazon launcher DB are not available on Linux.
+
 ## Install (from source)
 
 1. Clone or download the repo from [GitHub](https://github.com/Ogrods/BAKLOG).

--- a/packaging/apply_update.sh
+++ b/packaging/apply_update.sh
@@ -119,7 +119,11 @@ remove_old_backups() {
   done
 }
 
-start_tray_if_present() {
+is_linux() {
+  [[ "$(uname -s 2>/dev/null || true)" == "Linux" ]]
+}
+
+start_app_if_present() {
   if [[ -z "$INSTALL_DIR" ]]; then
     return 0
   fi
@@ -129,9 +133,25 @@ start_tray_if_present() {
       cd "$INSTALL_DIR"
       exec "./BAKLOG Tray" >/dev/null 2>&1 &
     )
+  elif is_linux && [[ -x "$INSTALL_DIR/BAKLOG" ]]; then
+    # Linux MVP ships without a tray; relaunch the server in a new session.
+    write_apply_log "relaunching server (linux MVP, no tray)"
+    (
+      cd "$INSTALL_DIR"
+      if command -v setsid >/dev/null 2>&1; then
+        setsid ./BAKLOG >/dev/null 2>&1 &
+      else
+        ./BAKLOG >/dev/null 2>&1 &
+      fi
+    )
   else
-    write_apply_log "tray binary missing; cannot relaunch"
+    write_apply_log "tray/server binary missing; cannot relaunch"
   fi
+}
+
+# Back-compat alias for fail()/early-exit paths that still call the old name.
+start_tray_if_present() {
+  start_app_if_present
 }
 
 wait_pid_gone() {
@@ -238,7 +258,8 @@ touch_applying_lock
 BUNDLE_ROOT=""
 while IFS= read -r -d '' candidate; do
   parent="$(dirname "$candidate")"
-  if [[ -f "$parent/BAKLOG Tray" ]]; then
+  # macOS/Windows bundles include BAKLOG Tray; Linux MVP is server-only.
+  if [[ -f "$parent/BAKLOG Tray" ]] || { is_linux && [[ -f "$parent/BAKLOG" ]]; }; then
     BUNDLE_ROOT="$parent"
     break
   fi
@@ -271,17 +292,32 @@ if ! (
   exit 1
 fi
 
-if [[ ! -f "$INSTALL_DIR/BAKLOG Tray" ]]; then
+if [[ ! -f "$INSTALL_DIR/BAKLOG" ]]; then
   restored=false
   if restore_install_from_backup "$INSTALL_DIR" "$BACKUP_DIR"; then
     restored=true
   fi
-  write_apply_result false "Updated bundle missing tray launcher" "$VERSION" "$restored"
-  start_tray_if_present
+  write_apply_result false "Updated bundle missing BAKLOG server" "$VERSION" "$restored"
+  start_app_if_present
   exit 1
 fi
 
-chmod +x "$INSTALL_DIR/BAKLOG" "$INSTALL_DIR/BAKLOG Tray" 2>/dev/null || true
+if [[ ! -f "$INSTALL_DIR/BAKLOG Tray" ]]; then
+  if is_linux; then
+    write_apply_log "no tray binary in bundle (linux MVP)"
+  else
+    restored=false
+    if restore_install_from_backup "$INSTALL_DIR" "$BACKUP_DIR"; then
+      restored=true
+    fi
+    write_apply_result false "Updated bundle missing tray launcher" "$VERSION" "$restored"
+    start_app_if_present
+    exit 1
+  fi
+fi
+
+chmod +x "$INSTALL_DIR/BAKLOG" 2>/dev/null || true
+chmod +x "$INSTALL_DIR/BAKLOG Tray" 2>/dev/null || true
 remove_old_backups "$INSTALL_PARENT" "$BACKUP_DIR"
 write_apply_result true "" "$VERSION" false
 # Drop ready package so the relaunched app does not rehydrate Install & restart.
@@ -291,8 +327,7 @@ if [[ -d "$VERSION_DIR" ]]; then
   rmdir "$VERSION_DIR" 2>/dev/null || true
 fi
 
-write_apply_log "starting tray"
-cd "$INSTALL_DIR"
-exec "./BAKLOG Tray" >/dev/null 2>&1 &
+write_apply_log "starting app after apply"
+start_app_if_present
 
 exit 0

--- a/packaging/baklog.spec
+++ b/packaging/baklog.spec
@@ -1,18 +1,28 @@
 # -*- mode: python ; coding: utf-8 -*-
-# PyInstaller spec for BAKLOG (Windows onedir). Run via packaging/build_windows.ps1.
-# Dual entry: BAKLOG.exe (server + fetcher dispatch) and BAKLOG Tray.exe (primary launcher).
+# PyInstaller spec for BAKLOG. Run via packaging/build_windows.ps1,
+# packaging/build_macos.sh, or packaging/build_linux.sh.
+# Dual entry on Windows/macOS: BAKLOG (+ .exe) and BAKLOG Tray.
+# Linux MVP: server binary only (no tray; Start BAKLOG.sh launches BAKLOG).
 
 import sys
 from pathlib import Path
 
 root = Path(SPEC).resolve().parent.parent
 app_icon = str(root / "packaging" / "BAKLOG.ico")
+_build_tray = sys.platform in ("win32", "darwin")
 
-_keyring_backends = (
-    ["keyring.backends.Windows"]
-    if sys.platform == "win32"
-    else ["keyring.backends.macOS"]
-)
+if sys.platform == "win32":
+    _keyring_backends = ["keyring.backends.Windows"]
+elif sys.platform == "darwin":
+    _keyring_backends = ["keyring.backends.macOS"]
+else:
+    # Linux SecretService + transitive deps PyInstaller often misses.
+    _keyring_backends = [
+        "keyring.backends.SecretService",
+        "secretstorage",
+        "jeepney",
+        "jeepney.io.blocking",
+    ]
 
 block_cipher = None
 
@@ -100,26 +110,7 @@ a = Analysis(
     noarchive=False,
 )
 
-a_tray = Analysis(
-    [str(root / "tray_app.py")],
-    pathex=[str(root)],
-    binaries=[],
-    datas=[],
-    hiddenimports=tray_hiddenimports,
-    hookspath=[],
-    hooksconfig={},
-    runtime_hooks=[],
-    excludes=["tests", "landing", "marketing", "node_modules"],
-    win_no_prefer_redirects=False,
-    win_private_assemblies=False,
-    cipher=block_cipher,
-    noarchive=False,
-)
-
-MERGE((a, "BAKLOG", "BAKLOG"), (a_tray, "BAKLOG", "BAKLOG Tray"))
-
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
-pyz_tray = PYZ(a_tray.pure, a_tray.zipped_data, cipher=block_cipher)
 
 exe = EXE(
     pyz,
@@ -140,38 +131,67 @@ exe = EXE(
     icon=app_icon,
 )
 
-exe_tray = EXE(
-    pyz_tray,
-    a_tray.scripts,
-    [],
-    exclude_binaries=True,
-    name="BAKLOG Tray",
-    debug=False,
-    bootloader_ignore_signals=False,
-    strip=False,
-    upx=True,
-    console=False,
-    disable_windowed_traceback=False,
-    argv_emulation=False,
-    target_arch=None,
-    codesign_identity=None,
-    entitlements_file=None,
-    icon=app_icon,
-)
-
-coll = COLLECT(
-    exe,
-    exe_tray,
-    a.binaries,
-    a.zipfiles,
-    a.datas,
-    # MERGE assigns tray-only deps (pystray, Pillow's _imaging.pyd) to a_tray;
-    # COLLECT must aggregate them too or the tray exe falls back to headless.
-    a_tray.binaries,
-    a_tray.zipfiles,
-    a_tray.datas,
-    strip=False,
-    upx=True,
-    upx_exclude=[],
-    name="BAKLOG",
-)
+if _build_tray:
+    a_tray = Analysis(
+        [str(root / "tray_app.py")],
+        pathex=[str(root)],
+        binaries=[],
+        datas=[],
+        hiddenimports=tray_hiddenimports,
+        hookspath=[],
+        hooksconfig={},
+        runtime_hooks=[],
+        excludes=["tests", "landing", "marketing", "node_modules"],
+        win_no_prefer_redirects=False,
+        win_private_assemblies=False,
+        cipher=block_cipher,
+        noarchive=False,
+    )
+    MERGE((a, "BAKLOG", "BAKLOG"), (a_tray, "BAKLOG", "BAKLOG Tray"))
+    pyz_tray = PYZ(a_tray.pure, a_tray.zipped_data, cipher=block_cipher)
+    exe_tray = EXE(
+        pyz_tray,
+        a_tray.scripts,
+        [],
+        exclude_binaries=True,
+        name="BAKLOG Tray",
+        debug=False,
+        bootloader_ignore_signals=False,
+        strip=False,
+        upx=True,
+        console=False,
+        disable_windowed_traceback=False,
+        argv_emulation=False,
+        target_arch=None,
+        codesign_identity=None,
+        entitlements_file=None,
+        icon=app_icon,
+    )
+    coll = COLLECT(
+        exe,
+        exe_tray,
+        a.binaries,
+        a.zipfiles,
+        a.datas,
+        # MERGE assigns tray-only deps (pystray, Pillow's _imaging.pyd) to a_tray;
+        # COLLECT must aggregate them too or the tray exe falls back to headless.
+        a_tray.binaries,
+        a_tray.zipfiles,
+        a_tray.datas,
+        strip=False,
+        upx=True,
+        upx_exclude=[],
+        name="BAKLOG",
+    )
+else:
+    # Linux MVP: server binary only.
+    coll = COLLECT(
+        exe,
+        a.binaries,
+        a.zipfiles,
+        a.datas,
+        strip=False,
+        upx=True,
+        upx_exclude=[],
+        name="BAKLOG",
+    )

--- a/packaging/build_linux.sh
+++ b/packaging/build_linux.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Build BAKLOG Linux onedir bundle with PyInstaller + zip + sha256 sidecar.
+# Run from repo root. Requires: Python 3.11+, Node 22+, pip install pyinstaller.
+#
+# Release artifacts use STABLE filenames (same pattern as build_macos.sh):
+#   BAKLOG-linux64.zip
+#   BAKLOG-linux64.sha256
+#
+# Linux MVP: server binary + Start BAKLOG.sh (no tray icon).
+#
+# Usage:
+#   ./packaging/build_linux.sh
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+RELEASE_DIR="${ROOT}/release"
+OUT_DIR="${RELEASE_DIR}/BAKLOG"
+
+if [[ -x "${ROOT}/.venv/bin/python" ]]; then
+  PYTHON="${ROOT}/.venv/bin/python"
+else
+  PYTHON="python3"
+fi
+
+echo "Installing Python dependencies..."
+"${PYTHON}" -m pip install -r requirements.txt
+"${PYTHON}" -m pip install pyinstaller secretstorage jeepney
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm not found - install Node.js 22+ before building the frozen bundle" >&2
+  exit 1
+fi
+
+echo "Building production frontend (esbuild dist/)..."
+npm ci
+npm run vendor:supabase
+npm run build
+npm run check:dist-integrity
+
+mkdir -p "${RELEASE_DIR}"
+
+echo "Building BAKLOG (onedir, server only)..."
+"${PYTHON}" -m PyInstaller packaging/baklog.spec --noconfirm --distpath "${RELEASE_DIR}" --workpath "${ROOT}/build/pyinstaller"
+
+SERVER_BIN="${OUT_DIR}/BAKLOG"
+if [[ ! -x "${SERVER_BIN}" ]]; then
+  echo "Build failed: ${SERVER_BIN} not found" >&2
+  exit 1
+fi
+
+FALLBACK_JSON="${OUT_DIR}/_internal/curated/free_claims.fallback.json"
+if [[ ! -f "${FALLBACK_JSON}" ]]; then
+  echo "Build failed: bundled curated feed missing at ${FALLBACK_JSON}" >&2
+  exit 1
+fi
+
+cp -f "${ROOT}/packaging/BETA-README.txt" "${OUT_DIR}/BETA-README.txt"
+cp -f "${ROOT}/packaging/apply_update.sh" "${OUT_DIR}/apply_update.sh"
+chmod +x "${OUT_DIR}/apply_update.sh" "${SERVER_BIN}"
+
+echo "Writing bundled account-auth .env..."
+if [[ -z "${BAKLOG_SUPABASE_URL:-}" || -z "${BAKLOG_SUPABASE_ANON_KEY:-}" ]]; then
+  echo "  Auth env: BAKLOG_SUPABASE_URL=${BAKLOG_SUPABASE_URL:+set}${BAKLOG_SUPABASE_URL:-MISSING}, BAKLOG_SUPABASE_ANON_KEY=${BAKLOG_SUPABASE_ANON_KEY:+set}${BAKLOG_SUPABASE_ANON_KEY:-MISSING}" >&2
+fi
+"${PYTHON}" "${ROOT}/scripts/write_bundle_auth_env.py" "${OUT_DIR}"
+
+cat > "${OUT_DIR}/Start BAKLOG.sh" <<'EOF'
+#!/usr/bin/env bash
+cd "$(dirname "$0")"
+xdg-open "http://127.0.0.1:8765" >/dev/null 2>&1 || true
+exec "./BAKLOG"
+EOF
+chmod +x "${OUT_DIR}/Start BAKLOG.sh"
+
+VERSION="0.0.0"
+if [[ -f "${ROOT}/pyproject.toml" ]]; then
+  VERSION="$(grep -E '^version\s*=' "${ROOT}/pyproject.toml" | head -1 | sed -E 's/.*"([^"]+)".*/\1/')"
+fi
+
+ZIP_NAME="BAKLOG-linux64.zip"
+ZIP_PATH="${RELEASE_DIR}/${ZIP_NAME}"
+rm -f "${ZIP_PATH}"
+(
+  cd "${RELEASE_DIR}"
+  zip -r -q "${ZIP_NAME}" BAKLOG
+)
+
+if command -v sha256sum >/dev/null 2>&1; then
+  HASH="$(sha256sum "${ZIP_PATH}" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  HASH="$(shasum -a 256 "${ZIP_PATH}" | awk '{print $1}')"
+else
+  echo "sha256sum or shasum required" >&2
+  exit 1
+fi
+HASH_FILE="${RELEASE_DIR}/BAKLOG-linux64.sha256"
+printf '%s  %s' "${HASH}" "${ZIP_NAME}" > "${HASH_FILE}"
+
+echo ""
+echo "Done (Linux experimental zip - Ubuntu 22.04 / glibc 2.35+ recommended)."
+echo "  Folder:  ${OUT_DIR}"
+echo "  Zip:     ${ZIP_PATH}"
+echo "  SHA256:  ${HASH_FILE}"
+echo "  Version: ${VERSION} (embedded in bundle; zip filename is stable)"
+echo "Upload both zip + .sha256 after CI smokes pass (workflow_dispatch preview first)."

--- a/scripts/frozen_bundle_smoke.py
+++ b/scripts/frozen_bundle_smoke.py
@@ -1,6 +1,5 @@
 import argparse
 import json
-import os
 import re
 import subprocess
 import sys

--- a/scripts/frozen_bundle_smoke.py
+++ b/scripts/frozen_bundle_smoke.py
@@ -14,6 +14,12 @@ _REPO = Path(__file__).resolve().parents[1]
 if str(_REPO) not in sys.path:
     sys.path.insert(0, str(_REPO))
 
+from scripts.frozen_smoke_paths import (  # noqa: E402
+    frozen_server_path,
+    frozen_tray_path,
+    smoke_home_env,
+)
+
 
 def _read_expected_version():
     text = (_REPO / "pyproject.toml").read_text(encoding="utf-8")
@@ -59,16 +65,19 @@ def run_smoke(bundle_dir, *, expected_version=None):
     bundle_dir = bundle_dir.resolve()
     version = expected_version or _read_expected_version()
     report = {"ok": False, "bundle_dir": str(bundle_dir), "checks": {}}
-    server_exe = bundle_dir / "BAKLOG.exe"
-    tray_exe = bundle_dir / "BAKLOG Tray.exe"
+    server_exe = frozen_server_path(bundle_dir)
+    tray_exe = frozen_tray_path(bundle_dir)
     fallback = bundle_dir / "_internal" / "curated" / "free_claims.fallback.json"
     env_path = bundle_dir / ".env"
-    static_ok = server_exe.is_file() and tray_exe.is_file() and fallback.is_file()
+    tray_required = tray_exe is not None
+    tray_ok = (not tray_required) or tray_exe.is_file()
+    static_ok = server_exe.is_file() and tray_ok and fallback.is_file()
     fetcher_count = _manifest_fetcher_count(bundle_dir)
     env_ok, env_missing = _env_has_auth_keys(env_path)
     report["checks"]["static"] = {
         "server_exe": server_exe.is_file(),
-        "tray_exe": tray_exe.is_file(),
+        "tray_exe": tray_exe.is_file() if tray_exe is not None else None,
+        "tray_required": tray_required,
         "curated_fallback": fallback.is_file(),
         "fetcher_manifest_count": fetcher_count,
         "bundled_env": env_ok,
@@ -99,10 +108,7 @@ def run_smoke(bundle_dir, *, expected_version=None):
         return report
     try:
         with tempfile.TemporaryDirectory(prefix="baklog-bundle-smoke-") as td:
-            localappdata = Path(td)
-            env = {**os.environ, "LOCALAPPDATA": str(localappdata), "BAKLOG_NO_BROWSER": "1"}
-            env.pop("BAKLOG_DATA_DIR", None)
-            env.pop("BAKLOG_PORTABLE", None)
+            env, _data_dir = smoke_home_env(Path(td))
             proc = subprocess.Popen(
                 [str(server_exe)],
                 cwd=str(bundle_dir),

--- a/scripts/frozen_connect_smoke.py
+++ b/scripts/frozen_connect_smoke.py
@@ -235,7 +235,7 @@ def main() -> int:
     )
     ap.add_argument(
         "--exe", type=Path, required=True,
-        help="Path to frozen BAKLOG.exe",
+        help="Path to frozen BAKLOG server binary",
     )
     ap.add_argument(
         "--json-out", type=Path, default=None,

--- a/scripts/frozen_data_dir_migration_smoke.py
+++ b/scripts/frozen_data_dir_migration_smoke.py
@@ -1,6 +1,5 @@
 import argparse
 import json
-import os
 import shutil
 import subprocess
 import sys
@@ -15,6 +14,10 @@ from scripts.smoke_port_guard import (  # noqa: E402
     port_listener_pid,
     wait_for_owned_server,
 )
+from scripts.frozen_smoke_paths import (  # noqa: E402
+    frozen_server_path,
+    smoke_home_env,
+)
 from shared.bundled_auth_env import parse_env_file  # noqa: E402
 
 
@@ -24,7 +27,7 @@ def _wait_for_server(base, proc, *, timeout_sec=25.0):
 
 def run_smoke(bundle_dir):
     bundle_dir = bundle_dir.resolve()
-    exe = bundle_dir / "BAKLOG.exe"
+    exe = frozen_server_path(bundle_dir)
     if not exe.is_file():
         raise FileNotFoundError(f"missing frozen server: {exe}")
     legacy_profiles = bundle_dir / "profiles"
@@ -46,15 +49,11 @@ def run_smoke(bundle_dir):
     proc = None
     try:
         with tempfile.TemporaryDirectory(prefix="baklog-migrate-smoke-") as td:
-            localappdata = Path(td)
-            data_dir = localappdata / "BAKLOG-Data"
+            env, data_dir = smoke_home_env(Path(td))
             data_dir.mkdir(parents=True, exist_ok=True)
             (data_dir / ".env").write_text(
                 "BAKLOG_SUPABASE_URL=https://stale.supabase.co\nBAKLOG_SUPABASE_ANON_KEY=stale-anon\n", encoding="utf-8"
             )
-            env = {**os.environ, "LOCALAPPDATA": str(localappdata), "BAKLOG_NO_BROWSER": "1"}
-            env.pop("BAKLOG_DATA_DIR", None)
-            env.pop("BAKLOG_PORTABLE", None)
             proc = subprocess.Popen(
                 [str(exe)],
                 cwd=str(bundle_dir),
@@ -113,7 +112,7 @@ def main():
         "--bundle-dir",
         type=Path,
         default=_REPO / "release" / "BAKLOG",
-        help="PyInstaller onedir output (contains BAKLOG.exe)",
+        help="PyInstaller onedir output (contains BAKLOG server binary)",
     )
     parser.add_argument("--json-out", type=Path, default=None, help="Write JSON report to this path")
     args = parser.parse_args()

--- a/scripts/frozen_data_dir_migration_smoke.py
+++ b/scripts/frozen_data_dir_migration_smoke.py
@@ -9,14 +9,14 @@ from pathlib import Path
 _REPO = Path(__file__).resolve().parents[1]
 if str(_REPO) not in sys.path:
     sys.path.insert(0, str(_REPO))
+from scripts.frozen_smoke_paths import (  # noqa: E402
+    frozen_server_path,
+    smoke_home_env,
+)
 from scripts.smoke_port_guard import (  # noqa: E402
     port_collision_message,
     port_listener_pid,
     wait_for_owned_server,
-)
-from scripts.frozen_smoke_paths import (  # noqa: E402
-    frozen_server_path,
-    smoke_home_env,
 )
 from shared.bundled_auth_env import parse_env_file  # noqa: E402
 

--- a/scripts/frozen_fetcher_smoke.py
+++ b/scripts/frozen_fetcher_smoke.py
@@ -87,8 +87,14 @@ def _live_ok(row):
 
 
 def main():
+    from shared.update_platform import server_binary_name
+
     ap = argparse.ArgumentParser(description="Frozen fetcher fleet smoke test")
-    ap.add_argument("--exe", type=Path, default=_REPO / "release" / "BAKLOG" / "BAKLOG.exe")
+    ap.add_argument(
+        "--exe",
+        type=Path,
+        default=_REPO / "release" / "BAKLOG" / server_binary_name(),
+    )
     ap.add_argument("--data-dir", type=Path, default=_REPO)
     ap.add_argument("--profile", default=os.environ.get("BAKLOG_PROFILE", "").strip() or None)
     ap.add_argument("--dispatch-only", action="store_true", help="Only run --help dispatch checks")
@@ -96,7 +102,7 @@ def main():
     args = ap.parse_args()
     exe = args.exe.resolve()
     if not exe.is_file():
-        print(f"BAKLOG.exe not found: {exe}", file=sys.stderr)
+        print(f"BAKLOG server binary not found: {exe}", file=sys.stderr)
         return 2
     data_dir = args.data_dir.resolve()
     env = os.environ.copy()

--- a/scripts/frozen_import_smoke.py
+++ b/scripts/frozen_import_smoke.py
@@ -7,8 +7,9 @@ BAKLOG.exe with -c "import X; print('ok')" for each module.
 
 Usage:
     python scripts/frozen_import_smoke.py --exe release/BAKLOG/BAKLOG.exe
+    python scripts/frozen_import_smoke.py --exe release/BAKLOG/BAKLOG
 
-The frozen exe is invoked as ``BAKLOG.exe --import-check <module>`` (not
+The frozen exe is invoked as ``BAKLOG --import-check <module>`` (not
 ``python -c``), which server.py handles and exits before binding the HTTP port.
 """
 
@@ -127,7 +128,7 @@ def run_smoke(exe: Path) -> dict:
 
 def main():
     ap = argparse.ArgumentParser(description="Frozen bundle import-chain smoke test")
-    ap.add_argument("--exe", type=Path, required=True, help="Path to frozen BAKLOG.exe")
+    ap.add_argument("--exe", type=Path, required=True, help="Path to frozen BAKLOG server binary")
     ap.add_argument("--json-out", type=Path, default=None, help="Write JSON report to file")
     args = ap.parse_args()
 

--- a/scripts/frozen_smoke_paths.py
+++ b/scripts/frozen_smoke_paths.py
@@ -1,0 +1,46 @@
+"""Shared path/env helpers for frozen bundle smoke scripts."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def frozen_server_path(bundle_dir: Path) -> Path:
+    from shared.update_platform import server_binary_name
+
+    return bundle_dir / server_binary_name()
+
+
+def frozen_tray_path(bundle_dir: Path) -> Path | None:
+    from shared.update_platform import tray_binary_name
+
+    name = tray_binary_name()
+    if not name:
+        return None
+    return bundle_dir / name
+
+
+def smoke_home_env(temp_home: Path) -> tuple[dict[str, str], Path]:
+    """Build env overrides and expected default frozen data dir under *temp_home*.
+
+    Mirrors ``shared.install_paths.default_frozen_data_dir`` for the current OS
+    without requiring ``sys.frozen``.
+    """
+    env = {**os.environ, "BAKLOG_NO_BROWSER": "1"}
+    env.pop("BAKLOG_DATA_DIR", None)
+    env.pop("BAKLOG_PORTABLE", None)
+    if sys.platform == "win32":
+        env["LOCALAPPDATA"] = str(temp_home)
+        data_dir = temp_home / "BAKLOG-Data"
+    elif sys.platform == "darwin":
+        env["HOME"] = str(temp_home)
+        data_dir = temp_home / "Library" / "Application Support" / "BAKLOG"
+    else:
+        # linux / other POSIX: XDG_DATA_HOME/baklog
+        xdg = temp_home / ".local" / "share"
+        env["HOME"] = str(temp_home)
+        env["XDG_DATA_HOME"] = str(xdg)
+        data_dir = xdg / "baklog"
+    return env, data_dir

--- a/shared/uninstall_cleanup.py
+++ b/shared/uninstall_cleanup.py
@@ -1,4 +1,8 @@
-"""Windows uninstall helpers: login autostart registry, keyring, and data dir."""
+"""Uninstall helpers: login autostart, keyring, and data dir (all platforms).
+
+``cleanup_autostart`` delegates to ``shared.startup.disable_startup`` which already
+covers Windows registry, macOS LaunchAgent, and Linux XDG autostart.
+"""
 
 from __future__ import annotations
 
@@ -43,7 +47,7 @@ def _request_graceful_shutdown() -> bool:
 
 
 def cleanup_autostart() -> None:
-    """Remove HKCU Run\\BAKLOG login autostart (safe when the app is uninstalled)."""
+    """Remove login autostart registration (Windows / macOS / Linux)."""
     disable_startup()
 
 

--- a/shared/update_platform.py
+++ b/shared/update_platform.py
@@ -9,25 +9,29 @@ from pathlib import Path
 _PLATFORM_ARTIFACTS: dict[str, tuple[str, str]] = {
     "win32": ("BAKLOG-win64.zip", "BAKLOG-win64.sha256"),
     "darwin": ("BAKLOG-macos.zip", "BAKLOG-macos.sha256"),
+    "linux": ("BAKLOG-linux64.zip", "BAKLOG-linux64.sha256"),
 }
 
+# Tray is optional on Linux MVP (server + Start BAKLOG.sh only).
 _PLATFORM_BUNDLE_FILES: dict[str, tuple[str, ...]] = {
     "win32": ("BAKLOG.exe", "BAKLOG Tray.exe"),
     "darwin": ("BAKLOG", "BAKLOG Tray"),
+    "linux": ("BAKLOG",),
 }
 
 _PLATFORM_APPLY_SCRIPT: dict[str, str] = {
     "win32": "apply_update.ps1",
     "darwin": "apply_update.sh",
+    "linux": "apply_update.sh",
 }
 
-_SUPPORTED_APPLY_PLATFORMS = frozenset({"win32", "darwin"})
+_SUPPORTED_APPLY_PLATFORMS = frozenset({"win32", "darwin", "linux"})
 
 
 def release_platform(platform: str | None = None) -> str:
-    """Platform key for GitHub release zip/sha256 names (win32 or darwin).
+    """Platform key for GitHub release zip/sha256 names (win32, darwin, or linux).
 
-    Linux dev/CI has no release bundle; callers fall back to win32 artifact names.
+    Unknown platforms fall back to win32 artifact names (legacy CI callers).
     """
     plat = platform or sys.platform
     if plat in _PLATFORM_ARTIFACTS:
@@ -85,7 +89,9 @@ def server_binary_name(platform: str | None = None) -> str:
 
 
 def tray_binary_name(platform: str | None = None) -> str:
-    return required_bundle_files(platform)[1]
+    """Tray launcher basename, or empty string when the platform ships without a tray (Linux MVP)."""
+    files = required_bundle_files(platform)
+    return files[1] if len(files) > 1 else ""
 
 
 def apply_log_path() -> Path:
@@ -132,7 +138,7 @@ def launch_apply_subprocess(*, script: Path, manifest_path: Path, install_dir: P
                 stdout=log_file,
                 stderr=subprocess.STDOUT,
             )
-        if platform == "darwin":
+        if platform in ("darwin", "linux"):
             cmd = [
                 "/bin/bash",
                 str(script),

--- a/shared/update_release.py
+++ b/shared/update_release.py
@@ -290,7 +290,7 @@ def safe_extract_zip(zip_path: Path, dest_dir: Path) -> Path:
 
 def locate_bundle_root(extracted_dir: Path, platform: str | None = None) -> Path:
     """Find the directory containing required frozen executables."""
-    plats = (platform,) if platform is not None else ("win32", "darwin")
+    plats = (platform,) if platform is not None else ("win32", "darwin", "linux")
     for plat in plats:
         server_name = server_binary_name(plat)
         required = required_bundle_files(plat)

--- a/tests/test_frozen_bundle_smoke.py
+++ b/tests/test_frozen_bundle_smoke.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 from pathlib import Path
 
 import scripts.frozen_bundle_smoke as smoke
+from shared.update_platform import server_binary_name, tray_binary_name
 
 
 def _stub_bundle(tmp_path: Path, *, with_env: bool = True) -> Path:
     bundle = tmp_path / "BAKLOG"
     bundle.mkdir()
-    (bundle / "BAKLOG.exe").write_text("", encoding="utf-8")
-    (bundle / "BAKLOG Tray.exe").write_text("", encoding="utf-8")
+    (bundle / server_binary_name()).write_text("", encoding="utf-8")
+    tray = tray_binary_name()
+    if tray:
+        (bundle / tray).write_text("", encoding="utf-8")
     internal = bundle / "_internal" / "curated"
     internal.mkdir(parents=True)
     (internal / "free_claims.fallback.json").write_text("{}", encoding="utf-8")

--- a/tests/test_server_support_update.py
+++ b/tests/test_server_support_update.py
@@ -23,7 +23,8 @@ def test_update_available_compares_semver_tuple() -> None:
     assert update_available("0.9.0", "0.8.99") is False
 
 
-def test_build_update_check_payload_ok() -> None:
+def test_build_update_check_payload_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
     release = {
         "tag_name": "v1.2.3",
         "html_url": "https://github.com/Ogrods/BAKLOG/releases/tag/v1.2.3",
@@ -55,6 +56,7 @@ def test_build_update_check_payload_ok() -> None:
     assert payload["latest"] == "1.2.3"
     assert payload["release_notes"] == "## Notes\n- fix bug"
     assert payload["published_at"] == "2026-06-26T00:00:00Z"
+    assert payload["download_url"] is not None
     assert payload["download_url"].endswith("BAKLOG-win64.zip")
     assert payload["apply_supported"] is True
     assert payload["apply_blocked_reason"] is None

--- a/tests/test_update_platform.py
+++ b/tests/test_update_platform.py
@@ -21,24 +21,49 @@ from shared.update_release import is_allowed_download_url
 
 
 @pytest.mark.parametrize(
-    ("platform", "zip_name", "sha_name", "server", "tray", "script"),
+    ("platform", "zip_name", "sha_name", "server", "tray", "script", "bundle"),
     [
-        ("win32", "BAKLOG-win64.zip", "BAKLOG-win64.sha256", "BAKLOG.exe", "BAKLOG Tray.exe", "apply_update.ps1"),
-        ("darwin", "BAKLOG-macos.zip", "BAKLOG-macos.sha256", "BAKLOG", "BAKLOG Tray", "apply_update.sh"),
+        (
+            "win32",
+            "BAKLOG-win64.zip",
+            "BAKLOG-win64.sha256",
+            "BAKLOG.exe",
+            "BAKLOG Tray.exe",
+            "apply_update.ps1",
+            ("BAKLOG.exe", "BAKLOG Tray.exe"),
+        ),
+        (
+            "darwin",
+            "BAKLOG-macos.zip",
+            "BAKLOG-macos.sha256",
+            "BAKLOG",
+            "BAKLOG Tray",
+            "apply_update.sh",
+            ("BAKLOG", "BAKLOG Tray"),
+        ),
+        (
+            "linux",
+            "BAKLOG-linux64.zip",
+            "BAKLOG-linux64.sha256",
+            "BAKLOG",
+            "",
+            "apply_update.sh",
+            ("BAKLOG",),
+        ),
     ],
 )
-def test_platform_constants(platform, zip_name, sha_name, server, tray, script) -> None:
+def test_platform_constants(platform, zip_name, sha_name, server, tray, script, bundle) -> None:
     assert stable_zip_name(platform) == zip_name
     assert stable_sha256_name(platform) == sha_name
     assert server_binary_name(platform) == server
     assert tray_binary_name(platform) == tray
     assert apply_script_name(platform) == script
-    assert required_bundle_files(platform) == (server, tray)
+    assert required_bundle_files(platform) == bundle
 
 
 @pytest.mark.parametrize(
     "platform",
-    ["win32", "darwin"],
+    ["win32", "darwin", "linux"],
 )
 def test_is_in_app_apply_platform(platform, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("sys.platform", platform)
@@ -50,9 +75,43 @@ def test_allowed_download_urls_for_macos_asset() -> None:
     assert is_allowed_download_url(url) is True
 
 
+def test_allowed_download_urls_for_linux_asset() -> None:
+    url = "https://github.com/Ogrods/BAKLOG/releases/download/v0.9.00/BAKLOG-linux64.zip"
+    assert is_allowed_download_url(url) is True
+
+
 @pytest.mark.no_leak_check
 def test_launch_apply_subprocess_darwin(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr("shared.update_platform.sys.platform", "darwin")
+    script = tmp_path / "apply_update.sh"
+    script.write_text("#!/bin/bash\n", encoding="utf-8")
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text("{}", encoding="utf-8")
+    install = tmp_path / "install"
+    install.mkdir()
+    calls: list[dict] = []
+
+    class FakePopen:
+        def __init__(self, cmd, **kwargs):
+            calls.append({"cmd": cmd, "kwargs": kwargs})
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr("shared.update_platform.subprocess.Popen", FakePopen)
+    launch_apply_subprocess(script=script, manifest_path=manifest, install_dir=install)
+    assert calls
+    assert calls[0]["cmd"][0] == "/bin/bash"
+    assert str(script) in calls[0]["cmd"]
+    assert calls[0]["kwargs"].get("start_new_session") is True
+
+
+@pytest.mark.no_leak_check
+def test_launch_apply_subprocess_linux(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("shared.update_platform.sys.platform", "linux")
     script = tmp_path / "apply_update.sh"
     script.write_text("#!/bin/bash\n", encoding="utf-8")
     manifest = tmp_path / "manifest.json"


### PR DESCRIPTION
## Summary
- Add `packaging/build_linux.sh` + Linux-aware `baklog.spec` (server-only, no tray) producing `BAKLOG-linux64.zip`
- Extend update/apply/smoke paths for Linux/XDG and add `workflow_dispatch` Build Linux (preview) on ubuntu-22.04 with frozen smokes + SBOM
- Document experimental Linux zip in README / getting-started / CHANGELOG; keep `release.yml` promotion deferred until a few clean preview runs

## Test plan
- [ ] Required CI green on this PR (pytest, vitest, lint, size budgets)
- [ ] After merge (or on this branch): Actions → **Build Linux (preview)** → Run workflow; confirm artifact `BAKLOG-linux64-preview` uploads and smokes pass
- [ ] After green CI: rebuild local Windows freeze with `packaging\build_windows.ps1` so zip matches tip
- [ ] Confirm Windows still requires tray binary; Linux zip has `BAKLOG` + `Start BAKLOG.sh` only
