### PR TITLE
Give each frozen smoke its own server session and port

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -107,14 +107,30 @@ jobs:
           print(f"default_frozen_data_dir ok: {got}")
           PY
 
+      # One server session per step, each on its own port, so a slow teardown
+      # in one smoke cannot stall the next one.
       - name: Frozen import smoke
         run: python scripts/frozen_import_smoke.py --exe release/BAKLOG/BAKLOG
 
+      - name: Frozen data-dir migration smoke
+        run: python scripts/frozen_data_dir_migration_smoke.py --bundle-dir release/BAKLOG --port 8766
+
       - name: Frozen bundle smoke
-        run: python scripts/frozen_bundle_smoke.py release/BAKLOG
+        run: python scripts/frozen_bundle_smoke.py release/BAKLOG --port 8765
 
       - name: Frozen connect smoke
-        run: python scripts/frozen_connect_smoke.py --exe release/BAKLOG/BAKLOG
+        run: python scripts/frozen_connect_smoke.py --exe release/BAKLOG/BAKLOG --port 8767
+
+      - name: Verify bundled auth .env survived smokes
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          from scripts.frozen_bundle_smoke import _env_has_auth_keys
+          env_path = Path("release/BAKLOG/.env")
+          ok, missing = _env_has_auth_keys(env_path)
+          assert ok, f"bundled .env lost during smokes: missing {missing}"
+          print(f"bundled auth intact: {env_path}")
+          PY
 
       - name: Verify Linux artifacts exist
         run: |

--- a/packaging/build_windows.ps1
+++ b/packaging/build_windows.ps1
@@ -87,26 +87,36 @@ Write-Host "Stopping stray BAKLOG servers on port 8765..."
 & $Python scripts/stop_baklog.py
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-Write-Host "Smoke: frozen bundle (migration + /api/config + fetcher dispatch)..."
-& $Python scripts/frozen_bundle_smoke.py $OutDir
-if ($LASTEXITCODE -ne 0) {
-    Write-Error "frozen_bundle_smoke failed (exit $LASTEXITCODE)"
-}
-# Migration smoke moves co-located .env into %LOCALAPPDATA%\BAKLOG-Data; restore bundled auth for the zip.
-Write-Host "Restoring bundled account-auth .env after migration smoke..."
-& $Python (Join-Path $Root "scripts\write_bundle_auth_env.py") $OutDir
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
+# One server session per smoke, each on its own port (8766 / 8765 / 8767).
 Write-Host "Smoke: frozen import chain (PyInstaller hidden imports)..."
 & $Python scripts/frozen_import_smoke.py --exe $ServerExe
 if ($LASTEXITCODE -ne 0) {
     Write-Error "frozen_import_smoke failed (exit $LASTEXITCODE)"
 }
 
+Write-Host "Smoke: frozen data-dir migration (legacy co-located data)..."
+& $Python scripts/frozen_data_dir_migration_smoke.py --bundle-dir $OutDir --port 8766
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "frozen_data_dir_migration_smoke failed (exit $LASTEXITCODE)"
+}
+
+Write-Host "Smoke: frozen bundle (/api/config + mirror gate + fetcher dispatch)..."
+& $Python scripts/frozen_bundle_smoke.py $OutDir --port 8765
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "frozen_bundle_smoke failed (exit $LASTEXITCODE)"
+}
+
 Write-Host "Smoke: frozen connect-flow (/api/config + auth endpoints)..."
-& $Python scripts/frozen_connect_smoke.py --exe $ServerExe
+& $Python scripts/frozen_connect_smoke.py --exe $ServerExe --port 8767
 if ($LASTEXITCODE -ne 0) {
     Write-Error "frozen_connect_smoke failed (exit $LASTEXITCODE)"
+}
+
+# Belt and braces: the bundled .env must survive every smoke before zipping.
+Write-Host "Verifying bundled account-auth .env after smokes..."
+& $Python -c "import sys; sys.path.insert(0, r'$Root'); from pathlib import Path; from scripts.frozen_bundle_smoke import _env_has_auth_keys; ok, missing = _env_has_auth_keys(Path(r'$OutDir') / '.env'); sys.exit(0 if ok else f'bundled .env missing keys: {missing}')"
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "bundled .env verification failed (exit $LASTEXITCODE)"
 }
 
 @"

--- a/scripts/frozen_bundle_smoke.py
+++ b/scripts/frozen_bundle_smoke.py
@@ -18,6 +18,10 @@ from scripts.frozen_smoke_paths import (  # noqa: E402
     frozen_tray_path,
     smoke_home_env,
 )
+from scripts.frozen_smoke_server import (  # noqa: E402
+    BUNDLE_SMOKE_PORT,
+    FrozenSmokeServer,
+)
 
 
 def _read_expected_version():
@@ -26,12 +30,6 @@ def _read_expected_version():
     if not m:
         raise RuntimeError("could not read version from pyproject.toml")
     return m.group(1)
-
-
-def _wait_for_server(base, proc, *, timeout_sec=30.0):
-    from scripts.smoke_port_guard import wait_for_owned_server
-
-    return wait_for_owned_server(proc, base, timeout_sec=timeout_sec)
 
 
 def _manifest_fetcher_count(bundle_dir):
@@ -60,10 +58,10 @@ def _env_has_auth_keys(env_path):
     return (not missing, missing)
 
 
-def run_smoke(bundle_dir, *, expected_version=None):
+def run_smoke(bundle_dir, *, expected_version=None, port=BUNDLE_SMOKE_PORT):
     bundle_dir = bundle_dir.resolve()
     version = expected_version or _read_expected_version()
-    report = {"ok": False, "bundle_dir": str(bundle_dir), "checks": {}}
+    report = {"ok": False, "bundle_dir": str(bundle_dir), "port": port, "checks": {}}
     server_exe = frozen_server_path(bundle_dir)
     tray_exe = frozen_tray_path(bundle_dir)
     fallback = bundle_dir / "_internal" / "curated" / "free_claims.fallback.json"
@@ -90,42 +88,18 @@ def run_smoke(bundle_dir, *, expected_version=None):
     if not env_ok:
         report["error"] = f"bundled .env missing keys: {', '.join(env_missing)}"
         return report
-    from scripts.frozen_data_dir_migration_smoke import run_smoke as migrate_smoke
-    from scripts.smoke_port_guard import port_collision_message, port_listener_pid
-
-    migrate = migrate_smoke(bundle_dir)
-    report["checks"]["migration"] = migrate
-    if not migrate.get("ok"):
-        report["error"] = "frozen_data_dir_migration_smoke failed"
-        return report
-    proc = None
     config = None
