### PR TITLE
Fix Linux frozen bundle smoke port leak after migration

### DIFF
--- a/scripts/frozen_bundle_smoke.py
+++ b/scripts/frozen_bundle_smoke.py
@@ -91,12 +91,16 @@ def run_smoke(bundle_dir, *, expected_version=None):
         report["error"] = f"bundled .env missing keys: {', '.join(env_missing)}"
         return report
     from scripts.frozen_data_dir_migration_smoke import run_smoke as migrate_smoke
-    from scripts.smoke_port_guard import port_collision_message, port_listener_pid
+    from scripts.smoke_port_guard import port_collision_message, port_listener_pid, ensure_dev_port_free
 
     migrate = migrate_smoke(bundle_dir)
     report["checks"]["migration"] = migrate
     if not migrate.get("ok"):
         report["error"] = "frozen_data_dir_migration_smoke failed"
+        return report
+    port_ok, port_err = ensure_dev_port_free()
+    if not port_ok:
+        report["error"] = port_err
         return report
     proc = None
     config = None
@@ -115,11 +119,19 @@ def run_smoke(bundle_dir, *, expected_version=None):
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
                 creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if sys.platform == "win32" else 0,
+                start_new_session=sys.platform != "win32",
             )
             ok, wait_err = _wait_for_server("http://127.0.0.1:8765", proc)
             if not ok:
                 err = (proc.stderr.read() if proc.stderr else b"").decode("utf-8", errors="replace")
-                report["error"] = wait_err or f"server did not respond; stderr tail: {err[-400:]}"
+                holder = port_listener_pid()
+                exit_code = proc.poll()
+                detail = wait_err or f"server did not respond; stderr tail: {err[-400:]}"
+                if holder is not None and exit_code is not None:
+                    detail = (
+                        f"{detail}; port held by pid {holder} after smoke proc exited ({exit_code})"
+                    )
+                report["error"] = detail
                 return report
             with urllib.request.urlopen("http://127.0.0.1:8765/api/config", timeout=5) as resp:
                 config = json.loads(resp.read().decode("utf-8"))
@@ -175,10 +187,9 @@ def run_smoke(bundle_dir, *, expected_version=None):
                 return report
     finally:
         if proc is not None and proc.poll() is None:
-            if sys.platform == "win32":
-                subprocess.run(["taskkill", "/F", "/PID", str(proc.pid), "/T"], capture_output=True, check=False)
-            else:
-                proc.terminate()
+            from shared.subprocess_guard import terminate_pid_tree
+
+            terminate_pid_tree(proc.pid)
     if not isinstance(config, dict):
         report["error"] = "invalid /api/config response"
         return report

--- a/scripts/frozen_bundle_smoke.py
+++ b/scripts/frozen_bundle_smoke.py
@@ -91,7 +91,7 @@ def run_smoke(bundle_dir, *, expected_version=None):
         report["error"] = f"bundled .env missing keys: {', '.join(env_missing)}"
         return report
     from scripts.frozen_data_dir_migration_smoke import run_smoke as migrate_smoke
-    from scripts.smoke_port_guard import port_collision_message, port_listener_pid, ensure_dev_port_free
+    from scripts.smoke_port_guard import ensure_dev_port_free, port_collision_message, port_listener_pid
 
     migrate = migrate_smoke(bundle_dir)
     report["checks"]["migration"] = migrate

--- a/scripts/frozen_bundle_smoke.py
+++ b/scripts/frozen_bundle_smoke.py
@@ -29,9 +29,9 @@ def _read_expected_version():
 
 
 def _wait_for_server(base, proc, *, timeout_sec=30.0):
-    from scripts.smoke_port_guard import wait_for_owned_server
+    from scripts.smoke_port_guard import wait_for_http_server
 
-    return wait_for_owned_server(proc, base, timeout_sec=timeout_sec)
+    return wait_for_http_server(proc, base, timeout_sec=timeout_sec)
 
 
 def _manifest_fetcher_count(bundle_dir):
@@ -190,6 +190,11 @@ def run_smoke(bundle_dir, *, expected_version=None):
             from shared.subprocess_guard import terminate_pid_tree
 
             terminate_pid_tree(proc.pid)
+        holder = port_listener_pid()
+        if holder is not None:
+            from shared.subprocess_guard import terminate_pid_tree
+
+            terminate_pid_tree(holder)
     if not isinstance(config, dict):
         report["error"] = "invalid /api/config response"
         return report

