### PR TITLE
Resolve the smoke exe path before spawning in the bundle

### DIFF
--- a/scripts/frozen_smoke_server.py
+++ b/scripts/frozen_smoke_server.py
@@ -78,8 +78,10 @@ class FrozenSmokeServer:
         host: str = DEFAULT_HOST,
         start_timeout_sec: float = DEFAULT_START_TIMEOUT_SEC,
     ) -> None:
-        self.exe = Path(exe)
-        self.cwd = Path(cwd) if cwd is not None else self.exe.parent
+        # Resolve up front: callers pass paths relative to the repo root, but we
+        # spawn with cwd inside the bundle.
+        self.exe = Path(exe).resolve()
+        self.cwd = Path(cwd).resolve() if cwd is not None else self.exe.parent
         self.port = port
         self.host = host
         self.start_timeout_sec = start_timeout_sec

--- a/tests/test_frozen_smoke_server.py
+++ b/tests/test_frozen_smoke_server.py
@@ -91,6 +91,29 @@ def test_server_reports_blocked_port(monkeypatch, stub_exe: Path) -> None:
         assert server.proc is None
 
 
+def test_relative_exe_is_resolved_before_spawn(monkeypatch, stub_exe: Path) -> None:
+    """Callers pass repo-relative paths, but we spawn with cwd inside the bundle."""
+    spawned: list[tuple[Path, Path]] = []
+    monkeypatch.setattr(smoke_server, "ensure_port_free", lambda **kw: (True, None))
+    monkeypatch.setattr(smoke_server, "port_listener_pid", lambda host, port: None)
+    monkeypatch.setattr(smoke_server, "wait_for_port_free", lambda **kw: None)
+    monkeypatch.setattr(smoke_server, "terminate_pid_tree", lambda pid: None)
+    monkeypatch.setattr(smoke_server, "_probe_config", lambda base, **kw: True)
+    monkeypatch.setattr(
+        smoke_server,
+        "_spawn",
+        lambda exe, cwd, env: spawned.append((exe, cwd)) or _FakeProc(),
+    )
+    monkeypatch.chdir(stub_exe.parent.parent)
+    relative = Path(stub_exe.parent.name) / stub_exe.name
+
+    with smoke_server.FrozenSmokeServer(relative, port=8799) as server:
+        assert server.ok is True
+    exe, cwd = spawned[0]
+    assert exe.is_absolute() and exe.is_file()
+    assert cwd == stub_exe.parent.resolve()
+
+
 def test_server_missing_exe(tmp_path: Path) -> None:
     with smoke_server.FrozenSmokeServer(tmp_path / "nope", port=8799) as server:
         assert server.ok is False


### PR DESCRIPTION
## Summary

Follow-up to #212 and #213. The Linux preview now clears the build, import smoke, migration smoke, and bundle smoke, and fails only in the connect smoke with `FileNotFoundError: 'release/BAKLOG/BAKLOG'`.

The workflow passes a repo-relative `--exe`. Before the refactor the connect smoke spawned with the caller's working directory, so the relative path worked; the shared helper spawns with cwd inside the bundle, so it no longer resolved. `FrozenSmokeServer` now resolves the executable and cwd on construction.

## Test plan

- [x] `ruff check .` clean
- [x] Smoke-server, bundle, and port-guard tests pass, including a new case that spawns from a relative exe path
- [x] Connect smoke green against the real frozen Windows bundle
- [ ] `Build Linux (preview)` green twice on `main`
