### PR TITLE
fix: Epic empty-guard allow_empty crash

### DIFF
--- a/fetchers/fetch_epic.py
+++ b/fetchers/fetch_epic.py
@@ -655,6 +655,8 @@ def main() -> int:
     empty_exit = refuse_empty_result(
         catalog_game_count(games_out),
         label="Epic playable library rows",
+        allow_empty=args.allow_empty,
+        output_path=GAMES_EPIC_JSON,
     )
     if empty_exit is not None:
         return stats.finish("fetch_epic", t0, exit_code=empty_exit)

--- a/tests/test_fetcher_manifest_audit.py
+++ b/tests/test_fetcher_manifest_audit.py
@@ -159,6 +159,28 @@ def test_refuse_empty_helper(script: str) -> None:
 
 @pytest.mark.parametrize(
     "script",
+    sorted(REFUSE_EMPTY_SCRIPTS),
+)
+def test_refuse_empty_calls_pass_allow_empty(script: str) -> None:
+    """Every refuse_empty_result(...) must pass allow_empty= (kw-only required)."""
+    import ast
+
+    tree = ast.parse((ROOT / script).read_text(encoding="utf-8"), filename=script)
+    missing: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = getattr(func, "id", None) or getattr(func, "attr", None)
+        if name != "refuse_empty_result":
+            continue
+        if not any(kw.arg == "allow_empty" for kw in node.keywords):
+            missing.append(getattr(node, "lineno", 0))
+    assert not missing, f"{script}: refuse_empty_result missing allow_empty at lines {missing}"
+
+
+@pytest.mark.parametrize(
+    "script",
     sorted(MANUAL_EMPTY_EXIT_SCRIPTS),
 )
 def test_manual_empty_guard(script: str) -> None:


### PR DESCRIPTION
## Summary
- Pass `allow_empty` (and `output_path`) to Epic''s post-playtime `refuse_empty_result` call so library fetch no longer crashes after applying playtime.
- Add AST audit so every `refuse_empty_result(...)` in refuse-empty scripts must include `allow_empty=`.

## Test plan
- [x] `pytest tests/test_fetcher_manifest_audit.py tests/test_fetch_epic.py tests/test_fetcher_progress.py` (221 passed)
- [ ] Re-run Epic Connect/fetch on a frozen or dev build and confirm it writes `games_epic.json` without the TypeError
- [ ] Confirm empty Epic library still exits 2 unless `--allow-empty`