--- a/scripts/frozen_data_dir_migration_smoke.py
+++ b/scripts/frozen_data_dir_migration_smoke.py
@@ -95,6 +95,9 @@ def run_smoke(bundle_dir):
     finally:
         if proc is not None and proc.poll() is None:
             terminate_pid_tree(proc.pid)
+        holder = port_listener_pid()
+        if holder is not None:
+            terminate_pid_tree(holder)
         ensure_dev_port_free(timeout_sec=5.0)
         smoke_games = bundle_dir / "games_steam_smoke.json"
         if smoke_games.is_file():

--- a/scripts/frozen_data_dir_migration_smoke.py
+++ b/scripts/frozen_data_dir_migration_smoke.py
@@ -19,8 +19,8 @@ from scripts.smoke_port_guard import (  # noqa: E402
     port_listener_pid,
     wait_for_owned_server,
 )
-from shared.subprocess_guard import terminate_pid_tree  # noqa: E402
 from shared.bundled_auth_env import parse_env_file  # noqa: E402
+from shared.subprocess_guard import terminate_pid_tree  # noqa: E402
 
 
 def _wait_for_server(base, proc, *, timeout_sec=25.0):

--- a/scripts/frozen_data_dir_migration_smoke.py
+++ b/scripts/frozen_data_dir_migration_smoke.py
@@ -14,10 +14,12 @@ from scripts.frozen_smoke_paths import (  # noqa: E402
     smoke_home_env,
 )
 from scripts.smoke_port_guard import (  # noqa: E402
+    ensure_dev_port_free,
     port_collision_message,
     port_listener_pid,
     wait_for_owned_server,
 )
+from shared.subprocess_guard import terminate_pid_tree  # noqa: E402
 from shared.bundled_auth_env import parse_env_file  # noqa: E402
 
 
@@ -61,6 +63,7 @@ def run_smoke(bundle_dir):
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
                 creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if sys.platform == "win32" else 0,
+                start_new_session=sys.platform != "win32",
             )
             ok, wait_err = _wait_for_server("http://127.0.0.1:8765", proc)
             if not ok:
@@ -91,10 +94,8 @@ def run_smoke(bundle_dir):
             return report
     finally:
         if proc is not None and proc.poll() is None:
-            if sys.platform == "win32":
-                subprocess.run(["taskkill", "/F", "/PID", str(proc.pid), "/T"], capture_output=True, check=False)
-            else:
-                proc.terminate()
+            terminate_pid_tree(proc.pid)
+        ensure_dev_port_free(timeout_sec=5.0)
         smoke_games = bundle_dir / "games_steam_smoke.json"
         if smoke_games.is_file():
             smoke_games.unlink()

