### PR TITLE
Release 0.9.01: sync Windows Apps version after in-app update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Fixed
 
+- In-app updates on Windows refresh the version shown in Settings → Apps for Setup installs.
 - Dashboard and picks jumps to a library row re-check the target after scroll so the wrong game is not left under the sticky header on phone and mid-width layouts.
 - Dev and installed runs no longer share one browser error history when both use the same localhost origin; each runtime keeps its own log.
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <!-- Must match pyproject.toml + package.json (see CHANGELOG release discipline). Read at runtime by js/error-boundary.js for bug-bundle metadata. -->
     <!-- Optional override for bug report endpoint during local testing: content="http://127.0.0.1:3000/api/report" -->
     <!-- <meta name="baklog-report-endpoint" content="https://baklog.app/api/report" /> -->
-    <meta name="baklog-version" content="0.9.00" />
+    <meta name="baklog-version" content="0.9.01" />
     <meta name="theme-color" content="#0f172a" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "steam-backlog",
-  "version": "0.9.00",
+  "version": "0.9.01",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "steam-backlog",
-      "version": "0.9.00",
+      "version": "0.9.01",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog",
-  "version": "0.9.00",
+  "version": "0.9.01",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/packaging/apply_update.ps1
+++ b/packaging/apply_update.ps1
@@ -212,6 +212,30 @@ function Wait-ProcessGone([int]$ProcessId, [int]$TimeoutSec) {
     }
 }
 
