### PR TITLE
Fix bundled .env removed before Linux frozen bundle smoke

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -61,6 +61,17 @@ jobs:
           BAKLOG_SUPABASE_ANON_KEY: ${{ secrets.BAKLOG_SUPABASE_ANON_KEY }}
         run: bash packaging/build_linux.sh
 
+      - name: Verify bundled auth .env after build
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          from scripts.frozen_bundle_smoke import _env_has_auth_keys
+          env_path = Path("release/BAKLOG/.env")
+          ok, missing = _env_has_auth_keys(env_path)
+          assert ok, f"bundled .env invalid after build: missing {missing}"
+          print(f"bundled auth ok: {env_path}")
+          PY
+
       - name: Isolate smoke home (XDG)
         run: |
           mkdir -p "$RUNNER_TEMP/baklog-home/.local/share"

--- a/shared/data_dir_migration.py
+++ b/shared/data_dir_migration.py
@@ -11,11 +11,12 @@ from pathlib import Path
 MIGRATION_MARKER = ".legacy_migration_done"
 
 # Root-level catalog / config files (not directories).
+# Omit `.env` — bundled auth stays beside the exe; sync_bundled_auth_env_to_data_dir
+# copies auth keys into the data dir without removing the install copy.
 _ROOT_FILES = (
     "itad_prices.json",
     "free_claims.json",
     "sponsors.json",
-    ".env",
     "license.json",
     "refresh.log",
 )

--- a/tests/test_data_dir_migration.py
+++ b/tests/test_data_dir_migration.py
@@ -97,3 +97,21 @@ def test_migrate_skips_when_legacy_empty(tmp_path: Path) -> None:
     legacy.mkdir()
     assert migrate_legacy_colocated_data(legacy, target) == []
     assert not migration_marker_path(target).exists()
+
+
+def test_migrate_leaves_bundled_env_in_install_dir(tmp_path: Path) -> None:
+    legacy = tmp_path / "install"
+    target = tmp_path / "userdata"
+    legacy.mkdir()
+    (legacy / "profiles").mkdir()
+    (legacy / "profiles" / "index.json").write_text('{"active":"default"}', encoding="utf-8")
+    env_text = (
+        "BAKLOG_SUPABASE_URL=https://proj.supabase.co\n"
+        "BAKLOG_SUPABASE_ANON_KEY=anon-key\n"
+    )
+    (legacy / ".env").write_text(env_text, encoding="utf-8")
+
+    migrate_legacy_colocated_data(legacy, target)
+
+    assert (legacy / ".env").read_text(encoding="utf-8") == env_text
+    assert not (target / ".env").exists()


### PR DESCRIPTION
## Summary
- Stop legacy data-dir migration from moving install-dir `.env` (bundled Supabase auth must stay beside the binary)
- Add post-build bundled `.env` verification step in the Linux preview workflow
- Regression test: migration moves profiles but leaves `.env` in the install dir

## Test plan
- [x] `pytest tests/test_data_dir_migration.py tests/test_frozen_bundle_smoke.py`
- [ ] CI green on PR
- [ ] Re-run **Build Linux (preview)** workflow_dispatch on main after merge


Made with [Cursor](https://cursor.com)