--- a/scripts/smoke_port_guard.py
+++ b/scripts/smoke_port_guard.py
@@ -80,6 +80,30 @@ def wait_for_owned_server(
     return False, f"server did not respond within {timeout_sec}s"
 
 
+def wait_for_http_server(
+    proc: subprocess.Popen,
+    base: str,
+    *,
+    timeout_sec: float = 30.0,
+) -> tuple[bool, str | None]:
+    """Wait until /api/config responds after a fresh spawn (port already cleared)."""
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        exit_code = proc.poll()
+        if exit_code is not None and exit_code != 0:
+            return False, f"server exited early with code {exit_code}"
+        try:
+            with urllib.request.urlopen(f"{base}/api/config", timeout=2) as resp:
+                if resp.status == 200:
+                    return True, None
+        except (urllib.error.URLError, TimeoutError, OSError):
+            pass
+        time.sleep(0.4)
+    exit_code = proc.poll()
+    suffix = f" (proc exit {exit_code})" if exit_code is not None else ""
+    return False, f"server did not respond within {timeout_sec}s{suffix}"
+
+
 def ensure_dev_port_free(
     *,
     host: str = DEFAULT_HOST,

--- a/scripts/smoke_port_guard.py
+++ b/scripts/smoke_port_guard.py
@@ -9,7 +9,7 @@ import urllib.error
 import urllib.request
 
 from shared.dev_server_pids import DEFAULT_HOST, DEFAULT_PORT, pid_listening_on_port
-from shared.subprocess_guard import related_pids
+from shared.subprocess_guard import related_pids, terminate_pid_tree
 
 
 def port_listener_pid(
@@ -78,6 +78,28 @@ def wait_for_owned_server(
             f"(pid {proc.pid}); run scripts/stop_baklog.py",
         )
     return False, f"server did not respond within {timeout_sec}s"
+
+
+def ensure_dev_port_free(
+    *,
+    host: str = DEFAULT_HOST,
+    port: int = DEFAULT_PORT,
+    timeout_sec: float = 15.0,
+) -> tuple[bool, str | None]:
+    """Terminate any listener on the dev port and wait until it is free."""
+    holder = port_listener_pid(host, port)
+    if holder is None:
+        return True, None
+    terminate_pid_tree(holder)
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        if port_listener_pid(host, port) is None:
+            return True, None
+        time.sleep(0.25)
+    holder = port_listener_pid(host, port)
+    if holder is None:
+        return True, None
+    return False, port_collision_message(holder, host=host, port=port)
 
 
 def port_collision_message(

--- a/shared/subprocess_guard.py
+++ b/shared/subprocess_guard.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import time
 from typing import Any
 
 
@@ -167,11 +168,23 @@ def terminate_pid_tree(pid: int) -> None:
             check=False,
             creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
         )
-    else:
-        import signal
+        return
+    import signal
 
+    targets = sorted(related_pids(pid), reverse=True)
+    for target in targets:
         try:
-            os.kill(pid, signal.SIGTERM)
+            os.kill(target, signal.SIGTERM)
+        except OSError:
+            pass
+    time.sleep(0.35)
+    for target in targets:
+        try:
+            os.kill(target, 0)
+        except OSError:
+            continue
+        try:
+            os.kill(target, signal.SIGKILL)
         except OSError:
             pass
 

--- a/tests/test_smoke_port_guard.py
+++ b/tests/test_smoke_port_guard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -59,5 +60,13 @@ def test_port_collision_message() -> None:
 def test_ensure_dev_port_free_when_idle(monkeypatch) -> None:
     monkeypatch.setattr(guard, "port_listener_pid", lambda host, port: None)
     ok, err = guard.ensure_dev_port_free(timeout_sec=0.01)
+    assert ok is True
+    assert err is None
+
+
+def test_wait_for_http_server_ok(monkeypatch) -> None:
+    proc = _FakeProc(1000)
+    monkeypatch.setattr(guard.urllib.request, "urlopen", MagicMock(return_value=MagicMock(status=200, __enter__=lambda s: s, __exit__=lambda *a: None)))
+    ok, err = guard.wait_for_http_server(proc, "http://127.0.0.1:8765", timeout_sec=0.01)
     assert ok is True
     assert err is None

--- a/tests/test_smoke_port_guard.py
+++ b/tests/test_smoke_port_guard.py
@@ -66,7 +66,8 @@ def test_ensure_dev_port_free_when_idle(monkeypatch) -> None:
 
 def test_wait_for_http_server_ok(monkeypatch) -> None:
     proc = _FakeProc(1000)
-    monkeypatch.setattr(guard.urllib.request, "urlopen", MagicMock(return_value=MagicMock(status=200, __enter__=lambda s: s, __exit__=lambda *a: None)))
+    resp = MagicMock(status=200, __enter__=lambda s: s, __exit__=lambda *a: None)
+    monkeypatch.setattr(guard.urllib.request, "urlopen", MagicMock(return_value=resp))
     ok, err = guard.wait_for_http_server(proc, "http://127.0.0.1:8765", timeout_sec=0.01)
     assert ok is True
     assert err is None

--- a/tests/test_smoke_port_guard.py
+++ b/tests/test_smoke_port_guard.py
@@ -54,3 +54,10 @@ def test_port_collision_message() -> None:
     msg = guard.port_collision_message(99)
     assert "99" in msg
     assert "stop_baklog" in msg
+
+
+def test_ensure_dev_port_free_when_idle(monkeypatch) -> None:
+    monkeypatch.setattr(guard, "port_listener_pid", lambda host, port: None)
+    ok, err = guard.ensure_dev_port_free(timeout_sec=0.01)
+    assert ok is True
+    assert err is None


### PR DESCRIPTION
## Summary
- Migration smoke inside \rozen_bundle_smoke\ left a listener on 8765 on Linux; the second server start then timed out on ownership checks
- Kill the full process tree on POSIX (\	erminate_pid_tree\), free the dev port between smokes, and start smokes in a new session

## Test plan
- [x] \pytest tests/test_smoke_port_guard.py tests/test_frozen_bundle_smoke.py\
- [ ] CI green
- [ ] Re-run **Build Linux (preview)** on main after merge


Made with [Cursor](https://cursor.com)