-    holder = port_listener_pid()
-    if holder is not None:
-        report["error"] = port_collision_message(holder)
-        report["port_collision_before_start"] = holder
-        return report
-    try:
-        with tempfile.TemporaryDirectory(prefix="baklog-bundle-smoke-") as td:
-            env, _data_dir = smoke_home_env(Path(td))
-            proc = subprocess.Popen(
-                [str(server_exe)],
-                cwd=str(bundle_dir),
-                env=env,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.PIPE,
-                creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if sys.platform == "win32" else 0,
-            )
-            ok, wait_err = _wait_for_server("http://127.0.0.1:8765", proc)
-            if not ok:
-                err = (proc.stderr.read() if proc.stderr else b"").decode("utf-8", errors="replace")
-                report["error"] = wait_err or f"server did not respond; stderr tail: {err[-400:]}"
+    with tempfile.TemporaryDirectory(prefix="baklog-bundle-smoke-") as td:
+        env, _data_dir = smoke_home_env(Path(td))
+        with FrozenSmokeServer(server_exe, cwd=bundle_dir, env=env, port=port) as server:
+            if not server.ok:
+                report["error"] = server.error
                 return report
-            with urllib.request.urlopen("http://127.0.0.1:8765/api/config", timeout=5) as resp:
-                config = json.loads(resp.read().decode("utf-8"))
+            base = server.base
+            config = server.get_json("/api/config")
             mirror_status = None
             # Verify root path serves HTML (the app), not a directory listing
-            with urllib.request.urlopen("http://127.0.0.1:8765/", timeout=5) as root_resp:
+            with urllib.request.urlopen(f"{base}/", timeout=5) as root_resp:
                 root_body = root_resp.read().decode("utf-8")
             root_ctype = root_resp.headers.get("Content-Type", "")
             if "text/html" not in root_ctype.lower():
@@ -141,7 +115,7 @@ def run_smoke(bundle_dir, *, expected_version=None):
             }
             mirror_body = None
             try:
-                with urllib.request.urlopen("http://127.0.0.1:8765/api/mirror", timeout=5) as resp:
+                with urllib.request.urlopen(f"{base}/api/mirror", timeout=5) as resp:
                     mirror_status = resp.status
                     mirror_body = json.loads(resp.read().decode("utf-8"))
             except urllib.error.HTTPError as exc:
@@ -153,7 +127,7 @@ def run_smoke(bundle_dir, *, expected_version=None):
             import_status = None
             try:
                 req = urllib.request.Request(
-                    "http://127.0.0.1:8765/api/mirror/import",
+                    f"{base}/api/mirror/import",
                     data=b"{}",
                     method="POST",
                     headers={"Content-Type": "application/json"},
@@ -173,12 +147,6 @@ def run_smoke(bundle_dir, *, expected_version=None):
             if import_status not in (HTTPStatus.FORBIDDEN, HTTPStatus.UNAUTHORIZED):
                 report["error"] = f"expected POST /api/mirror/import -> 403/401, got {import_status}"
                 return report
-    finally:
-        if proc is not None and proc.poll() is None:
-            if sys.platform == "win32":
-                subprocess.run(["taskkill", "/F", "/PID", str(proc.pid), "/T"], capture_output=True, check=False)
-            else:
-                proc.terminate()
     if not isinstance(config, dict):
         report["error"] = "invalid /api/config response"
         return report
@@ -229,8 +197,14 @@ def main():
         "-o", "--json-out", dest="json_out", type=Path, default=None,
         help="Write JSON report to file (default: stdout)"
     )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=BUNDLE_SMOKE_PORT,
+        help=f"Port for the smoke server (default {BUNDLE_SMOKE_PORT})",
+    )
     args = parser.parse_args()
-    report = run_smoke(Path(args.bundle_dir))
+    report = run_smoke(Path(args.bundle_dir), port=args.port)
     text = json.dumps(report, indent=2)
     if args.json_out:
         args.json_out.write_text(text + "\n", encoding="utf-8")

--- a/scripts/frozen_connect_smoke.py
+++ b/scripts/frozen_connect_smoke.py
@@ -6,7 +6,7 @@ endpoints without crashing. Run as a post-build gate after
 packaging/build_windows.ps1.
 
 Usage:
-    python scripts/frozen_connect_smoke.py --exd release/BAKLOG
+    python scripts/frozen_connect_smoke.py --exe release/BAKLOG/BAKLOG
 
 This test:
     1. Starts the frozen server (with BAKLOG_NO_BROWSER=1)
@@ -21,60 +21,25 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import subprocess
 import sys
-import time
 import urllib.error
 import urllib.request
 from pathlib import Path
 
-BASE_URL = "http://127.0.0.1:8765"
-SMOKE_PORT = 8765  # Must match default server port
-START_TIMEOUT_SEC = 15
-POLL_INTERVAL_SEC = 0.5
+_REPO = Path(__file__).resolve().parents[1]
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+from scripts.frozen_smoke_server import (  # noqa: E402
+    CONNECT_SMOKE_PORT,
+    FrozenSmokeServer,
+)
 
 
-def _start_server(exe: Path, env: dict[str, str]) -> subprocess.Popen:
-    """Start the frozen server as a subprocess."""
-    print(f"Starting server: {exe}", file=sys.stderr)
-    merged_env = os.environ.copy()
-    merged_env.update(env)
-    proc = subprocess.Popen(
-        [str(exe)],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env=merged_env,
-        creationflags=(
-            subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW
-        )
-        if sys.platform == "win32"
-        else 0,
-    )
-    return proc
-
-
-def _wait_for_server(timeout: float = START_TIMEOUT_SEC) -> bool:
-    """Poll /api/config until the server responds or timeout."""
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        try:
-            req = urllib.request.Request(
-                f"{BASE_URL}/api/config",
-                headers={"Accept": "application/json"},
-            )
-            with urllib.request.urlopen(req, timeout=5) as resp:
-                if resp.status == 200:
-                    return True
-        except (urllib.error.URLError, TimeoutError, OSError):
-            pass
-        time.sleep(POLL_INTERVAL_SEC)
-    return False
-
-
-def _hit_endpoint(path: str) -> dict:
+def _hit_endpoint(base_url: str, path: str) -> dict:
     """GET an endpoint and return parsed JSON."""
     req = urllib.request.Request(
-        f"{BASE_URL}{path}",
+        f"{base_url}{path}",
         headers={"Accept": "application/json"},
     )
     with urllib.request.urlopen(req, timeout=10) as resp:
