### PR TITLE
feat: Linux release zip + open-beta docs (0.9.01 notes)

### DIFF
--- a/.cursor/rules/release.mdc
+++ b/.cursor/rules/release.mdc
@@ -16,7 +16,7 @@ Before **tagging or publishing** any release (`vX.Y.Z`, `replace_release_tag.ps1
    - Run `.\scripts\release_preflight.ps1 -TagVersion vX.Y.Z` (full gate: tests + Inno stub + `packaging\build_windows.ps1`), or at minimum `packaging\build_windows.ps1` alone.
    - Automated smokes run inside the build: `frozen_bundle_smoke`, `frozen_import_smoke`, `frozen_connect_smoke`.
    - **Manual smoke** on `release\BAKLOG\`: launch `BAKLOG Tray.exe`, confirm version badge, sign-in gate, and one Connect if relevant.
-   - Local zip/Setup is for testing only; **do not upload it**. Tagging triggers `release.yml`, which rebuilds on GitHub and publishes authoritative assets.
+   - Local zip/Setup is for testing only; **do not upload it**. Tagging triggers `release.yml`, which rebuilds on GitHub and publishes authoritative assets (Windows Setup + win64/macos/linux64 zips).
 5. Flow: commit → push → merge to `main` → confirm clean tree + CI green → local frozen build + manual smoke → `git tag -a vX.Y.Z` and `git push origin vX.Y.Z` so `release.yml` builds assets.
 
 Do **not** tag a dirty tree, an unmerged feature branch, or a commit whose CI failed/is pending.

--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@
 # only when you intentionally need admin against the installed library:
 # BAKLOG_ADMIN_ALLOW_INSTALLED=1
 
-# Optional: Supabase invite-only login (BAKLOG_SUPABASE_* in .env.example)
+# Optional: account sign-in (BAKLOG_SUPABASE_* below)
 # Required for beta builds: frozen bundle writes these into release/BAKLOG/.env
 # via scripts/write_bundle_auth_env.py (from .env, packaging/bundle-auth.env, or CI).
 # BAKLOG_SUPABASE_URL=https://xxxx.supabase.co

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,7 +1,7 @@
-# Experimental Linux frozen build (workflow_dispatch preview).
+# Manual Linux frozen preview (workflow_dispatch).
 # Builds BAKLOG-linux64.zip on ubuntu-22.04 (glibc 2.35 baseline), runs frozen
-# smokes headlessly, then uploads zip + sha256 + SBOM as workflow artifacts.
-# Promote into release.yml on v* tags only after 2-3 clean dispatch runs.
+# smokes, then uploads zip + sha256 + SBOM as workflow artifacts (14-day retention).
+# Tagged releases publish the same zip via release.yml (build-linux job).
 name: Build Linux (preview)
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
-# Immutable releases: a push of a v* tag builds the Windows bundle on a clean
-# runner, attaches a SHA-256 + a signed build-provenance attestation, and
-# publishes the GitHub Release. The artifact is built from the tagged commit by
-# CI (not hand-uploaded), so anyone can verify it with `gh attestation verify`.
+# Immutable releases: a push of a v* tag builds Windows (then attaches macOS +
+# Linux), with SHA-256 + signed build-provenance where configured, and
+# publishes the GitHub Release. Artifacts are built from the tagged commit by
+# CI (not hand-uploaded), so anyone can verify with `gh attestation verify`.
 #
 # Policy: prefer not to move tags. If a published installer is broken for
 # strangers/beta, replace the SAME version: fix on main, run
@@ -216,3 +216,159 @@ jobs:
         run: |
           tag="${{ github.ref_name }}"
           gh release upload "$tag" release/BAKLOG-macos.zip release/BAKLOG-macos.sha256 --clobber
+
+  build-linux:
+    name: Build and attach Linux release
+    runs-on: ubuntu-22.04
+    needs: build
+    timeout-minutes: 45
+    env:
+      BAKLOG_NO_BROWSER: "1"
+      BAKLOG_NO_CHROMIUM_DOWNLOAD: "1"
+      BAKLOG_IDLE_SHUTDOWN_MINUTES: "0"
+      BAKLOG_PROFILE: smoke
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install zip utility
+        run: sudo apt-get update && sudo apt-get install -y zip
+
+      - name: Verify release auth secrets (fail fast)
+        env:
+          BAKLOG_SUPABASE_URL: ${{ secrets.BAKLOG_SUPABASE_URL }}
+          BAKLOG_SUPABASE_ANON_KEY: ${{ secrets.BAKLOG_SUPABASE_ANON_KEY }}
+        run: |
+          if [ -z "$BAKLOG_SUPABASE_URL" ] || [ -z "$BAKLOG_SUPABASE_ANON_KEY" ]; then
+            echo "::error::GitHub repo secrets BAKLOG_SUPABASE_URL and BAKLOG_SUPABASE_ANON_KEY must be set before tagging."
+            exit 1
+          fi
+          echo "Release auth secrets present (values not printed)."
+
+      - name: Build Linux bundle
+        env:
+          BAKLOG_SUPABASE_URL: ${{ secrets.BAKLOG_SUPABASE_URL }}
+          BAKLOG_SUPABASE_ANON_KEY: ${{ secrets.BAKLOG_SUPABASE_ANON_KEY }}
+        run: bash packaging/build_linux.sh
+
+      - name: Verify bundled auth .env after build
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          from scripts.frozen_bundle_smoke import _env_has_auth_keys
+          env_path = Path("release/BAKLOG/.env")
+          ok, missing = _env_has_auth_keys(env_path)
+          assert ok, f"bundled .env invalid after build: missing {missing}"
+          print(f"bundled auth ok: {env_path}")
+          PY
+
+      - name: Isolate smoke home (XDG)
+        run: |
+          mkdir -p "$RUNNER_TEMP/baklog-home/.local/share"
+          echo "HOME=$RUNNER_TEMP/baklog-home" >> "$GITHUB_ENV"
+          echo "XDG_DATA_HOME=$RUNNER_TEMP/baklog-home/.local/share" >> "$GITHUB_ENV"
+
+      - name: Chromium pin smoke (linux64)
+        run: |
+          python - <<'PY'
+          from shared.chromium_runtime import is_allowed_cft_url, load_pin, platform_key
+          assert platform_key() == "linux64", platform_key()
+          pin = load_pin()
+          entry = (pin.get("platforms") or {}).get("linux64")
+          assert isinstance(entry, dict), entry
+          url = str(entry.get("url") or "")
+          sha = str(entry.get("sha256") or "")
+          assert is_allowed_cft_url(url), url
+          assert len(sha) == 64, sha
+          print("chromium pin linux64 ok")
+          PY
+
+      - name: XDG data-dir smoke
+        run: |
+          python - <<'PY'
+          import os
+          from pathlib import Path
+          from shared.install_paths import default_frozen_data_dir
+          home = Path(os.environ["HOME"]).resolve()
+          xdg = Path(os.environ["XDG_DATA_HOME"]).resolve()
+          got = default_frozen_data_dir()
+          expect = (xdg / "baklog").resolve()
+          assert got == expect, (got, expect, home)
+          print(f"default_frozen_data_dir ok: {got}")
+          PY
+
+      - name: Frozen import smoke
+        run: python scripts/frozen_import_smoke.py --exe release/BAKLOG/BAKLOG
+
+      - name: Frozen data-dir migration smoke
+        run: python scripts/frozen_data_dir_migration_smoke.py --bundle-dir release/BAKLOG --port 8766
+
+      - name: Frozen bundle smoke
+        run: python scripts/frozen_bundle_smoke.py release/BAKLOG --port 8765
+
+      - name: Frozen connect smoke
+        run: python scripts/frozen_connect_smoke.py --exe release/BAKLOG/BAKLOG --port 8767
+
+      - name: Verify bundled auth .env survived smokes
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          from scripts.frozen_bundle_smoke import _env_has_auth_keys
+          env_path = Path("release/BAKLOG/.env")
+          ok, missing = _env_has_auth_keys(env_path)
+          assert ok, f"bundled .env lost during smokes: missing {missing}"
+          print(f"bundled auth intact: {env_path}")
+          PY
+
+      - name: Verify Linux artifacts exist
+        run: |
+          test -f release/BAKLOG-linux64.zip
+          test -f release/BAKLOG-linux64.sha256
+          test -x release/BAKLOG/BAKLOG
+          test -x "release/BAKLOG/Start BAKLOG.sh"
+          test ! -e "release/BAKLOG/BAKLOG Tray"
+          (
+            cd release
+            sha256sum -c BAKLOG-linux64.sha256
+          )
+          ls -lh release/BAKLOG-linux64.zip release/BAKLOG-linux64.sha256
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: release/BAKLOG
+          format: spdx-json
+          output-file: release/BAKLOG-linux64.sbom.spdx.json
+
+      - name: Generate build provenance attestation
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: release/BAKLOG-linux64.zip
+
+      - name: Attest SBOM
+        uses: actions/attest-sbom@v2
+        with:
+          subject-path: release/BAKLOG-linux64.zip
+          sbom-path: release/BAKLOG-linux64.sbom.spdx.json
+
+      - name: Upload Linux assets to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${{ github.ref_name }}"
+          gh release upload "$tag" \
+            release/BAKLOG-linux64.zip \
+            release/BAKLOG-linux64.sha256 \
+            release/BAKLOG-linux64.sbom.spdx.json \
+            --clobber

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -76,10 +76,10 @@ Without Supabase, Pro is **`license.json` on disk** (honor system for local dev;
 Polar activation for paid users). With Supabase, plan comes from JWT / admin
 metadata. Source is public; paying supports development, not a secret fork.
 
-## Open source vs invite beta
+## Open source vs open beta
 
 - **MIT + full source** in this repo (server, fetchers, UI, packaging scripts).
-- **Invite-only** refers to packaged beta builds and rollout, not hidden code.
+- **Open beta** means packaged builds and rollout pacing, not hidden code.
 - **Gitignored** paths: personal `profiles/`, `games_*.json`, `.env`, and
   maintainer-only `admin/`, `marketing/`, internal `docs/` (synced to private repo).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 - baklog.app is open beta: signup confirmation includes the GitHub Releases download link.
 - Free claims feed refreshed (stale approved-only ids dropped).
 - Docs and in-app tips describe open beta downloads for Windows, macOS, and Linux.
+- Auto-enrich new games stays off by default (opt in from Fetcher health).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,21 +33,23 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [Unreleased]
 
+## [0.9.01] - 2026-08-31
+
 ### Added
 
-- Experimental Linux zip build (`BAKLOG-linux64.zip`) for testers who prefer a packaged app to running from source (server + Start script; no tray yet).
+- Packaged Linux zip (`BAKLOG-linux64.zip`) on GitHub Releases (server + Start script; no tray yet). Prefer a desktop or GUI session - Connect needs a headed browser.
 
 ### Changed
 
-- baklog.app is open beta: signup email still collected, confirmation includes the GitHub Releases download link.
-- Maintainer admin console will not attach to the default installed library folder unless you explicitly allow it. Prefer a separate data folder for admin work.
-- Free claims feed rebuilt from current approved auto rows (stale approved-only ids dropped).
+- baklog.app is open beta: signup confirmation includes the GitHub Releases download link.
+- Free claims feed refreshed (stale approved-only ids dropped).
+- Docs and in-app tips describe open beta downloads for Windows, macOS, and Linux.
 
 ### Fixed
 
 - In-app updates on Windows refresh the version shown in Settings → Apps for Setup installs.
 - Dashboard and picks jumps to a library row re-check the target after scroll so the wrong game is not left under the sticky header on phone and mid-width layouts.
-- Dev and installed runs no longer share one browser error history when both use the same localhost origin; each runtime keeps its own log.
+- Source and packaged runs no longer share one browser error history when both use the same localhost origin; each runtime keeps its own log.
 
 ## [0.9.00] - 2026-08-18
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -9,7 +9,7 @@ machine. On frozen Windows beta installs, the default data root is
 `%LOCALAPPDATA%\BAKLOG-Data` (override with `BAKLOG_DATA_DIR`). Profile-scoped
 files live under `profiles/<id>/` inside that root.
 
-**Optional Supabase sign-in:** If you enable invite-only auth (set
+**Optional account sign-in:** If you enable auth (set
 `BAKLOG_SUPABASE_URL` and `BAKLOG_SUPABASE_ANON_KEY` in `.env`), Supabase stores your account
 email and session metadata on their hosted service. BAKLOG still keeps library
 JSON and Connections secrets locally; only the login handshake talks to Supabase.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **BAKLOG pulls every game you own into one local, honest table.** Free forever to import · **twelve libraries and eight wishlists** · runs on your machine, no telemetry by default. Connect your stores once — Steam, GOG, PlayStation, Epic, Amazon, Xbox, Battle.net, Ubisoft Connect, Nintendo Switch, itch.io, Humble Bundle, and EA App — then decide what to play next and whether that "deal" is actually worth opening. Your credentials and library JSON stay on your machine (see [PRIVACY.md](PRIVACY.md) for the few optional network calls).
 
-**Open source (MIT)** - [read the code on GitHub](https://github.com/Ogrods/BAKLOG) and verify the privacy story yourself. **Free forever to import · Invite-only early access.** Request access at **[baklog.app](https://baklog.app)**. Community chat: **[Discord](https://discord.gg/VFvxN5nCCB)** (canonical invite in [`shared/community.json`](shared/community.json)).
+**Open source (MIT)** - [read the code on GitHub](https://github.com/Ogrods/BAKLOG) and verify the privacy story yourself. **Free forever to import · Open beta.** Download at **[baklog.app](https://baklog.app)** or [GitHub Releases](https://github.com/Ogrods/BAKLOG/releases/latest). Community chat: **[Discord](https://discord.gg/VFvxN5nCCB)** (canonical invite in [`shared/community.json`](shared/community.json)).
 
 **Reviewing the repo?** See [ARCHITECTURE.md](ARCHITECTURE.md) for an honest map (local vs network, monolith shape, Pro licensing, store ToS).
 
@@ -61,7 +61,7 @@ See [PRIVACY.md](PRIVACY.md) for the data-handling story (TL;DR: library and cre
 |----|--------|
 | **Windows 10/11** | Fully supported (primary development target) |
 | **macOS** | Supported with limits — **Amazon Games (launcher)** and **GOG Galaxy (local)** are Windows/macOS-only local sources |
-| **Linux** | Supported with limits - Amazon Games (launcher) and GOG Galaxy (local) unavailable (use web Connect). Experimental frozen zip (`BAKLOG-linux64.zip`) available via CI preview; source-run still recommended |
+| **Linux** | Supported with limits - Amazon Games (launcher) and GOG Galaxy (local) unavailable (use web Connect). Packaged zip (`BAKLOG-linux64.zip`) on GitHub Releases (experimental; no tray yet) |
 
 The app itself (dashboard, `server.py`, secret storage, browser sign-in) is OS-agnostic. **Windows-only local source:** **Amazon Games (launcher)** reads the desktop launcher's DPAPI-encrypted SQLite (no portable equivalent) — on macOS/Linux use **Amazon (Prime Gaming, web)** Connect instead; the Amazon fetcher still runs and auto-picks the web session. **GOG Galaxy (local)** reads `galaxy-2.0.db` from the Galaxy install (Windows ProgramData or macOS Shared) — there is no supported Linux path, so Linux users use **GOG (web)** instead. Platform-restricted local providers show as **Unavailable** on unsupported OSes; their fetcher chips stay enabled when a web fallback exists.
 
@@ -89,7 +89,7 @@ powershell -ExecutionPolicy Bypass -File scripts/build_installer.ps1
 
 **Pro background refresh:** when the server process is alive (tray or `python server.py`), the paid tier scheduler refreshes stale stores without an open browser tab. Under Supabase auth, sign in once in the browser so the server caches your plan for headless refresh.
 
-**Optional invite-only accounts:** Supabase Auth can require sign-in before the dashboard loads; each user gets their own profile data directory. Set `BAKLOG_SUPABASE_URL` and `BAKLOG_SUPABASE_ANON_KEY` in `.env` (see `.env.example`). Without Supabase env vars, behavior is unchanged. Use `BAKLOG_AUTH_DISABLED=1` to skip the gate while testing. Set `BAKLOG_LOCAL_PROFILES=1` to keep the local Work/Play profile switcher available while Supabase sign-in stays on (optional per-profile PINs gate switching; profile mutations require the in-app `X-BAKLOG-Local` header).
+**Optional account sign-in:** When configured, Supabase Auth can require sign-in before the dashboard loads; each user gets their own profile data directory. Set `BAKLOG_SUPABASE_URL` and `BAKLOG_SUPABASE_ANON_KEY` in `.env` (see `.env.example`). Without those env vars, local behavior is unchanged. Use `BAKLOG_AUTH_DISABLED=1` to skip the gate while testing. Set `BAKLOG_LOCAL_PROFILES=1` to keep the local Work/Play profile switcher available while sign-in stays on (optional per-profile PINs gate switching; profile mutations require the in-app `X-BAKLOG-Local` header).
 
 ### Store availability by platform
 
@@ -329,4 +329,4 @@ pytest tests/test_cdp_browser.py -m integration
 
 On GitHub, use **Actions → CDP smoke (manual) → Run workflow** after a suspected Chrome/Edge regression.
 
-BAKLOG is **local-first**: your library JSON and store credentials stay on your machine. Optional invite Supabase sign-in and Polar Pro checkout exist when configured; catalogs are not hosted in a BAKLOG cloud by default.
+BAKLOG is **local-first**: your library JSON and store credentials stay on your machine. Optional account sign-in and Polar Pro checkout exist when configured; catalogs are not hosted in a BAKLOG cloud by default.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ powershell -ExecutionPolicy Bypass -File scripts/build_installer.ps1
 - **Connections tab:** one-click store auth (browser sign-in or API keys), encrypted credential storage, portable secrets bundle
 - **Auto-fetch on connect** (default on): when you connect or reconnect a store, BAKLOG auto-fetches its library and opens the fetcher log
 - **Auto-refresh stale stores** (default on): Connections toggle — quietly refreshes one store older than 24h every ~30 min while the app is open
-- **Auto-enrich** (default on): after a library fetch adds games, queues HLTB, reviews, covers, and co-op tags
+- **Auto-enrich** (default off): after a library fetch adds games, optionally queues HLTB, reviews, covers, and co-op tags (Fetcher health toggle)
 - **ITAD auto-refresh** (default on): deal prices refresh on a 15–60 min schedule while the dashboard is open
 
 ### Paid tier ($5/mo)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ defends, what it explicitly does **not**, and the cryptography behind the
 claims. For the plain-language data inventory and network-host list, see
 [PRIVACY.md](PRIVACY.md).
 
-**Optional invite-only accounts:** When `BAKLOG_SUPABASE_*` is set, Supabase
+**Optional account sign-in:** When `BAKLOG_SUPABASE_*` is set, Supabase
 hosts login only (email + JWT). Your library and Connections secrets still live
 under `profiles/<user-id>/` on the machine running `server.py`. Configure
 `BAKLOG_SUPABASE_URL` and `BAKLOG_SUPABASE_ANON_KEY` in `.env` (see `.env.example`).

--- a/guide/faq.md
+++ b/guide/faq.md
@@ -48,9 +48,9 @@ The marketing site at [baklog.app](https://baklog.app) has a separate waitlist a
 
 No telemetry by default. Optional anonymous aggregate metrics (active sessions, sponsored-slot impressions) stay off unless you turn on **Share anonymous stats** in Connections. No library data or per-game telemetry leaves your machine. See [PRIVACY.md](../PRIVACY.md).
 
-## Why invite-only right now?
+## Is BAKLOG open beta?
 
-We are onboarding in small waves so we can fix what breaks on real setups before opening the doors. Request access at [baklog.app](https://baklog.app).
+Yes. Download from [baklog.app](https://baklog.app) or [GitHub Releases](https://github.com/Ogrods/BAKLOG/releases/latest). Builds are unsigned beta - see [troubleshooting](troubleshooting.md#unsigned-beta-builds-no-code-signing).
 
 ## Supported platforms
 
@@ -58,7 +58,7 @@ We are onboarding in small waves so we can fix what breaks on real setups before
 |----|--------|
 | **Windows 10/11** | Fully supported (primary development target) |
 | **macOS** | Supported with limits - Amazon Games (launcher) and GOG Galaxy (local) are Windows/macOS-only local sources |
-| **Linux** | Supported with limits - Amazon Games (launcher) and GOG Galaxy (local) unavailable (use web Connect). Experimental `BAKLOG-linux64.zip` packaged build in preview |
+| **Linux** | Supported with limits - Amazon Games (launcher) and GOG Galaxy (local) unavailable (use web Connect). Packaged `BAKLOG-linux64.zip` on GitHub Releases (experimental; no tray yet) |
 
 The app itself (dashboard, server, secret storage, browser sign-in) is OS-agnostic. Platform-restricted local providers show as **Unavailable** on unsupported OSes; web fallbacks remain available.
 

--- a/guide/getting-help.md
+++ b/guide/getting-help.md
@@ -36,7 +36,7 @@ Discord invite and GitHub repo URLs are canonical in [`shared/community.json`](.
 
 1. [Troubleshooting](troubleshooting.md) - auth failures, 403s, empty results, platform limits
 2. [Connecting stores](connecting-stores.md) - per-store privacy settings and CLI fallbacks
-3. [FAQ](faq.md) - free vs paid, invite-only access, count differences
+3. [FAQ](faq.md) - free vs paid, open beta access, count differences
 
 ## Full user guide
 

--- a/guide/getting-started.md
+++ b/guide/getting-started.md
@@ -14,38 +14,36 @@ On Windows, use the project `.venv` Python - not the Microsoft Store `python.exe
 
 ## Beta (Windows)
 
-If you received a beta invite:
-
-1. Download and run **BAKLOG-Setup.exe** from your invite link.
-2. If SmartScreen warns about an unknown publisher, click **More info**, then **Run anyway**. BAKLOG is an unsigned beta — see [Unsigned beta builds](troubleshooting.md#unsigned-beta-builds-no-code-signing).
+1. Download **BAKLOG-Setup.exe** (or the portable zip) from [GitHub Releases](https://github.com/Ogrods/BAKLOG/releases/latest) or [baklog.app](https://baklog.app).
+2. If SmartScreen warns about an unknown publisher, click **More info**, then **Run anyway**. BAKLOG is an unsigned beta - see [Unsigned beta builds](troubleshooting.md#unsigned-beta-builds-no-code-signing).
 3. Launch **BAKLOG** from the Start Menu. A tray icon appears and your browser opens.
 4. Open the **Connections** tab and connect each store you use (Chrome or Edge required).
 
 Your library data (profiles, games, connections) lives in `%LOCALAPPDATA%\BAKLOG-Data`, separate from the app folder (or beside the exe when `portable.txt` is present). Uninstalling BAKLOG removes the app and always clears login autostart; the uninstall wizard lets you keep your library or remove everything (data folder and saved sign-ins). Zip-only installs can run **Uninstall BAKLOG.bat** in the install folder for the same cleanup before deleting the folder.
 
-**Maintainers testing dev and frozen on one PC:** set both in `.env` before `python server.py`:
+**Running from source and a packaged install on one PC:** set both in `.env` before `python server.py`:
 
 ```env
 BAKLOG_DATA_DIR=%LOCALAPPDATA%\BAKLOG-Dev
 PORT=8766
 ```
 
-That keeps library files out of `BAKLOG-Data` and gives dev its own browser origin so localStorage is not shared with the installed app on port 8765. The dashboard header shows a **Dev server** chip when the dev server is active. See [troubleshooting](troubleshooting.md#dev-server-vs-frozen-exe-same-browser-origin).
+That keeps library files out of `BAKLOG-Data` and gives the source run its own browser origin so localStorage is not shared with the installed app on port 8765. The dashboard header shows a **Dev server** chip when that mode is active. See [troubleshooting](troubleshooting.md#dev-server-vs-frozen-exe-same-browser-origin).
 
 Portable zip builds work too: unzip to a normal folder, then run `Start BAKLOG.bat` or `BAKLOG Tray.exe`. Add an empty `portable.txt` beside `BAKLOG.exe` only if you want all data in the unzip folder (thumb drives). See `BETA-README.txt` in the bundle.
 
 ## Beta (macOS)
 
-1. Download **BAKLOG-macos.zip** from [GitHub Releases](https://github.com/Ogrods/BAKLOG/releases/latest) (or your invite link once tagged).
-2. Unzip to a normal folder (not Downloads directly — Gatekeeper is stricter there). Double-click **Start BAKLOG.command** or run **BAKLOG Tray** from the `BAKLOG` folder.
+1. Download **BAKLOG-macos.zip** from [GitHub Releases](https://github.com/Ogrods/BAKLOG/releases/latest).
+2. Unzip to a normal folder (not Downloads directly - Gatekeeper is stricter there). Double-click **Start BAKLOG.command** or run **BAKLOG Tray** from the `BAKLOG` folder.
 3. If macOS blocks the app ("cannot be opened"), right-click **BAKLOG Tray** → **Open** once, or run `xattr -cr /path/to/BAKLOG` in Terminal. See [Unsigned beta builds](troubleshooting.md#unsigned-beta-builds-no-code-signing).
 4. Library data lives in `~/Library/Application Support/BAKLOG-Data` (or beside the app when `portable.txt` is present). In-app updates use `apply_update.sh` once a mac zip is on the release.
 
 ## Beta (Linux)
 
-Experimental packaged zip (no tray icon yet). Prefer a desktop session or GUI VM - Connect needs a headed browser.
+Experimental packaged zip (no tray icon yet). Prefer a desktop session or GUI VM - Connect needs a headed browser. Needs a modern glibc (2.35+), same baseline as Ubuntu 22.04.
 
-1. Download **BAKLOG-linux64.zip** from [GitHub Releases](https://github.com/Ogrods/BAKLOG/releases/latest) when published, or from a CI preview artifact while it is still experimental.
+1. Download **BAKLOG-linux64.zip** from [GitHub Releases](https://github.com/Ogrods/BAKLOG/releases/latest).
 2. Unzip to a normal folder, then run:
 
    ```bash
@@ -141,4 +139,4 @@ $env:BAKLOG_SERVE_BUILT='1'; python server.py   # PowerShell
 
 - [Connecting stores](connecting-stores.md) - per-store Connect steps and CLI fallbacks
 - [Using the dashboard](using-the-dashboard.md) - tabs, filters, statuses
-- [FAQ](faq.md) - free vs paid, invite-only access, no-games-yet paths
+- [FAQ](faq.md) - free vs paid, open beta access, no-games-yet paths

--- a/guide/profiles-and-moving-machines.md
+++ b/guide/profiles-and-moving-machines.md
@@ -69,6 +69,6 @@ Copy these folders/files to the new machine (or sync via Dropbox/OneDrive):
 
 Re-run fetchers on the new machine to refresh stale data, or copy `cache/` to skip re-downloading API responses.
 
-## Optional invite-only accounts
+## Optional account sign-in
 
-Supabase Auth can require sign-in before the dashboard loads; each user gets their own profile data directory. Set `BAKLOG_SUPABASE_URL` and `BAKLOG_SUPABASE_ANON_KEY` in `.env` (see `.env.example`). Without Supabase env vars, behavior is unchanged. Use `BAKLOG_AUTH_DISABLED=1` to skip the gate while testing.
+When configured, account sign-in can require a login before the dashboard loads; each user gets their own profile data directory. Set `BAKLOG_SUPABASE_URL` and `BAKLOG_SUPABASE_ANON_KEY` in `.env` (see `.env.example`). Without those env vars, local behavior is unchanged. Use `BAKLOG_AUTH_DISABLED=1` to skip the gate while testing.

--- a/guide/refresh-and-enrichment.md
+++ b/guide/refresh-and-enrichment.md
@@ -8,7 +8,7 @@ Keep library data current and backfill metadata after fetchers run.
 
 **ITAD auto-refresh** (default on): deal prices refresh on a 15-60 min schedule from the Fetcher health panel.
 
-**Auto-enrich** (default on): after a library fetch adds games, queues HLTB, reviews, covers, and co-op tags.
+**Auto-enrich** (default off): after a library fetch adds games, optionally queues HLTB, reviews, covers, and co-op tags. Turn it on from the Fetcher health panel if you want that.
 
 On the free tier, store refresh is one store at a time, on demand (click a fetcher chip). Pro adds scheduled refresh while the app is closed - see [FAQ](faq.md).
 

--- a/guide/troubleshooting.md
+++ b/guide/troubleshooting.md
@@ -172,7 +172,7 @@ If you still have `BAKLOG-Data`, reinstall BAKLOG and launch normally - first bo
 
 ## Known issues (beta)
 
-These are expected limits in the current invite-only beta, not one-off bugs:
+These are expected limits in the current open beta, not one-off bugs:
 
 | Topic | What to expect |
 |-------|----------------|
@@ -186,11 +186,11 @@ These are expected limits in the current invite-only beta, not one-off bugs:
 
 ## Unsigned beta builds (no code signing)
 
-BAKLOG beta builds are **not code-signed** yet. That is normal for invite-only testing — you are not doing anything wrong.
+BAKLOG beta builds are **not code-signed** yet. That is normal for open beta - you are not doing anything wrong.
 
 | Platform | What you may see | What to do |
 |----------|------------------|------------|
-| **Windows** | SmartScreen "Unknown publisher" on first launch or after manual download | **More info** → **Run anyway**. Only download from [GitHub Releases](https://github.com/Ogrods/BAKLOG/releases) or your official invite link. |
+| **Windows** | SmartScreen "Unknown publisher" on first launch or after manual download | **More info** → **Run anyway**. Only download from [GitHub Releases](https://github.com/Ogrods/BAKLOG/releases) or [baklog.app](https://baklog.app). |
 | **Windows Setup + in-app updates** | Add/Remove Programs shows an older version than the app header | Expected: zip-based in-app updates replace files but do not refresh Inno's registry entry. Re-run **BAKLOG-Setup.exe** when you want Settings → Apps to match, or ignore if the in-app version is correct. **Copy diagnostics** shows `install_source`, `arp_version`, and `arp_version_mismatch`. |
 | **macOS** | "App can't be opened" or quarantine after download/update | Right-click the app → **Open** once, or `xattr -cr /path/to/BAKLOG` in Terminal. Unzip to Applications or another stable folder, not directly from Downloads. |
 
@@ -210,13 +210,13 @@ We skip paid signing for now; future releases may add certificates. Verify SHA-2
 
 **Apply failure:** If install fails mid-copy, the updater restores your previous build from a backup when possible and writes `%TEMP%\\BAKLOG-update\\apply-result.json`. The UI shows the error; if BAKLOG does not restart automatically, open **BAKLOG Tray** from the Start Menu (or run `BAKLOG Tray.exe`).
 
-**In-app update vs Setup.exe:** Use in-app **Update now** for routine binary updates on Windows/macOS frozen builds. Re-run **BAKLOG-Setup.exe** when Add/Remove Programs version drifts, shortcuts break, or `apply_update.ps1` / `apply_update.sh` is missing from the install folder.
+**In-app update vs Setup.exe:** Use in-app **Update now** for routine binary updates on Windows, macOS, and Linux frozen builds. Re-run **BAKLOG-Setup.exe** when Add/Remove Programs version drifts, shortcuts break, or `apply_update.ps1` / `apply_update.sh` is missing from the install folder.
 
 **Zip-only uninstall:** Portable zip installs include **Uninstall BAKLOG.bat** beside the exes. Run it to clear login autostart and optionally wipe library data, then delete the install folder.
 
 **Version:** Your current build version appears at the bottom of the **⋮** menu on installed builds.
 
-**Platforms:** Windows uses `BAKLOG-win64.zip` + `apply_update.ps1`. macOS uses `BAKLOG-macos.zip` + `apply_update.sh` on tagged releases (built in CI alongside Windows).
+**Platforms:** Windows uses `BAKLOG-win64.zip` + `apply_update.ps1`. macOS uses `BAKLOG-macos.zip` + `apply_update.sh`. Linux uses `BAKLOG-linux64.zip` + `apply_update.sh` (no tray relaunch - the Start script keeps the server in the terminal).
 
 **Add/Remove Programs vs in-app version:** On Windows Setup installs, zip-based in-app updates replace app files but do not refresh the Inno uninstall registry version. Use **Copy diagnostics** or `GET /api/diagnostics` (`install_source`, `arp_version`, `arp_version_mismatch`, `trust_note`) to compare; re-run **BAKLOG-Setup.exe** when Settings → Apps should match the running build.
 

--- a/guide/using-the-dashboard.md
+++ b/guide/using-the-dashboard.md
@@ -105,11 +105,11 @@ Free forever to import and browse. Optional **$5/mo** ($50/yr) adds:
 
 See [FAQ](faq.md) for the full free-vs-paid breakdown.
 
-## Auto-behaviors (default on)
+## Auto-behaviors
 
-- **Auto-fetch on connect:** when you connect or reconnect a store, BAKLOG auto-fetches its library and opens the fetcher log
-- **Auto-refresh stale stores:** quietly refreshes one store older than 24h every ~30 min while the app is open (Connections toggle)
-- **Auto-enrich:** after a library fetch adds games, queues HLTB, reviews, covers, and co-op tags
-- **ITAD auto-refresh:** deal prices refresh on a 15-60 min schedule while the dashboard is open
+- **Auto-fetch on connect** (default on): when you connect or reconnect a store, BAKLOG auto-fetches its library and opens the fetcher log
+- **Auto-refresh stale stores** (default on): quietly refreshes one store older than 24h every ~30 min while the app is open (Connections toggle)
+- **Auto-enrich new games** (default off): after a library fetch adds games, optionally queues HLTB, reviews, covers, and co-op tags (Fetcher health toggle)
+- **ITAD auto-refresh** (default on): deal prices refresh on a 15-60 min schedule while the dashboard is open
 
 Details: [Refresh and enrichment](refresh-and-enrichment.md).

--- a/index.html
+++ b/index.html
@@ -896,7 +896,7 @@
               "Sponsored cards are clearly marked and optional, but a click helps keep BAKLOG free.",
               "BAKLOG Pro adds sync and bulk refresh - and nothing free today moves behind it.",
               "Fewer sponsored slots? Pro supporters help fund BAKLOG.",
-              "Not in the beta yet? Request an invite at baklog.app - we onboard in small waves.",
+              "Grab the open beta at baklog.app or GitHub Releases - Windows, macOS, and Linux zips.",
               "Know someone who'd love BAKLOG? Send them to baklog.app to grab an invite.",
               "Want to help without spending? Toggle Share anonymous usage counts in Connections.",
               "Sharing anonymous usage counts (off by default) helps fund BAKLOG - no library data leaves your machine.",

--- a/js/auth-gate.js
+++ b/js/auth-gate.js
@@ -1,5 +1,5 @@
 /**
- * Supabase invite-only gate — blocks the app until the user signs in.
+ * Optional Supabase account gate - blocks the app until the user signs in.
  * Config from GET /api/config; session stored by Supabase client in localStorage.
  */
 

--- a/js/tips.js
+++ b/js/tips.js
@@ -149,7 +149,7 @@ export const SUPPORT_GROUPS = [
     "Fewer sponsored slots? Pro supporters help fund BAKLOG.",
   ],
   [
-    "Not in the beta yet? Request an invite at baklog.app - we onboard in small waves.",
+    "Grab the open beta at baklog.app or GitHub Releases - Windows, macOS, and Linux zips.",
     "Know someone who'd love BAKLOG? Send them to baklog.app to grab an invite.",
   ],
   [

--- a/landing/README.md
+++ b/landing/README.md
@@ -103,7 +103,7 @@ Without the Resend trio, `/api/subscribe` returns `500 Server not configured` an
 
 ### BAKLOG account signup notifications (Supabase auth)
 
-When invite-only auth is on, users create accounts via **Create account** in the local app (`js/auth-gate.js` → Supabase `signUp`). That writes directly to Supabase Auth; it does **not** hit `/api/subscribe`.
+When account sign-in is on, users create accounts via **Create account** in the local app (`js/auth-gate.js` → Supabase `signUp`). That writes directly to Supabase Auth; it does **not** hit `/api/subscribe`.
 
 To get an email when a new `auth.users` row appears:
 

--- a/landing/supabase-email-templates/invite-user.html
+++ b/landing/supabase-email-templates/invite-user.html
@@ -2,8 +2,8 @@
 <html>
   <body style="margin:0;background:#0f172a;font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#e2e8f0;">
     <div style="max-width:520px;margin:0 auto;padding:32px 24px;">
-      <h1 style="font-size:20px;margin:0 0 16px;color:#f8fafc;">You're invited to BAKLOG beta</h1>
-      <p style="font-size:15px;line-height:1.6;margin:0 0 16px;">You have been invited to create a BAKLOG account for the invite-only beta.</p>
+      <h1 style="font-size:20px;margin:0 0 16px;color:#f8fafc;">You're invited to BAKLOG</h1>
+      <p style="font-size:15px;line-height:1.6;margin:0 0 16px;">You have been invited to create a BAKLOG account.</p>
       <p style="font-size:15px;line-height:1.6;margin:0 0 24px;">Tap the button below to set your password. You can open this link on any device. When finished, open BAKLOG on your PC and sign in.</p>
       <p style="margin:0 0 24px;">
         <a href="{{ .ConfirmationURL }}" style="display:inline-block;padding:12px 20px;background:#38bdf8;color:#0f172a;font-weight:600;text-decoration:none;border-radius:8px;">Accept invite</a>

--- a/packaging/BETA-README-linux.txt
+++ b/packaging/BETA-README-linux.txt
@@ -1,0 +1,31 @@
+BAKLOG beta - quick start (Linux)
+=================================
+
+Experimental packaged build (no tray icon yet). Prefer a desktop session or
+GUI VM - store Connect needs a headed browser.
+
+1. Download BAKLOG-linux64.zip from GitHub Releases:
+   https://github.com/Ogrods/BAKLOG/releases/latest
+2. Unzip to a normal folder (not a temp extract).
+3. Run:
+     chmod +x "BAKLOG/Start BAKLOG.sh" BAKLOG/BAKLOG
+     ./BAKLOG/Start\ BAKLOG.sh
+4. Your browser opens http://127.0.0.1:8765/
+   Closing the terminal stops the server.
+5. Open Connections and Connect each store. Prefer Google Chrome or Chromium.
+   If neither is installed, Connect can download a one-time browser (~150 MB).
+
+Library data lives in ~/.local/share/baklog (or $XDG_DATA_HOME/baklog).
+On Linux use GOG (web) and Amazon (Prime Gaming, web) - Galaxy local and
+Amazon launcher DB are not available.
+
+Needs a modern glibc (2.35+), same baseline as Ubuntu 22.04.
+
+Your data stays on this PC. Nothing is uploaded to our servers.
+
+If your build uses account sign-in, you will see a sign-in screen before the
+dashboard. Create a free account on that screen, or sign in if you already
+have one.
+
+Bug reports: use the app menu (Report a bug...) or Discord #bug-reports.
+Community: https://discord.gg/VFvxN5nCCB

--- a/packaging/BETA-README.txt
+++ b/packaging/BETA-README.txt
@@ -1,7 +1,7 @@
-BAKLOG beta — quick start (Windows)
+BAKLOG beta - quick start (Windows)
 ===================================
 
-Recommended: run BAKLOG-Setup.exe from your invite link.
+Download BAKLOG-Setup.exe from GitHub Releases or baklog.app.
 
 1. If Windows SmartScreen warns "Unknown publisher":
    click More info, then Run anyway.
@@ -32,10 +32,10 @@ window unless you launched the server-console shortcut.
 
 Your data stays on this PC. Nothing is uploaded to our servers.
 
-If your invite build uses account sign-in (Supabase), you will see a sign-in
-screen before the dashboard. Create a free account on that screen, or sign in
-if you already have one. Store Connect prefers Chrome or Edge; otherwise
-BAKLOG downloads a one-time browser (~150 MB) on first Connect.
+If your build uses account sign-in, you will see a sign-in screen before the
+dashboard. Create a free account on that screen, or sign in if you already
+have one. Store Connect prefers Chrome or Edge; otherwise BAKLOG downloads a
+one-time browser (~150 MB) on first Connect.
 
-Bug reports: use the app menu (Report a bug…) or Discord #bug-reports.
-Version: see the About line in the app or BAKLOG-*.sha256 next to the zip.
+Bug reports: use the app menu (Report a bug...) or Discord #bug-reports.
+Community: https://discord.gg/VFvxN5nCCB

--- a/packaging/build_linux.sh
+++ b/packaging/build_linux.sh
@@ -60,7 +60,7 @@ fi
 # pyproject.toml must be at bundle root for frozen version detection: bundle_root()
 # is the exe directory, while PyInstaller puts the packaged copy under _internal/.
 cp -f "${ROOT}/pyproject.toml" "${OUT_DIR}/pyproject.toml"
-cp -f "${ROOT}/packaging/BETA-README.txt" "${OUT_DIR}/BETA-README.txt"
+cp -f "${ROOT}/packaging/BETA-README-linux.txt" "${OUT_DIR}/BETA-README.txt"
 cp -f "${ROOT}/packaging/apply_update.sh" "${OUT_DIR}/apply_update.sh"
 chmod +x "${OUT_DIR}/apply_update.sh" "${SERVER_BIN}"
 


### PR DESCRIPTION
## Summary
- Tag builds attach `BAKLOG-linux64.zip` (+ sha256 + SBOM) after the Windows release job
- Linux beta README in the zip; guide/README/SECURITY/PRIVACY tip copy describe open beta (not invite-only)
- CHANGELOG cut `[0.9.01]` with user-facing notes only (no tag in this PR)

## Test plan
- [x] Diff: `release.yml` has `build-linux` with `needs: build` and three-asset upload
- [ ] CI green on this PR
- [ ] After merge: do **not** tag until local freeze + tray smoke on tip
- [ ] First `v*` tag after merge should publish Linux assets on Releases

## Notes
Does not tag. Preview workflow kept for manual dispatch.