+function Sync-ArpDisplayVersion {
+    param(
+        [string]$InstallDir,
+        [string]$Version
+    )
+    if (-not $Version) { return }
+    $unins = Get-ChildItem -LiteralPath $InstallDir -Filter "unins*.exe" -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if (-not $unins) {
+        Write-ApplyLog "skip ARP sync (no Inno uninstaller in install dir)"
+        return
+    }
+    $subkey = "Software\Microsoft\Windows\CurrentVersion\Uninstall\{A7B3C9D1-E4F2-4A8B-9C0D-1E2F3A4B5C6D}_is1"
+    foreach ($root in @("HKCU:\", "HKLM:\")) {
+        $path = "$root$subkey"
+        if (Test-Path -LiteralPath $path) {
+            Set-ItemProperty -LiteralPath $path -Name DisplayVersion -Value $Version -ErrorAction Stop
+            Write-ApplyLog "updated ARP DisplayVersion to $Version ($path)"
+            return
+        }
+    }
+    Write-ApplyLog "skip ARP sync (Inno uninstall registry key not found)"
+}
+
 function Start-TrayIfPresent {
     if (-not $script:InstallDir) { return }
     $trayExePath = Join-Path $script:InstallDir "BAKLOG Tray.exe"
@@ -344,6 +368,7 @@ try {
         }
 
         Remove-OldBackups -InstallParent $installParent -KeepBackup $script:BackupDir
+        Sync-ArpDisplayVersion -InstallDir $installDir -Version $script:Version
         Write-ApplyResult -Ok $true -Version $script:Version -Restored $false
         # Drop ready package so the relaunched app does not rehydrate Install & restart.
         $versionDir = Join-Path $script:UpdateRoot $script:Version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["auth*", "clients*", "fetchers*", "enrichers*", "shared*"]
 
 [project]
 name = "steam-backlog"
-version = "0.9.00"
+version = "0.9.01"
 description = "Local multi-store game library dashboard and fetchers"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/shared/install_visibility.py
+++ b/shared/install_visibility.py
@@ -54,6 +54,32 @@ def read_arp_display_version() -> str | None:
     return None
 
 
+def write_arp_display_version(version: str) -> bool:
+    """Update Inno DisplayVersion when the uninstall registry entry exists.
+
+    In-app zip updates replace files under ``%LOCALAPPDATA%\\BAKLOG`` but do not
+    re-run Setup; without this, Settings → Apps keeps showing the version from
+    the last ``BAKLOG-Setup.exe`` run.
+    """
+    text = str(version or "").strip()
+    if sys.platform != "win32" or not text:
+        return False
+    try:
+        import winreg
+    except ImportError:
+        return False
+
+    subkey = rf"Software\Microsoft\Windows\CurrentVersion\Uninstall\{INNO_UNINSTALL_REG_SUFFIX}"
+    for hive in (winreg.HKEY_CURRENT_USER, winreg.HKEY_LOCAL_MACHINE):
+        try:
+            with winreg.OpenKey(hive, subkey, 0, winreg.KEY_SET_VALUE) as key:
+                winreg.SetValueEx(key, "DisplayVersion", 0, winreg.REG_SZ, text)
+                return True
+        except OSError:
+            continue
+    return False
+
+
 def arp_version_mismatch(current_version: str, arp_version: str | None) -> bool:
     """True when ARP lists a different version than the running build."""
     from shared.server_support import normalize_version_tag
@@ -71,7 +97,7 @@ def install_trust_fields() -> dict[str, Any]:
     if sys.platform == "win32":
         fields["trust_note"] = (
             "Unsigned beta: SmartScreen may warn on first launch — More info, then Run anyway. "
-            "In-app zip updates do not refresh Add/Remove Programs; re-run Setup when you want ARP to match."
+            "Setup installs sync Add/Remove Programs after in-app zip updates."
         )
     elif sys.platform == "darwin":
         fields["trust_note"] = (

--- a/tests/test_apply_update_ps1.py
+++ b/tests/test_apply_update_ps1.py
@@ -182,6 +182,42 @@ def test_apply_update_ps1_missing_tray_in_bundle_restores(
     assert (install / "BAKLOG.exe").read_bytes() == b"old-server"
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows apply script only")
+def test_apply_update_ps1_syncs_arp_display_version(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import winreg
+
+    from shared.install_visibility import INNO_UNINSTALL_REG_SUFFIX
+
+    subkey = rf"Software\Microsoft\Windows\CurrentVersion\Uninstall\{INNO_UNINSTALL_REG_SUFFIX}"
+    monkeypatch.setenv("TEMP", str(tmp_path))
+    monkeypatch.setenv("TMP", str(tmp_path))
+
+    winreg.CreateKey(winreg.HKEY_CURRENT_USER, subkey)
+    try:
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, subkey, 0, winreg.KEY_SET_VALUE) as key:
+            winreg.SetValueEx(key, "DisplayVersion", 0, winreg.REG_SZ, "0.8.38")
+
+        install = tmp_path / "install" / "BAKLOG"
+        install.mkdir(parents=True)
+        (install / "BAKLOG.exe").write_bytes(b"old-server")
+        (install / "BAKLOG Tray.exe").write_bytes(b"old-tray")
+        (install / "unins000.exe").write_bytes(b"inno-uninstall-stub")
+
+        zip_path, sha256 = _make_bundle_zip(tmp_path)
+        proc = _run_apply(tmp_path, install=install, zip_path=zip_path, sha256=sha256, version="0.9.01")
+        assert proc.returncode == 0, proc.stderr
+
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, subkey) as key:
+            display_version, _ = winreg.QueryValueEx(key, "DisplayVersion")
+        assert display_version == "0.9.01"
+        assert "updated ARP DisplayVersion" in (tmp_path / "BAKLOG-update" / "apply.log").read_text(encoding="utf-8")
+    finally:
+        try:
+            winreg.DeleteKey(winreg.HKEY_CURRENT_USER, subkey)
+        except OSError:
+            pass
+
+
 def test_apply_update_ps1_avoids_module_cmdlets() -> None:
     text = APPLY_PS1.read_text(encoding="utf-8")
     assert "Expand-Archive" not in text
@@ -195,6 +231,7 @@ def test_apply_update_ps1_avoids_module_cmdlets() -> None:
     assert "zip-slip" in text
     assert "ExtractToFile" in text
     assert "ExtractToDirectory" not in text
+    assert "Sync-ArpDisplayVersion" in text
 
 
 def test_apply_update_ps1_kill_helper_excludes_self() -> None:

--- a/tests/test_install_visibility.py
+++ b/tests/test_install_visibility.py
@@ -1,14 +1,19 @@
 """Tests for install source + ARP visibility helpers."""
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from shared.install_visibility import (
+    INNO_UNINSTALL_REG_SUFFIX,
     arp_version_mismatch,
     detect_install_source,
     install_visibility_fields,
     read_arp_display_version,
+    write_arp_display_version,
 )
 
 
@@ -52,6 +57,30 @@ def test_arp_version_mismatch() -> None:
 def test_read_arp_display_version_non_windows() -> None:
     with patch("shared.install_visibility.sys.platform", "linux"):
         assert read_arp_display_version() is None
+
+
+def test_write_arp_display_version_non_windows() -> None:
+    with patch("shared.install_visibility.sys.platform", "linux"):
+        assert write_arp_display_version("0.9.01") is False
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows registry only")
+def test_write_arp_display_version_updates_registry() -> None:
+    import winreg
+
+    subkey = rf"Software\Microsoft\Windows\CurrentVersion\Uninstall\{INNO_UNINSTALL_REG_SUFFIX}"
+    with patch("shared.install_visibility.sys.platform", "win32"):
+        winreg.CreateKey(winreg.HKEY_CURRENT_USER, subkey)
+        try:
+            with winreg.OpenKey(winreg.HKEY_CURRENT_USER, subkey, 0, winreg.KEY_SET_VALUE) as key:
+                winreg.SetValueEx(key, "DisplayVersion", 0, winreg.REG_SZ, "0.8.38")
+            assert write_arp_display_version("0.9.01") is True
+            assert read_arp_display_version() == "0.9.01"
+        finally:
+            try:
+                winreg.DeleteKey(winreg.HKEY_CURRENT_USER, subkey)
+            except OSError:
+                pass
 
 
 def test_install_visibility_fields_includes_keys() -> None:


### PR DESCRIPTION
## Summary

- In-app zip updates on Windows now refresh **Settings → Apps** `DisplayVersion` when the install came from `BAKLOG-Setup.exe` (`unins*.exe` present).
- Adds `write_arp_display_version()` + apply-update integration and tests.
- Version stamps bumped to **0.9.01** for the release cut.

## Test plan

- [x] `pytest tests/test_install_visibility.py tests/test_apply_update_ps1.py`
- [x] `ruff check` on touched files
- [ ] Merge to `main`, CI green, then `release_preflight.ps1 -TagVersion v0.9.01` + manual tray smoke before tag