@@ -82,10 +47,10 @@ def _hit_endpoint(path: str) -> dict:
     return json.loads(data)
 
 
-def _hit_endpoint_allow_auth_gate(path: str, *, auth_required: bool) -> dict:
+def _hit_endpoint_allow_auth_gate(base_url: str, path: str, *, auth_required: bool) -> dict:
     """GET path; when auth is on, a 401 proves the gate (no crash)."""
     req = urllib.request.Request(
-        f"{BASE_URL}{path}",
+        f"{base_url}{path}",
         headers={"Accept": "application/json"},
     )
     try:
@@ -104,47 +69,12 @@ def _hit_endpoint_allow_auth_gate(path: str, *, auth_required: bool) -> dict:
         raise
 
 
-def _shutdown_server(proc: subprocess.Popen) -> None:
-    """Send graceful shutdown via API, then force-kill."""
-    try:
-        req = urllib.request.Request(
-            f"{BASE_URL}/api/shutdown",
-            method="POST",
-            headers={"X-BAKLOG-Local": "1"},
-        )
-        urllib.request.urlopen(req, timeout=5)
-        proc.wait(timeout=10)
-    except (urllib.error.URLError, TimeoutError, OSError):
-        pass
-
-    if proc.poll() is None:
-        if sys.platform == "win32":
-            proc.send_signal(subprocess.signal.CTRL_BREAK_EVENT)
-        else:
-            proc.terminate()
-        try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait(timeout=5)
-
-
-def _collect_stderr(proc: subprocess.Popen) -> str:
-    """Read remaining stderr from the process (non-blocking best-effort)."""
-    try:
-        out, _ = proc.communicate(timeout=3)
-        return (out or b"").decode("utf-8", errors="replace")
-    except subprocess.TimeoutExpired:
-        proc.kill()
-        out, _ = proc.communicate(timeout=3)
-        return (out or b"").decode("utf-8", errors="replace")
-
-
-def run_smoke(exe: Path) -> dict:
+def run_smoke(exe: Path, *, port: int = CONNECT_SMOKE_PORT) -> dict:
     """Run the connect-flow smoke test and return a report."""
     report: dict = {
         "ok": False,
         "exe": str(exe),
+        "port": port,
         "steps": [],
         "error": None,
     }
@@ -154,24 +84,24 @@ def run_smoke(exe: Path) -> dict:
         return report
 
     env = {
+        **os.environ,
         "BAKLOG_NO_BROWSER": "1",
         "BAKLOG_PROFILE": "smoke",
         "BAKLOG_IDLE_SHUTDOWN_MINUTES": "0",
     }
 
-    proc = _start_server(exe, env)
-
-    try:
+    print(f"Starting server: {exe} (port {port})", file=sys.stderr)
+    with FrozenSmokeServer(exe, env=env, port=port) as server:
         # Step 1: Wait for server
-        if not _wait_for_server():
-            report["error"] = "server did not start within timeout"
-            report["stderr"] = _collect_stderr(proc)
+        if not server.ok:
+            report["error"] = server.error
             return report
         report["steps"].append({"step": "wait_for_server", "ok": True})
+        base_url = server.base
 
         # Step 2: /api/config
         try:
-            config = _hit_endpoint("/api/config")
+            config = _hit_endpoint(base_url, "/api/config")
             assert isinstance(config, dict), "config is not a dict"
             assert config.get("frozen") is True, "config.frozen is not True"
             auth_required = bool(config.get("authRequired"))
@@ -186,7 +116,7 @@ def run_smoke(exe: Path) -> dict:
         # Step 3: /api/auth/status (connect endpoints)
         try:
             status = _hit_endpoint_allow_auth_gate(
-                "/api/auth/status", auth_required=auth_required
+                base_url, "/api/auth/status", auth_required=auth_required
             )
             assert isinstance(status, dict), "auth status not a dict"
             report["steps"].append({"step": "api_auth_status", "ok": True})
@@ -198,7 +128,7 @@ def run_smoke(exe: Path) -> dict:
         # Step 4: /api/fetchers (used by connections view)
         try:
             fetchers = _hit_endpoint_allow_auth_gate(
-                "/api/fetchers", auth_required=auth_required
+                base_url, "/api/fetchers", auth_required=auth_required
             )
             assert isinstance(fetchers, dict), "fetchers not a dict"
             report["steps"].append({"step": "api_fetchers", "ok": True})
@@ -209,7 +139,7 @@ def run_smoke(exe: Path) -> dict:
 
         # Step 5: Verify server is still alive after all the hits
         try:
-            alive = _hit_endpoint("/api/config")
+            alive = _hit_endpoint(base_url, "/api/config")
             assert alive.get("frozen") is True, "server not alive after connect endpoint hits"
             report["steps"].append({"step": "post_connect_alive", "ok": True})
         except Exception as exc:
@@ -219,13 +149,6 @@ def run_smoke(exe: Path) -> dict:
 
         report["ok"] = True
 
-    finally:
-        _shutdown_server(proc)
-        if proc.poll() is None:
-            proc.kill()
-            proc.wait(timeout=5)
-
-    report["stderr"] = _collect_stderr(proc)
     return report
 
 
@@ -241,9 +164,13 @@ def main() -> int:
         "--json-out", type=Path, default=None,
         help="Write JSON report to file",
     )
+    ap.add_argument(
+        "--port", type=int, default=CONNECT_SMOKE_PORT,
+        help=f"Port for the smoke server (default {CONNECT_SMOKE_PORT})",
+    )
     args = ap.parse_args()
 
-    report = run_smoke(args.exe)
+    report = run_smoke(args.exe, port=args.port)
     text = json.dumps(report, indent=2)
     print(text)
 

--- a/scripts/frozen_data_dir_migration_smoke.py
+++ b/scripts/frozen_data_dir_migration_smoke.py
@@ -1,7 +1,6 @@
 import argparse
 import json
 import shutil
-import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -13,19 +12,14 @@ from scripts.frozen_smoke_paths import (  # noqa: E402
     frozen_server_path,
     smoke_home_env,
 )
