### PR TITLE
Stage pyproject.toml at bundle root on Linux and macOS

### DIFF
--- a/packaging/build_linux.sh
+++ b/packaging/build_linux.sh
@@ -57,6 +57,9 @@ if [[ ! -f "${FALLBACK_JSON}" ]]; then
   exit 1
 fi
 
+# pyproject.toml must be at bundle root for frozen version detection: bundle_root()
+# is the exe directory, while PyInstaller puts the packaged copy under _internal/.
+cp -f "${ROOT}/pyproject.toml" "${OUT_DIR}/pyproject.toml"
 cp -f "${ROOT}/packaging/BETA-README.txt" "${OUT_DIR}/BETA-README.txt"
 cp -f "${ROOT}/packaging/apply_update.sh" "${OUT_DIR}/apply_update.sh"
 chmod +x "${OUT_DIR}/apply_update.sh" "${SERVER_BIN}"

--- a/packaging/build_macos.sh
+++ b/packaging/build_macos.sh
@@ -60,6 +60,9 @@ if [[ ! -f "${FALLBACK_JSON}" ]]; then
   exit 1
 fi
 
+# pyproject.toml must be at bundle root for frozen version detection: bundle_root()
+# is the exe directory, while PyInstaller puts the packaged copy under _internal/.
+cp -f "${ROOT}/pyproject.toml" "${OUT_DIR}/pyproject.toml"
 cp -f "${ROOT}/packaging/BETA-README.txt" "${OUT_DIR}/BETA-README.txt"
 cp -f "${ROOT}/packaging/apply_update.sh" "${OUT_DIR}/apply_update.sh"
 chmod +x "${OUT_DIR}/apply_update.sh" "${SERVER_BIN}" "${TRAY_BIN}"

--- a/scripts/frozen_bundle_smoke.py
+++ b/scripts/frozen_bundle_smoke.py
@@ -66,6 +66,9 @@ def run_smoke(bundle_dir, *, expected_version=None, port=BUNDLE_SMOKE_PORT):
     tray_exe = frozen_tray_path(bundle_dir)
     fallback = bundle_dir / "_internal" / "curated" / "free_claims.fallback.json"
     env_path = bundle_dir / ".env"
+    # bundle_root() is the exe directory, so the version source has to sit beside
+    # the binary, not in the PyInstaller _internal/ copy.
+    pyproject = bundle_dir / "pyproject.toml"
     tray_required = tray_exe is not None
     tray_ok = (not tray_required) or tray_exe.is_file()
     static_ok = server_exe.is_file() and tray_ok and fallback.is_file()
@@ -78,9 +81,16 @@ def run_smoke(bundle_dir, *, expected_version=None, port=BUNDLE_SMOKE_PORT):
         "curated_fallback": fallback.is_file(),
         "fetcher_manifest_count": fetcher_count,
         "bundled_env": env_ok,
+        "bundle_pyproject": pyproject.is_file(),
     }
     if not static_ok:
         report["error"] = "missing required bundle files"
+        return report
+    if not pyproject.is_file():
+        report["error"] = (
+            f"pyproject.toml missing at bundle root ({pyproject}); "
+            "the frozen server reads its version from there"
+        )
         return report
     if fetcher_count < 1:
         report["error"] = "fetchers/manifest.json missing or empty in bundle"

--- a/tests/test_frozen_bundle_smoke.py
+++ b/tests/test_frozen_bundle_smoke.py
@@ -8,10 +8,14 @@ import scripts.frozen_bundle_smoke as smoke
 from shared.update_platform import server_binary_name, tray_binary_name
 
 
-def _stub_bundle(tmp_path: Path, *, with_env: bool = True) -> Path:
+def _stub_bundle(tmp_path: Path, *, with_env: bool = True, with_pyproject: bool = True) -> Path:
     bundle = tmp_path / "BAKLOG"
     bundle.mkdir()
     (bundle / server_binary_name()).write_text("", encoding="utf-8")
+    if with_pyproject:
+        (bundle / "pyproject.toml").write_text(
+            '[project]\nversion = "0.8.20"\n', encoding="utf-8"
+        )
     tray = tray_binary_name()
     if tray:
         (bundle / tray).write_text("", encoding="utf-8")
@@ -61,6 +65,23 @@ def test_run_smoke_does_not_nest_migration_smoke(tmp_path: Path, monkeypatch) ->
     report = smoke.run_smoke(bundle, expected_version="0.8.20")
     assert "migration" not in report["checks"]
     assert report["port"] == smoke.BUNDLE_SMOKE_PORT
+
+
+def test_run_smoke_requires_pyproject_at_bundle_root(tmp_path: Path, monkeypatch) -> None:
+    """Frozen version detection reads bundle_root()/pyproject.toml, not _internal/."""
+    bundle = _stub_bundle(tmp_path, with_pyproject=False)
+    monkeypatch.setattr(smoke, "_read_expected_version", lambda: "0.8.20")
+    report = smoke.run_smoke(bundle, expected_version="0.8.20")
+    assert not report["ok"]
+    assert report["checks"]["static"]["bundle_pyproject"] is False
+    assert "pyproject.toml missing at bundle root" in (report.get("error") or "")
+
+
+def test_unix_build_scripts_stage_pyproject_at_bundle_root() -> None:
+    root = Path(__file__).resolve().parents[1]
+    for script in ("build_linux.sh", "build_macos.sh"):
+        text = (root / "packaging" / script).read_text(encoding="utf-8")
+        assert '"${ROOT}/pyproject.toml" "${OUT_DIR}/pyproject.toml"' in text, script
 
 
 def test_smoke_ports_are_distinct() -> None:


### PR DESCRIPTION
## Summary

Follow-up to #212. With the smoke refactor in place, the Linux preview finally reached the bundle smoke's version assertion and failed with `version mismatch: expected '0.9.00', got '0.0.0'`. Everything before it passed: build, migration smoke, import smoke, server start, root HTML, and the mirror auth gates.

The frozen server reads its version from `bundle_root()/pyproject.toml`, and `bundle_root()` is the executable's directory. PyInstaller only stages its packaged copy under `_internal/`, so `build_windows.ps1` has always copied the file next to the exe. `build_linux.sh` and `build_macos.sh` never did, so both bundles reported `0.0.0` to `/api/config` and to the update check.

- Copy `pyproject.toml` to the bundle root in `build_linux.sh` and `build_macos.sh`.
- `frozen_bundle_smoke` gains a `bundle_pyproject` static check, so a missing file reports itself directly instead of surfacing later as a version mismatch.
- Test guards for both the smoke check and the two build scripts.

## Test plan

- [x] `ruff check .` clean
- [x] Bundle / smoke-server / port-guard tests pass, including the two new guards
- [x] Bundle smoke green against the real frozen Windows bundle: `bundle_pyproject: true`, version `0.9.00`
- [ ] `Build Linux (preview)` green twice on `main`
