### PR TITLE
chore: Dependabot leftovers (charset-normalizer + upload-artifact)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -164,7 +164,7 @@ jobs:
           sbom-path: release/BAKLOG-linux64.sbom.spdx.json
 
       - name: Upload preview artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: BAKLOG-linux64-preview
           path: |

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -9,7 +9,7 @@ brotli==1.2.0
 browser-cookie3==0.20.1
 certifi==2026.7.22
 cffi==2.1.1
-charset-normalizer==3.4.7
+charset-normalizer==3.5.1
 colorama==0.4.6
 cryptography==50.0.1
 fake-useragent==2.2.0


### PR DESCRIPTION
## Summary
- Bump `charset-normalizer` 3.4.7 → 3.5.1 (`requirements-lock.txt`) after #221 conflicted on main.
- Bump `actions/upload-artifact` v4 → v7 in `build-linux.yml` after #216 could not merge via API (OAuth `workflow` scope).

Supersedes Dependabot #216 and #221.

## Test plan
- [ ] CI green on this PR
- [ ] Close #216 and #221 as superseded after merge