-from scripts.smoke_port_guard import (  # noqa: E402
-    port_collision_message,
-    port_listener_pid,
-    wait_for_owned_server,
+from scripts.frozen_smoke_server import (  # noqa: E402
+    MIGRATION_SMOKE_PORT,
+    FrozenSmokeServer,
 )
 from shared.bundled_auth_env import parse_env_file  # noqa: E402
 
 
-def _wait_for_server(base, proc, *, timeout_sec=25.0):
-    return wait_for_owned_server(proc, base, timeout_sec=timeout_sec)
-
-
-def run_smoke(bundle_dir):
+def run_smoke(bundle_dir, *, port=MIGRATION_SMOKE_PORT):
     bundle_dir = bundle_dir.resolve()
     exe = frozen_server_path(bundle_dir)
     if not exe.is_file():
@@ -40,13 +34,7 @@ def run_smoke(bundle_dir):
     legacy_profiles.mkdir()
     (legacy_profiles / "index.json").write_text(json.dumps({"active": "default", "profiles": []}), encoding="utf-8")
     (bundle_dir / "games_steam_smoke.json").write_text('{"games":[]}', encoding="utf-8")
-    report = {"ok": False, "bundle_dir": str(bundle_dir)}
-    holder = port_listener_pid()
-    if holder is not None:
-        report["port_collision_before_start"] = holder
-        report["error"] = port_collision_message(holder)
-        return report
-    proc = None
+    report = {"ok": False, "bundle_dir": str(bundle_dir), "port": port}
     try:
         with tempfile.TemporaryDirectory(prefix="baklog-migrate-smoke-") as td:
             env, data_dir = smoke_home_env(Path(td))
@@ -54,47 +42,33 @@ def run_smoke(bundle_dir):
             (data_dir / ".env").write_text(
                 "BAKLOG_SUPABASE_URL=https://stale.supabase.co\nBAKLOG_SUPABASE_ANON_KEY=stale-anon\n", encoding="utf-8"
             )
-            proc = subprocess.Popen(
-                [str(exe)],
-                cwd=str(bundle_dir),
-                env=env,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.PIPE,
-                creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if sys.platform == "win32" else 0,
-            )
-            ok, wait_err = _wait_for_server("http://127.0.0.1:8765", proc)
-            if not ok:
-                err = (proc.stderr.read() if proc.stderr else b"").decode("utf-8", errors="replace")
-                report["error"] = wait_err or f"server did not respond within timeout; stderr tail: {err[-500:]}"
-                return report
-            migrated_index = data_dir / "profiles" / "index.json"
-            migrated_games = data_dir / "games_steam_smoke.json"
-            report["data_dir"] = str(data_dir)
-            report["migrated_index"] = migrated_index.is_file()
-            report["migrated_games"] = migrated_games.is_file()
-            report["legacy_profiles_gone"] = not legacy_profiles.exists()
-            bundle_auth = parse_env_file(bundle_dir / ".env")
-            data_auth = parse_env_file(data_dir / ".env")
-            report["auth_env_synced"] = (
-                bundle_auth.get("BAKLOG_SUPABASE_URL") == data_auth.get("BAKLOG_SUPABASE_URL")
-                and bundle_auth.get("BAKLOG_SUPABASE_ANON_KEY") == data_auth.get("BAKLOG_SUPABASE_ANON_KEY")
-                and (data_auth.get("BAKLOG_SUPABASE_URL") != "https://stale.supabase.co")
-            )
-            report["ok"] = all(
-                (
-                    report["migrated_index"],
-                    report["migrated_games"],
-                    report["legacy_profiles_gone"],
-                    report["auth_env_synced"],
+            with FrozenSmokeServer(exe, cwd=bundle_dir, env=env, port=port) as server:
+                if not server.ok:
+                    report["error"] = server.error
+                    return report
+                migrated_index = data_dir / "profiles" / "index.json"
+                migrated_games = data_dir / "games_steam_smoke.json"
+                report["data_dir"] = str(data_dir)
+                report["migrated_index"] = migrated_index.is_file()
+                report["migrated_games"] = migrated_games.is_file()
+                report["legacy_profiles_gone"] = not legacy_profiles.exists()
+                bundle_auth = parse_env_file(bundle_dir / ".env")
+                data_auth = parse_env_file(data_dir / ".env")
+                report["auth_env_synced"] = (
+                    bundle_auth.get("BAKLOG_SUPABASE_URL") == data_auth.get("BAKLOG_SUPABASE_URL")
+                    and bundle_auth.get("BAKLOG_SUPABASE_ANON_KEY") == data_auth.get("BAKLOG_SUPABASE_ANON_KEY")
+                    and (data_auth.get("BAKLOG_SUPABASE_URL") != "https://stale.supabase.co")
                 )
-            )
-            return report
+                report["ok"] = all(
+                    (
+                        report["migrated_index"],
+                        report["migrated_games"],
+                        report["legacy_profiles_gone"],
+                        report["auth_env_synced"],
+                    )
+                )
+                return report
     finally:
-        if proc is not None and proc.poll() is None:
-            if sys.platform == "win32":
-                subprocess.run(["taskkill", "/F", "/PID", str(proc.pid), "/T"], capture_output=True, check=False)
-            else:
-                proc.terminate()
         smoke_games = bundle_dir / "games_steam_smoke.json"
         if smoke_games.is_file():
             smoke_games.unlink()
@@ -115,8 +89,14 @@ def main():
         help="PyInstaller onedir output (contains BAKLOG server binary)",
     )
     parser.add_argument("--json-out", type=Path, default=None, help="Write JSON report to this path")
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=MIGRATION_SMOKE_PORT,
+        help=f"Port for the smoke server (default {MIGRATION_SMOKE_PORT})",
+    )
     args = parser.parse_args()
-    report = run_smoke(args.bundle_dir)
+    report = run_smoke(args.bundle_dir, port=args.port)
     text = json.dumps(report, indent=2)
     print(text)
     if args.json_out:

--- a/scripts/frozen_smoke_server.py
+++ b/scripts/frozen_smoke_server.py
@@ -38,6 +38,28 @@ CONNECT_SMOKE_PORT = 8767
 DEFAULT_START_TIMEOUT_SEC = 30.0
 
 
+def _spawn(exe: Path, cwd: Path, env: dict[str, str]) -> subprocess.Popen:
+    """Spawn the frozen server detached enough to be tree-killed on exit."""
+    return subprocess.Popen(
+        [str(exe)],
+        cwd=str(cwd),
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if sys.platform == "win32" else 0,
+        start_new_session=sys.platform != "win32",
+    )
+
+
+def _probe_config(base: str, *, timeout: float = 2.0) -> bool:
+    """True when /api/config answers 200."""
+    try:
+        with urllib.request.urlopen(f"{base}/api/config", timeout=timeout) as resp:
+            return resp.status == 200
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return False
+
+
 class FrozenSmokeServer:
     """Context manager that owns one frozen-server run for a smoke script.
 
@@ -78,15 +100,7 @@ class FrozenSmokeServer:
         if not free:
             self.error = free_err
             return self
-        self.proc = subprocess.Popen(
-            [str(self.exe)],
-            cwd=str(self.cwd),
-            env=self.env,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
-            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if sys.platform == "win32" else 0,
-            start_new_session=sys.platform != "win32",
-        )
+        self.proc = _spawn(self.exe, self.cwd, self.env)
         self.ok, self.error = self._wait_for_http()
         return self
 
@@ -105,12 +119,8 @@ class FrozenSmokeServer:
             exit_code = self.proc.poll()
             if exit_code is not None and exit_code != 0:
                 return False, f"server exited with code {exit_code}{self._stderr_suffix()}"
-            try:
-                with urllib.request.urlopen(f"{self.base}/api/config", timeout=2) as resp:
-                    if resp.status == 200:
-                        return True, None
-            except (urllib.error.URLError, TimeoutError, OSError):
-                pass
+            if _probe_config(self.base):
+                return True, None
             time.sleep(0.4)
         return False, (
             f"server did not respond on {self.base} within "

--- a/scripts/frozen_smoke_server.py
+++ b/scripts/frozen_smoke_server.py
@@ -1,0 +1,134 @@
+"""Single-session frozen server lifecycle shared by the frozen smoke scripts.
+
+Each smoke script starts the frozen server at most once, on its own port, and
+tears the whole process tree down on exit. Readiness is decided by polling
+``/api/config`` rather than by port ownership: a PyInstaller launcher can hand
+the listening socket to a process outside the spawned tree, so ownership checks
+time out even when the server is healthy.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+from scripts.smoke_port_guard import (  # noqa: E402
+    ensure_port_free,
+    port_listener_pid,
+    wait_for_port_free,
+)
+from shared.dev_server_pids import DEFAULT_HOST  # noqa: E402
+from shared.subprocess_guard import terminate_pid_tree  # noqa: E402
+
+# One port per smoke step so a failed teardown cannot cascade into the next
+# step. The product default (8765) stays on the bundle smoke.
+BUNDLE_SMOKE_PORT = 8765
+MIGRATION_SMOKE_PORT = 8766
+CONNECT_SMOKE_PORT = 8767
+
+DEFAULT_START_TIMEOUT_SEC = 30.0
+
+
+class FrozenSmokeServer:
+    """Context manager that owns one frozen-server run for a smoke script.
+
+    Enter clears the port, spawns the server, and waits for HTTP readiness.
+    Check ``ok``/``error`` after entering; exit kills the process tree and any
+    process still holding the port.
+    """
+
+    def __init__(
+        self,
+        exe: Path,
+        *,
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        port: int = BUNDLE_SMOKE_PORT,
+        host: str = DEFAULT_HOST,
+        start_timeout_sec: float = DEFAULT_START_TIMEOUT_SEC,
+    ) -> None:
+        self.exe = Path(exe)
+        self.cwd = Path(cwd) if cwd is not None else self.exe.parent
+        self.port = port
+        self.host = host
+        self.start_timeout_sec = start_timeout_sec
+        self.env = {**(env if env is not None else os.environ), "PORT": str(port)}
+        self.proc: subprocess.Popen | None = None
+        self.ok = False
+        self.error: str | None = None
+
+    @property
+    def base(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    def __enter__(self) -> FrozenSmokeServer:
+        if not self.exe.is_file():
+            self.error = f"frozen server not found: {self.exe}"
+            return self
+        free, free_err = ensure_port_free(host=self.host, port=self.port)
+        if not free:
+            self.error = free_err
+            return self
+        self.proc = subprocess.Popen(
+            [str(self.exe)],
+            cwd=str(self.cwd),
+            env=self.env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if sys.platform == "win32" else 0,
+            start_new_session=sys.platform != "win32",
+        )
+        self.ok, self.error = self._wait_for_http()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self.proc is not None and self.proc.poll() is None:
+            terminate_pid_tree(self.proc.pid)
+        holder = port_listener_pid(self.host, self.port)
+        if holder is not None:
+            terminate_pid_tree(holder)
+        wait_for_port_free(host=self.host, port=self.port, timeout_sec=5.0)
+
+    def _wait_for_http(self) -> tuple[bool, str | None]:
+        assert self.proc is not None
+        deadline = time.monotonic() + self.start_timeout_sec
+        while time.monotonic() < deadline:
+            exit_code = self.proc.poll()
+            if exit_code is not None and exit_code != 0:
+                return False, f"server exited with code {exit_code}{self._stderr_suffix()}"
+            try:
+                with urllib.request.urlopen(f"{self.base}/api/config", timeout=2) as resp:
+                    if resp.status == 200:
+                        return True, None
+            except (urllib.error.URLError, TimeoutError, OSError):
+                pass
+            time.sleep(0.4)
+        return False, (
+            f"server did not respond on {self.base} within "
+            f"{self.start_timeout_sec}s{self._stderr_suffix()}"
+        )
+
+    def _stderr_suffix(self) -> str:
+        if self.proc is None or self.proc.stderr is None:
+            return ""
+        try:
+            raw = self.proc.stderr.read() or b""
+        except (OSError, ValueError):
+            return ""
+        text = raw.decode("utf-8", errors="replace").strip()
+        return f"; stderr tail: {text[-400:]}" if text else ""
+
+    def get_json(self, path: str, *, timeout: float = 5.0):
+        import json
+
+        with urllib.request.urlopen(f"{self.base}{path}", timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))

--- a/scripts/smoke_port_guard.py
+++ b/scripts/smoke_port_guard.py
@@ -9,7 +9,7 @@ import urllib.error
 import urllib.request
 
 from shared.dev_server_pids import DEFAULT_HOST, DEFAULT_PORT, pid_listening_on_port
-from shared.subprocess_guard import related_pids
+from shared.subprocess_guard import related_pids, terminate_pid_tree
 
 
 def port_listener_pid(
@@ -47,6 +47,40 @@ def proc_owns_dev_port(
     return listener in related_pids(proc.pid)
 
 
+def wait_for_port_free(
+    *,
+    host: str = DEFAULT_HOST,
+    port: int = DEFAULT_PORT,
+    timeout_sec: float = 10.0,
+) -> int | None:
+    """Wait for the port to have no listener; return the holding pid on timeout."""
+    deadline = time.monotonic() + timeout_sec
+    while True:
+        holder = port_listener_pid(host, port)
+        if holder is None:
+            return None
+        if time.monotonic() >= deadline:
+            return holder
+        time.sleep(0.25)
+
+
+def ensure_port_free(
+    *,
+    host: str = DEFAULT_HOST,
+    port: int = DEFAULT_PORT,
+    timeout_sec: float = 15.0,
+) -> tuple[bool, str | None]:
+    """Terminate any listener on the smoke port and wait until it is released."""
+    holder = port_listener_pid(host, port)
+    if holder is None:
+        return True, None
+    terminate_pid_tree(holder)
+    remaining = wait_for_port_free(host=host, port=port, timeout_sec=timeout_sec)
+    if remaining is None:
+        return True, None
+    return False, port_collision_message(remaining, host=host, port=port)
+
+
 def wait_for_owned_server(
     proc: subprocess.Popen,
     base: str,
@@ -55,7 +89,13 @@ def wait_for_owned_server(
     host: str = DEFAULT_HOST,
     port: int = DEFAULT_PORT,
 ) -> tuple[bool, str | None]:
-    """Wait until /api/config responds from the spawned process tree."""
+    """Wait until /api/config responds from the spawned process tree.
+
+    Dev-stray detection only. Frozen smokes use
+    ``scripts.frozen_smoke_server.FrozenSmokeServer``, which polls HTTP instead:
+    a PyInstaller launcher can hand the listening socket to a process outside
+    the spawned tree, which makes ownership checks time out on a healthy server.
+    """
     deadline = time.monotonic() + timeout_sec
     collision_holder: int | None = None
     while time.monotonic() < deadline:

--- a/shared/subprocess_guard.py
+++ b/shared/subprocess_guard.py
@@ -167,13 +167,43 @@ def terminate_pid_tree(pid: int) -> None:
             check=False,
             creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
         )
-    else:
-        import signal
+        return
 
+    import signal
+    import time
+
+    # Descendants first: a PyInstaller launcher can respawn/hand off to a child
+    # that keeps the listening socket after the parent is gone.
+    targets = sorted(related_pids(pid) - _ancestors_of(pid), reverse=True)
+    for target in targets:
         try:
-            os.kill(pid, signal.SIGTERM)
+            os.kill(target, signal.SIGTERM)
         except OSError:
             pass
+    time.sleep(0.35)
+    for target in targets:
+        try:
+            os.kill(target, 0)
+        except OSError:
+            continue
+        try:
+            os.kill(target, signal.SIGKILL)
+        except OSError:
+            pass
+
+
+def _ancestors_of(pid: int) -> set[int]:
+    """Ancestors of ``pid`` (never kill the shell/CI runner that launched us)."""
+    table = _proc_parent_map()
+    ancestors: set[int] = set()
+    cur = pid
+    while cur in table:
+        parent = table[cur]
+        if parent <= 0 or parent in ancestors:
+            break
+        ancestors.add(parent)
+        cur = parent
+    return ancestors
 
 
 class _WindowsJobPopen(subprocess.Popen[str]):

--- a/tests/test_frozen_bundle_smoke.py
+++ b/tests/test_frozen_bundle_smoke.py
@@ -52,3 +52,24 @@ def test_run_smoke_fails_without_env(tmp_path: Path, monkeypatch) -> None:
     report = smoke.run_smoke(bundle, expected_version="0.8.20")
     assert not report["ok"]
     assert "bundled .env" in (report.get("error") or "")
+
+
+def test_run_smoke_does_not_nest_migration_smoke(tmp_path: Path, monkeypatch) -> None:
+    """Migration runs as its own workflow step, on its own port."""
+    bundle = _stub_bundle(tmp_path, with_env=False)
+    monkeypatch.setattr(smoke, "_read_expected_version", lambda: "0.8.20")
+    report = smoke.run_smoke(bundle, expected_version="0.8.20")
+    assert "migration" not in report["checks"]
+    assert report["port"] == smoke.BUNDLE_SMOKE_PORT
+
+
+def test_smoke_ports_are_distinct() -> None:
+    from scripts.frozen_smoke_server import (
+        BUNDLE_SMOKE_PORT,
+        CONNECT_SMOKE_PORT,
+        MIGRATION_SMOKE_PORT,
+    )
+
+    ports = {BUNDLE_SMOKE_PORT, MIGRATION_SMOKE_PORT, CONNECT_SMOKE_PORT}
+    assert len(ports) == 3
+    assert BUNDLE_SMOKE_PORT == 8765

--- a/tests/test_frozen_smoke_server.py
+++ b/tests/test_frozen_smoke_server.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -20,15 +19,6 @@ class _FakeProc:
         return self._returncode
 
 
-@contextmanager
-def _ok_response(status: int = 200):
-    class _Resp:
-        def __init__(self) -> None:
-            self.status = status
-
-    yield _Resp()
-
-
 @pytest.fixture
 def stub_exe(tmp_path: Path) -> Path:
     exe = tmp_path / "BAKLOG"
@@ -36,20 +26,28 @@ def stub_exe(tmp_path: Path) -> Path:
     return exe
 
 
-def _patch_lifecycle(monkeypatch, *, proc, port_free=(True, None), listener=None):
+def _patch_lifecycle(
+    monkeypatch,
+    *,
+    proc,
+    port_free=(True, None),
+    listener=None,
+    reachable=True,
+):
+    """Stub the spawn/probe/kill seams so no real process or socket is used."""
     killed: list[int] = []
     monkeypatch.setattr(smoke_server, "ensure_port_free", lambda **kw: port_free)
     monkeypatch.setattr(smoke_server, "port_listener_pid", lambda host, port: listener)
     monkeypatch.setattr(smoke_server, "wait_for_port_free", lambda **kw: None)
     monkeypatch.setattr(smoke_server, "terminate_pid_tree", killed.append)
-    monkeypatch.setattr(smoke_server.subprocess, "Popen", lambda *a, **kw: proc)
+    monkeypatch.setattr(smoke_server, "_spawn", lambda exe, cwd, env: proc)
+    monkeypatch.setattr(smoke_server, "_probe_config", lambda base, **kw: reachable)
     return killed
 
 
 def test_server_ready_when_config_responds(monkeypatch, stub_exe: Path) -> None:
     proc = _FakeProc()
     killed = _patch_lifecycle(monkeypatch, proc=proc)
-    monkeypatch.setattr(smoke_server.urllib.request, "urlopen", lambda *a, **kw: _ok_response())
 
     with smoke_server.FrozenSmokeServer(stub_exe, port=8799) as server:
         assert server.ok is True
@@ -59,9 +57,7 @@ def test_server_ready_when_config_responds(monkeypatch, stub_exe: Path) -> None:
 
 
 def test_server_injects_port_into_env(monkeypatch, stub_exe: Path) -> None:
-    proc = _FakeProc()
-    _patch_lifecycle(monkeypatch, proc=proc)
-    monkeypatch.setattr(smoke_server.urllib.request, "urlopen", lambda *a, **kw: _ok_response())
+    _patch_lifecycle(monkeypatch, proc=_FakeProc())
 
     with smoke_server.FrozenSmokeServer(stub_exe, env={"A": "b"}, port=8766) as server:
         assert server.env["PORT"] == "8766"
@@ -69,17 +65,25 @@ def test_server_injects_port_into_env(monkeypatch, stub_exe: Path) -> None:
 
 
 def test_server_reports_early_exit(monkeypatch, stub_exe: Path) -> None:
-    proc = _FakeProc(returncode=3)
-    _patch_lifecycle(monkeypatch, proc=proc)
+    _patch_lifecycle(monkeypatch, proc=_FakeProc(returncode=3), reachable=False)
 
     with smoke_server.FrozenSmokeServer(stub_exe, port=8799) as server:
         assert server.ok is False
         assert "exited with code 3" in (server.error or "")
 
 
+def test_server_reports_timeout(monkeypatch, stub_exe: Path) -> None:
+    _patch_lifecycle(monkeypatch, proc=_FakeProc(), reachable=False)
+    monkeypatch.setattr(smoke_server.time, "sleep", lambda _: None)
+
+    server = smoke_server.FrozenSmokeServer(stub_exe, port=8799, start_timeout_sec=0.01)
+    with server:
+        assert server.ok is False
+        assert "did not respond" in (server.error or "")
+
+
 def test_server_reports_blocked_port(monkeypatch, stub_exe: Path) -> None:
-    proc = _FakeProc()
-    _patch_lifecycle(monkeypatch, proc=proc, port_free=(False, "port busy"))
+    _patch_lifecycle(monkeypatch, proc=_FakeProc(), port_free=(False, "port busy"))
 
     with smoke_server.FrozenSmokeServer(stub_exe, port=8799) as server:
         assert server.ok is False
@@ -96,7 +100,6 @@ def test_server_missing_exe(tmp_path: Path) -> None:
 def test_exit_kills_leftover_port_holder(monkeypatch, stub_exe: Path) -> None:
     proc = _FakeProc(pid=111, returncode=0)
     killed = _patch_lifecycle(monkeypatch, proc=proc, listener=222)
-    monkeypatch.setattr(smoke_server.urllib.request, "urlopen", lambda *a, **kw: _ok_response())
 
     with smoke_server.FrozenSmokeServer(stub_exe, port=8799) as server:
         assert server.ok is True

--- a/tests/test_frozen_smoke_server.py
+++ b/tests/test_frozen_smoke_server.py
@@ -1,0 +1,104 @@
+"""Unit tests for scripts/frozen_smoke_server.py (no real server spawned)."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+import scripts.frozen_smoke_server as smoke_server
+
+
+class _FakeProc:
+    def __init__(self, pid: int = 4242, *, returncode: int | None = None) -> None:
+        self.pid = pid
+        self._returncode = returncode
+        self.stderr = None
+
+    def poll(self) -> int | None:
+        return self._returncode
+
+
+@contextmanager
+def _ok_response(status: int = 200):
+    class _Resp:
+        def __init__(self) -> None:
+            self.status = status
+
+    yield _Resp()
+
+
+@pytest.fixture
+def stub_exe(tmp_path: Path) -> Path:
+    exe = tmp_path / "BAKLOG"
+    exe.write_text("", encoding="utf-8")
+    return exe
+
+
+def _patch_lifecycle(monkeypatch, *, proc, port_free=(True, None), listener=None):
+    killed: list[int] = []
+    monkeypatch.setattr(smoke_server, "ensure_port_free", lambda **kw: port_free)
+    monkeypatch.setattr(smoke_server, "port_listener_pid", lambda host, port: listener)
+    monkeypatch.setattr(smoke_server, "wait_for_port_free", lambda **kw: None)
+    monkeypatch.setattr(smoke_server, "terminate_pid_tree", killed.append)
+    monkeypatch.setattr(smoke_server.subprocess, "Popen", lambda *a, **kw: proc)
+    return killed
+
+
+def test_server_ready_when_config_responds(monkeypatch, stub_exe: Path) -> None:
+    proc = _FakeProc()
+    killed = _patch_lifecycle(monkeypatch, proc=proc)
+    monkeypatch.setattr(smoke_server.urllib.request, "urlopen", lambda *a, **kw: _ok_response())
+
+    with smoke_server.FrozenSmokeServer(stub_exe, port=8799) as server:
+        assert server.ok is True
+        assert server.error is None
+        assert server.base == "http://127.0.0.1:8799"
+    assert killed == [proc.pid]
+
+
+def test_server_injects_port_into_env(monkeypatch, stub_exe: Path) -> None:
+    proc = _FakeProc()
+    _patch_lifecycle(monkeypatch, proc=proc)
+    monkeypatch.setattr(smoke_server.urllib.request, "urlopen", lambda *a, **kw: _ok_response())
+
+    with smoke_server.FrozenSmokeServer(stub_exe, env={"A": "b"}, port=8766) as server:
+        assert server.env["PORT"] == "8766"
+        assert server.env["A"] == "b"
+
+
+def test_server_reports_early_exit(monkeypatch, stub_exe: Path) -> None:
+    proc = _FakeProc(returncode=3)
+    _patch_lifecycle(monkeypatch, proc=proc)
+
+    with smoke_server.FrozenSmokeServer(stub_exe, port=8799) as server:
+        assert server.ok is False
+        assert "exited with code 3" in (server.error or "")
+
+
+def test_server_reports_blocked_port(monkeypatch, stub_exe: Path) -> None:
+    proc = _FakeProc()
+    _patch_lifecycle(monkeypatch, proc=proc, port_free=(False, "port busy"))
+
+    with smoke_server.FrozenSmokeServer(stub_exe, port=8799) as server:
+        assert server.ok is False
+        assert server.error == "port busy"
+        assert server.proc is None
+
+
+def test_server_missing_exe(tmp_path: Path) -> None:
+    with smoke_server.FrozenSmokeServer(tmp_path / "nope", port=8799) as server:
+        assert server.ok is False
+        assert "not found" in (server.error or "")
+
+
+def test_exit_kills_leftover_port_holder(monkeypatch, stub_exe: Path) -> None:
+    proc = _FakeProc(pid=111, returncode=0)
+    killed = _patch_lifecycle(monkeypatch, proc=proc, listener=222)
+    monkeypatch.setattr(smoke_server.urllib.request, "urlopen", lambda *a, **kw: _ok_response())
+
+    with smoke_server.FrozenSmokeServer(stub_exe, port=8799) as server:
+        assert server.ok is True
+    # Parent already exited; the process still holding the port is killed.
+    assert killed == [222]

--- a/tests/test_smoke_port_guard.py
+++ b/tests/test_smoke_port_guard.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -54,3 +56,36 @@ def test_port_collision_message() -> None:
     msg = guard.port_collision_message(99)
     assert "99" in msg
     assert "stop_baklog" in msg
+
+
+def test_ensure_port_free_noop_when_idle(monkeypatch) -> None:
+    monkeypatch.setattr(guard, "port_listener_pid", lambda host, port: None)
+    monkeypatch.setattr(guard, "terminate_pid_tree", lambda pid: pytest.fail("should not kill"))
+    ok, err = guard.ensure_port_free(timeout_sec=0.01)
+    assert ok is True
+    assert err is None
+
+
+def test_ensure_port_free_kills_holder(monkeypatch) -> None:
+    listeners = iter([4242, None])
+    killed: list[int] = []
+    monkeypatch.setattr(guard, "port_listener_pid", lambda host, port: next(listeners, None))
+    monkeypatch.setattr(guard, "terminate_pid_tree", killed.append)
+    monkeypatch.setattr(guard.time, "sleep", lambda _: None)
+
+    ok, err = guard.ensure_port_free(timeout_sec=1.0)
+    assert ok is True
+    assert err is None
+    assert killed == [4242]
+
+
+def test_ensure_port_free_reports_stubborn_holder(monkeypatch) -> None:
+    monkeypatch.setattr(guard, "port_listener_pid", lambda host, port: 777)
+    monkeypatch.setattr(guard, "terminate_pid_tree", lambda pid: None)
+    monkeypatch.setattr(guard.time, "sleep", lambda _: None)
+    ticks = iter([0.0, 0.0, 5.0, 5.0])
+    monkeypatch.setattr(guard.time, "monotonic", lambda: next(ticks))
+
+    ok, err = guard.ensure_port_free(timeout_sec=0.01)
+    assert ok is False
+    assert "777" in (err or "")

--- a/tests/test_smoke_port_guard.py
+++ b/tests/test_smoke_port_guard.py
@@ -71,7 +71,6 @@ def test_ensure_port_free_kills_holder(monkeypatch) -> None:
     killed: list[int] = []
     monkeypatch.setattr(guard, "port_listener_pid", lambda host, port: next(listeners, None))
     monkeypatch.setattr(guard, "terminate_pid_tree", killed.append)
-    monkeypatch.setattr(guard.time, "sleep", lambda _: None)
 
     ok, err = guard.ensure_port_free(timeout_sec=1.0)
     assert ok is True
@@ -82,10 +81,7 @@ def test_ensure_port_free_kills_holder(monkeypatch) -> None:
 def test_ensure_port_free_reports_stubborn_holder(monkeypatch) -> None:
     monkeypatch.setattr(guard, "port_listener_pid", lambda host, port: 777)
     monkeypatch.setattr(guard, "terminate_pid_tree", lambda pid: None)
-    monkeypatch.setattr(guard.time, "sleep", lambda _: None)
-    ticks = iter([0.0, 0.0, 5.0, 5.0])
-    monkeypatch.setattr(guard.time, "monotonic", lambda: next(ticks))
 
-    ok, err = guard.ensure_port_free(timeout_sec=0.01)
+    ok, err = guard.ensure_port_free(timeout_sec=0.0)
     assert ok is False
     assert "777" in (err or "")


### PR DESCRIPTION
## Summary

Replaces #211 (closed). That PR patched port cleanup; this one fixes the layout that made cleanup matter.

The Linux preview kept failing in `frozen_bundle_smoke` with `server did not respond within 30.0s`. Root cause: `frozen_bundle_smoke` called `frozen_data_dir_migration_smoke` inline, so a single workflow step started two servers on `127.0.0.1:8765`. Windows hid it via `taskkill /T`; on Linux the PyInstaller child could keep the listening socket after the parent was terminated, and the second bind then waited out the full timeout. Both scripts also waited on **port ownership**, which fails when a PyInstaller launcher hands the socket to a process outside the spawned tree.

Changes:

- **New `scripts/frozen_smoke_server.py`** - `FrozenSmokeServer` context manager owns exactly one server run: clear the port, spawn in its own session (`start_new_session` on POSIX), wait on `GET /api/config`, then kill the process tree plus anything still holding the port.
- **One server per script** - `frozen_bundle_smoke` no longer nests the migration smoke. Migration is its own step.
- **One port per step** - migration `8766`, bundle `8765` (product default, unchanged), connect `8767`, all overridable with `--port`. A slow teardown in one step can no longer stall the next.
- **`wait_for_owned_server` narrowed** to dev-stray detection (`stop_baklog.py`); frozen smokes use the HTTP wait.
- **`terminate_pid_tree`** kills descendants first on POSIX with a `SIGKILL` fallback, and never walks up into the CI runner.
- **Windows build mirrors the Linux order**, and both verify the bundled auth `.env` survives the smokes.

## Test plan

- [x] `ruff check .` clean
- [x] Full `pytest`: 1827 passed, 5 skipped
- [x] New `tests/test_frozen_smoke_server.py` covers ready / early-exit / blocked-port / leftover-listener paths
- [x] All three smokes run green against a real frozen Windows bundle on their new ports (migration 8766, bundle 8765, connect 8767), with ports released afterwards
- [ ] `Build Linux (preview)` green twice on `main` before the zip is promoted to `release.yml`

Note: the post-smoke `.env` check flagged the local `release/` bundle, whose binary predates the #210 migration fix and still moves `.env`. A fresh build carries the fix; the check exists to catch exactly that regression.
