### PR TITLE
fix: HLTB client bump, circuit breaker, and ETA confirm

### DIFF
--- a/enrichers/enrich_hltb.py
+++ b/enrichers/enrich_hltb.py
@@ -7,7 +7,13 @@ previously failed - so this is cheap to run on a cron.
 
 Negative lookups are cached as the literal value False so retries don't spam
 HowLongToBeat. Pass --retry-misses to force re-lookup of those.
+
+If HowLongToBeat's search API is down (many consecutive empty results with no
+exceptions), stop early so we do not poison the map with False for the whole
+library. Mid-run catalog flushes keep already-matched hours on disk.
 """
+
+from __future__ import annotations
 
 import argparse
 import json
@@ -27,9 +33,14 @@ sys.stdout.reconfigure(encoding="utf-8", errors="replace", line_buffering=True)
 
 def mapping_file() -> Path:
     return cache_json_path("hltb_map.json")
-QUERY_DELAY_SEC = 0.15  # light spacing; each lookup is ~7s network-bound (see runtime logs)
+
+
+QUERY_DELAY_SEC = 0.15  # light spacing; each lookup is ~7s network-bound
+LOOKUP_NETWORK_SEC = 7.5  # used for ETA (matches UI modal formula)
 SAVE_EVERY_N_LOOKUPS = 25
 HEARTBEAT_EVERY = 25
+# Soft API outage: empty search() with no exception looks like "no match".
+CONSECUTIVE_EMPTY_ABORT = 15
 
 STORE_FILES = [
     ("games_steam.json", "steam", None),
@@ -57,6 +68,12 @@ HLTB_FIELDS = (
 )
 
 
+def estimate_lookup_seconds(pending: int) -> float:
+    """Wall-clock estimate for *pending* live HLTB network lookups."""
+    n = max(0, int(pending))
+    return n * (QUERY_DELAY_SEC + LOOKUP_NETWORK_SEC)
+
+
 def load_mapping() -> dict:
     path = mapping_file()
     if path.exists():
@@ -74,6 +91,11 @@ def save_mapping(mapping: dict) -> None:
     path.write_text(
         json.dumps(mapping, indent=2, ensure_ascii=False), encoding="utf-8"
     )
+
+
+def _flush_catalog(rel: Path, data: dict, games: list) -> None:
+    data["game_count"] = len(games)
+    write_catalog_text(rel, json.dumps(data, indent=2, ensure_ascii=False))
 
 
 def main() -> int:
@@ -96,6 +118,8 @@ def main() -> int:
     mapping = load_mapping()
     grand_lookups = 0
     grand_updated = 0
+    consecutive_empty = 0
+    api_outage = False
     # Pre-pass: count pending lookups so the run prints an up-front time estimate
     # (each lookup is ~7.5s network-bound, so a large backlog can run for a while).
     pending_lookups = 0
@@ -117,10 +141,10 @@ def main() -> int:
             if isinstance(cached, dict):
                 continue
             pending_lookups += 1
-    est_sec = pending_lookups * (QUERY_DELAY_SEC + 7.5)
+    est_sec = estimate_lookup_seconds(pending_lookups)
     print(
         f"  ~{pending_lookups} HLTB lookups pending "
-        f"(est. {int(est_sec // 60)}m at ~{QUERY_DELAY_SEC + 7.5:.1f}s each)",
+        f"(est. {int(est_sec // 60)}m at ~{QUERY_DELAY_SEC + LOOKUP_NETWORK_SEC:.1f}s each)",
         flush=True,
     )
     # Wall-clock heartbeat: HLTB network lookups are slow and often miss, so a
@@ -130,6 +154,8 @@ def main() -> int:
     hb = HeartbeatTimer(45.0)
 
     for filename, store, row_filter in STORE_FILES:
+        if api_outage:
+            break
         if args.store and args.store != store:
             continue
         rel = Path(filename)
@@ -155,13 +181,16 @@ def main() -> int:
         store_misses = 0
         store_skipped = 0
         processed = 0
+        catalog_dirty = False
         for i, g in enumerate(missing, 1):
+            if api_outage:
+                break
             key = f"{store}:{g.get('id')}"
             cached = mapping.get(key)
             processed += 1
             hb.tick(
                 f"{filename}: [{i}/{len(missing)}] {store_lookups} lookups "
-                f"(+{store_hits} hits) — still working"
+                f"(+{store_hits} hits) - still working"
             )
 
             if cached is False and not args.retry_misses:
@@ -169,7 +198,7 @@ def main() -> int:
                 if processed % HEARTBEAT_EVERY == 0:
                     hb.tick(
                         f"[{i}/{len(missing)}] skipped {store_skipped} cached misses, "
-                        f"{store_lookups} lookups (+{store_hits} hits) — still working"
+                        f"{store_lookups} lookups (+{store_hits} hits) - still working"
                     )
                     hb.reset()
                 continue
@@ -181,17 +210,33 @@ def main() -> int:
                 try:
                     hit = hltb.lookup(g.get("name") or "")
                 except Exception as e:
+                    consecutive_empty = 0
                     stats.warn(f"hltb error for {g.get('name')!r}: {e}")
                     continue
                 grand_lookups += 1
                 store_lookups += 1
                 if hit:
+                    consecutive_empty = 0
                     store_hits += 1
+                    mapping[key] = hit
                 else:
+                    consecutive_empty += 1
                     store_misses += 1
-                mapping[key] = hit if hit else False
-                if grand_lookups % SAVE_EVERY_N_LOOKUPS == 0:
+                    mapping[key] = False
+                    if consecutive_empty >= CONSECUTIVE_EMPTY_ABORT:
+                        api_outage = True
+                        print(
+                            f"  HLTB search API appears down: {consecutive_empty} "
+                            f"consecutive empty lookups with no errors. "
+                            "Stopping so we do not cache more misses. "
+                            "Bump howlongtobeatpy or retry later; "
+                            "use Shift+click / --retry-misses after a fix.",
+                            flush=True,
+                        )
+                if grand_lookups % SAVE_EVERY_N_LOOKUPS == 0 or api_outage:
                     save_mapping(mapping)
+                if api_outage:
+                    break
 
             if not hit:
                 continue
@@ -201,18 +246,21 @@ def main() -> int:
                     g[field] = hit[field]
             updated += 1
             grand_updated += 1
+            catalog_dirty = True
             stats.ok += 1
-            if updated % 25 == 0:
+            if updated % SAVE_EVERY_N_LOOKUPS == 0:
                 print(
                     f"  [{i}/{len(missing)}] {updated} updated so far "
                     f"({g.get('name')} -> {hit.get('hltb_main_hours')}h, "
                     f"match {hit.get('hltb_match_confidence')})",
                     flush=True,
                 )
+                _flush_catalog(rel, data, games)
+                catalog_dirty = False
                 hb.reset()
 
-        data["game_count"] = len(games)
-        write_catalog_text(rel, json.dumps(data, indent=2, ensure_ascii=False))
+        if catalog_dirty or updated:
+            _flush_catalog(rel, data, games)
         print(
             f"  saved {updated} HLTB updates to {filename} "
             f"({store_lookups} lookups: {store_hits} hits, {store_misses} no-match, "
@@ -223,11 +271,15 @@ def main() -> int:
 
     save_mapping(mapping)
     stats.ok = grand_updated
+    exit_code = 1 if api_outage else 0
+    extra = f"{grand_lookups} lookups, {grand_updated} updated"
+    if api_outage:
+        extra += f", aborted after {CONSECUTIVE_EMPTY_ABORT} consecutive empty searches"
     return stats.finish(
         "enrich_hltb",
         t0,
-        exit_code=0,
-        extra=f"{grand_lookups} lookups, {grand_updated} updated",
+        exit_code=exit_code,
+        extra=extra,
     )
 
 

--- a/guide/refresh-and-enrichment.md
+++ b/guide/refresh-and-enrichment.md
@@ -19,7 +19,9 @@ Click any chip in **Fetcher health** to enqueue that fetcher. Output streams liv
 - Shift+click on supported library/wishlist chips adds `--refresh`
 - Shift+click on HLTB, Reviews, Covers enrichers adds `--retry-misses`
 
-**Stall watchdog:** when a fetcher runs via `server.py`, if stdout is silent for 30s the server injects `[server] no output for Ns - still running (PID …)` into the log panel (repeats every 60s). Informational only - the process is not killed.
+**HLTB backlog:** if many titles still need hours (or you Shift+click to retry cached misses), BAKLOG shows a confirm dialog with a rough ETA before starting. Matched hours are saved as the run progresses. If HowLongToBeat's search API is down, the enricher stops after a streak of empty results so it does not mark your whole library as "no match" - bump `howlongtobeatpy` if needed, then Shift+click HLTB to retry.
+
+**Stall watchdog:** when a fetcher runs via `server.py`, if stdout is silent for about 60s the server injects `[server] no output for Ns - still running (PID …)` into the log panel (repeats). If silence continues for 180s with no heartbeat, the process is force-killed. HLTB prints heartbeats during slow lookups so healthy runs stay alive.
 
 Run logs also land in `profiles/<id>/cache/runs/*.jsonl`.
 

--- a/js/bind-events-fetcher.js
+++ b/js/bind-events-fetcher.js
@@ -8,6 +8,11 @@ import {
   primaryFailureNavigateTarget,
   dismissStickyFailedState,
 } from './fetcher-health.js';
+import { pendingForEnrich } from './fetcher/source-meta.js';
+import {
+  confirmHltbEstimate,
+  shouldConfirmHltbRun,
+} from './hltb-estimate-modal.js';
 import { reconnectProvider } from './connections.js';
 
 /** @internal Vitest + bind-events entry for global status pill clicks. */
@@ -119,7 +124,18 @@ export function bindFetcherHealthEvents() {
     }
     if (chip.disabled) return;
     e.preventDefault();
-    fetcherRunner.run(chip.dataset.fetcherKey, { refresh: e.shiftKey });
+    const key = chip.dataset.fetcherKey;
+    const refresh = e.shiftKey;
+    if (key === 'hltb') {
+      const pending = pendingForEnrich('hltb');
+      if (shouldConfirmHltbRun(pending, { refresh })) {
+        void confirmHltbEstimate(pending, { refresh }).then((ok) => {
+          if (ok) fetcherRunner.run(key, { refresh });
+        });
+        return;
+      }
+    }
+    fetcherRunner.run(key, { refresh });
   });
 
   // Pro-only deep achievement/trophy sync: re-pull the store's achievement data.

--- a/js/fetcher/render/dashboard.js
+++ b/js/fetcher/render/dashboard.js
@@ -118,11 +118,12 @@ export function renderDashboardFetcherHealth() {
   const showReadonly = probeDone && !apiReady;
   const summaryTooltip = [
     'Click a chip → run an incremental sync (fast - fills gaps, uses cache where safe).',
-    'Shift+click → force a full refresh that ignores local cache (slower; only on chips that support it).',
+    'Shift+click on library/wishlist chips → force a full refresh that ignores local cache (slower; only on chips that support it).',
+    'Shift+click on HLTB / Reviews / Covers → retry titles cached as "no match".',
     'Hover any chip to see exactly what click vs. Shift+click will do for that source.',
   ].join('\n');
   const clickHint = apiReady
-    ? `<span class="fh-legend-item" title="${escapeAttr(summaryTooltip)}"><span class="fh-chip-warn" aria-hidden="true">!</span> click a chip = sync &middot; Shift+click = full refresh</span>`
+    ? `<span class="fh-legend-item" title="${escapeAttr(summaryTooltip)}"><span class="fh-chip-warn" aria-hidden="true">!</span> click a chip = sync &middot; Shift+click = refresh or retry misses</span>`
     : '';
   const readonlyBanner = showReadonly
     ? (isAccountAuthMode()
@@ -185,7 +186,13 @@ export function renderDashboardFetcherHealth() {
           enrichLine,
           `Click: ${clickHint}`,
           refreshHint ? `Shift+click: ${refreshHint}` : 'Shift+click: not supported for this fetcher',
-          `Command: ${src.cmd}${refreshHint ? ' [+ --refresh on Shift+click]' : ''}`,
+          `Command: ${src.cmd}${refreshHint
+            ? (src.key === 'hltb' || src.key === 'steamReviews' || src.key === 'steamCovers'
+              ? ' [+ --retry-misses on Shift+click]'
+              : src.key === 'protondb'
+                ? ' [+ --retry-misses --refresh on Shift+click]'
+                : ' [+ --refresh on Shift+click]')
+            : ''}`,
           needsConfig ? 'Not configured for this profile - open Connections to add keys.' : '',
           configHint ? `Note:${configHint}` : '',
         ].filter(Boolean)

--- a/js/fetcher/runner/index.js
+++ b/js/fetcher/runner/index.js
@@ -1489,7 +1489,14 @@ export const fetcherRunner = (() => {
           `[warning: ${hint} - open Connections before running]`,
         );
       }
-      const cmdSuffix = refresh ? ' --refresh' : '';
+      const refreshArgHint = {
+        hltb: ' --retry-misses',
+        steamReviews: ' --retry-misses',
+        steamCovers: ' --retry-misses',
+        steamTags: ' --refresh',
+        protondb: ' --retry-misses --refresh',
+      };
+      const cmdSuffix = refresh ? (refreshArgHint[key] || ' --refresh') : '';
       logEvent('cmd', `$ ${src.cmd}${cmdSuffix}`);
       if (!auto) scrollPopoverModule('console');
     }

--- a/js/fetcher/source-meta.js
+++ b/js/fetcher/source-meta.js
@@ -80,7 +80,7 @@ const REFRESH_HINTS = {
   psn: 'Re-fetch every PlayStation entry, ignoring local cache',
   epic: 'Re-fetch every Epic entry, ignoring local cache',
   wishlistGog: 'Re-fetch every wishlist entry from GOG, ignoring cached details',
-  hltb: 'Also retry titles previously cached as "no HLTB match" - use after HLTB adds new entries',
+  hltb: 'Also retry titles previously cached as "no HLTB match" - use after an API outage or client bump',
   steamReviews:
     'Also retry titles previously cached as "no Steam app match" - use after Steam lists the game',
   steamCovers: 'Also retry rows previously cached as "no Steam match" - use after Steam adds new entries',
@@ -101,7 +101,7 @@ const REFRESH_HINTS = {
 //              won't change the numbers much.
 //   noMatch  → cached as "no match" so the fetcher skips on a normal click.
 //              Only Shift+click (HLTB) can revisit.
-function pendingForEnrich(key) {
+export function pendingForEnrich(key) {
   if (key === 'hltb') {
     const cache = state.libraryMeta.hltb || {};
     const rows = allLibraryRows();

--- a/js/hltb-estimate-modal.js
+++ b/js/hltb-estimate-modal.js
@@ -1,0 +1,141 @@
+/**
+ * Pre-run confirm for large HowLongToBeat enrich jobs.
+ * Shows pending count + rough ETA so multi-hour runs are intentional.
+ */
+
+import { escapeHtml, formatNum } from './dom-util.js';
+import { bindEscapeClose, trapFocus } from './focus-trap.js';
+
+const MODAL_ID = 'hltbEstimateModal';
+/** Match enrichers/enrich_hltb.py QUERY_DELAY_SEC + LOOKUP_NETWORK_SEC. */
+export const HLTB_LOOKUP_SEC = 0.15 + 7.5;
+export const HLTB_MODAL_UNCHECKED_MIN = 50;
+export const HLTB_MODAL_ETA_MIN_MINUTES = 15;
+export const HLTB_MODAL_NOMATCH_MIN = 50;
+
+/**
+ * @param {{ unchecked?: number, noMatch?: number, retry?: number } | null} pending
+ * @param {{ refresh?: boolean }} [opts]
+ */
+export function hltbPendingLookupCount(pending, { refresh = false } = {}) {
+  if (!pending) return 0;
+  const unchecked = pending.unchecked || 0;
+  const noMatch = refresh ? (pending.noMatch || 0) : 0;
+  return unchecked + noMatch;
+}
+
+/** @param {number} pendingLookups */
+export function estimateHltbSeconds(pendingLookups) {
+  return Math.max(0, Math.round(pendingLookups)) * HLTB_LOOKUP_SEC;
+}
+
+/**
+ * @param {{ unchecked?: number, noMatch?: number } | null} pending
+ * @param {{ refresh?: boolean }} [opts]
+ */
+export function shouldConfirmHltbRun(pending, { refresh = false } = {}) {
+  if (!pending) return false;
+  const lookups = hltbPendingLookupCount(pending, { refresh });
+  if (lookups <= 0) return false;
+  const etaMin = estimateHltbSeconds(lookups) / 60;
+  if (pending.unchecked > HLTB_MODAL_UNCHECKED_MIN) return true;
+  if (etaMin > HLTB_MODAL_ETA_MIN_MINUTES) return true;
+  if (refresh && (pending.noMatch || 0) >= HLTB_MODAL_NOMATCH_MIN) return true;
+  return false;
+}
+
+function formatEta(seconds) {
+  const s = Math.max(0, Math.round(seconds));
+  if (s < 60) return `about ${s}s`;
+  const m = Math.round(s / 60);
+  if (m < 120) return `about ${m} min`;
+  const h = Math.floor(m / 60);
+  const rem = m % 60;
+  return rem ? `about ${h}h ${rem}m` : `about ${h}h`;
+}
+
+function ensureModal() {
+  let modal = document.getElementById(MODAL_ID);
+  if (modal) return modal;
+  modal = document.createElement('div');
+  modal.id = MODAL_ID;
+  modal.className =
+    'app-modal fixed inset-0 z-50 hidden flex items-center justify-center bg-black/60';
+  modal.tabIndex = -1;
+  document.body.appendChild(modal);
+  return modal;
+}
+
+/**
+ * @param {{ unchecked?: number, noMatch?: number } | null} pending
+ * @param {{ refresh?: boolean }} [opts]
+ * @returns {Promise<boolean>}
+ */
+export function confirmHltbEstimate(pending, { refresh = false } = {}) {
+  const lookups = hltbPendingLookupCount(pending, { refresh });
+  const eta = formatEta(estimateHltbSeconds(lookups));
+  const unchecked = pending?.unchecked || 0;
+  const noMatch = pending?.noMatch || 0;
+  const retryLine = refresh && noMatch > 0
+    ? `<p class="text-sm text-slate-300 mt-2">Shift+click will also retry ${escapeHtml(formatNum(noMatch))} titles cached as no match.</p>`
+    : '';
+
+  return new Promise((resolve) => {
+    const modal = ensureModal();
+    modal.className =
+      'app-modal fixed inset-0 z-50 flex items-center justify-center bg-black/60';
+    modal.replaceChildren();
+    modal.insertAdjacentHTML(
+      'beforeend',
+      `<div class="app-modal-panel bg-slate-800 border border-slate-600 rounded-lg shadow-xl max-w-md w-full mx-4 p-6" role="dialog" aria-modal="true" aria-labelledby="hltbEstimateTitle">
+        <h2 id="hltbEstimateTitle" class="text-lg font-semibold text-slate-100">Run HowLongToBeat?</h2>
+        <p class="text-sm text-slate-300 mt-3">
+          About <strong>${escapeHtml(formatNum(lookups))}</strong> lookups
+          (${escapeHtml(formatNum(unchecked))} new${refresh && noMatch ? `, ${escapeHtml(formatNum(noMatch))} retries` : ''}).
+          Rough ETA: <strong>${escapeHtml(eta)}</strong>.
+        </p>
+        ${retryLine}
+        <p class="text-xs text-slate-400 mt-3">
+          Keep this machine awake. Leaving the dashboard open is fine - progress streams in Fetcher health.
+          Matched hours save as the run goes.
+        </p>
+        <div class="flex justify-end gap-2 mt-5">
+          <button type="button" class="hltb-estimate-cancel text-sm px-3 py-2 rounded hover:bg-slate-700 text-slate-300">Cancel</button>
+          <button type="button" class="hltb-estimate-run bg-cyan-700 hover:bg-cyan-600 px-3 py-2 rounded text-sm text-white">Run HLTB</button>
+        </div>
+      </div>`,
+    );
+    modal.classList.remove('hidden');
+
+    let releaseFocus = null;
+    const finish = (ok) => {
+      releaseFocus?.();
+      releaseFocus = null;
+      modal.classList.add('hidden');
+      modal.replaceChildren();
+      resolve(ok);
+    };
+
+    const panel = modal.querySelector('.app-modal-panel');
+    releaseFocus = trapFocus(panel || modal);
+    bindEscapeClose(modal, () => finish(false));
+    modal.addEventListener(
+      'click',
+      (ev) => {
+        if (ev.target === modal) finish(false);
+      },
+      { once: true },
+    );
+    modal.querySelector('.hltb-estimate-cancel')?.addEventListener(
+      'click',
+      () => finish(false),
+      { once: true },
+    );
+    modal.querySelector('.hltb-estimate-run')?.addEventListener(
+      'click',
+      () => finish(true),
+      { once: true },
+    );
+    modal.querySelector('.hltb-estimate-run')?.focus();
+  });
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "keyring>=25.0.0",
     "cryptography>=50.0.0",
     "requests>=2.31.0",
-    "howlongtobeatpy>=1.0.0",
+    "howlongtobeatpy>=1.0.23",
     "psnawp>=3.0.0",
     "PyJWT>=2.8.0",
 ]

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -16,7 +16,7 @@ fake-useragent==2.2.0
 fonttools==4.63.0
 frozenlist==1.8.0
 git-filter-repo==2.47.0
-howlongtobeatpy==1.0.21
+howlongtobeatpy==1.0.23
 idna==3.19
 iniconfig==2.3.0
 jaraco.classes==3.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 requests>=2.31.0
 python-dotenv>=1.0.0
 browser-cookie3>=0.20.0
-howlongtobeatpy>=1.0.0
+howlongtobeatpy>=1.0.23
 psnawp>=3.0.0
 websocket-client>=1.6.0
 keyring>=25.0.0

--- a/tests/hltb-estimate-modal.test.js
+++ b/tests/hltb-estimate-modal.test.js
@@ -1,0 +1,40 @@
+/**
+ * HLTB pre-run estimate modal thresholds + ETA helpers.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  estimateHltbSeconds,
+  hltbPendingLookupCount,
+  HLTB_LOOKUP_SEC,
+  HLTB_MODAL_ETA_MIN_MINUTES,
+  HLTB_MODAL_UNCHECKED_MIN,
+  shouldConfirmHltbRun,
+} from '../js/hltb-estimate-modal.js';
+
+describe('hltb estimate modal helpers', () => {
+  it('counts unchecked only unless refresh retries noMatch', () => {
+    const pending = { unchecked: 10, noMatch: 40, retry: 0 };
+    expect(hltbPendingLookupCount(pending)).toBe(10);
+    expect(hltbPendingLookupCount(pending, { refresh: true })).toBe(50);
+  });
+
+  it('matches enricher ETA seconds per lookup', () => {
+    expect(HLTB_LOOKUP_SEC).toBeCloseTo(7.65);
+    expect(estimateHltbSeconds(100)).toBeCloseTo(765);
+  });
+
+  it('requires confirm for large unchecked backlog', () => {
+    expect(shouldConfirmHltbRun({ unchecked: HLTB_MODAL_UNCHECKED_MIN, noMatch: 0 })).toBe(false);
+    expect(shouldConfirmHltbRun({ unchecked: HLTB_MODAL_UNCHECKED_MIN + 1, noMatch: 0 })).toBe(true);
+  });
+
+  it('requires confirm when ETA exceeds threshold', () => {
+    const need = Math.ceil((HLTB_MODAL_ETA_MIN_MINUTES * 60) / HLTB_LOOKUP_SEC) + 1;
+    expect(shouldConfirmHltbRun({ unchecked: need, noMatch: 0 })).toBe(true);
+  });
+
+  it('requires confirm for large Shift+click miss retries', () => {
+    expect(shouldConfirmHltbRun({ unchecked: 0, noMatch: 49 }, { refresh: true })).toBe(false);
+    expect(shouldConfirmHltbRun({ unchecked: 0, noMatch: 50 }, { refresh: true })).toBe(true);
+  });
+});

--- a/tests/test_enrich_hltb_circuit.py
+++ b/tests/test_enrich_hltb_circuit.py
@@ -1,0 +1,102 @@
+"""Offline tests for enrich_hltb circuit breaker + catalog checkpoints."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    from shared.profile_paths import DEFAULT_PROFILE_ID
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("shared.profile_paths.profile_root", lambda profile_id=None: tmp_path)
+    monkeypatch.setattr(
+        "shared.profile_paths.get_active_profile_id",
+        lambda: DEFAULT_PROFILE_ID,
+    )
+    monkeypatch.setattr("auth.manager.get_active_profile_id", lambda: DEFAULT_PROFILE_ID)
+    (tmp_path / "cache").mkdir()
+    games = [
+        {"id": str(i), "name": f"Game {i}", "hltb_main_hours": None}
+        for i in range(1, 41)
+    ]
+    (tmp_path / "games_steam.json").write_text(
+        json.dumps({"fetched_at": "2026-01-01T00:00:00Z", "games": games}),
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def _reload_enrich():
+    for mod in ("enrichers.enrich_hltb", "clients.hltb_client"):
+        sys.modules.pop(mod, None)
+    import enrichers.enrich_hltb as enrich_hltb
+
+    return enrich_hltb
+
+
+def test_estimate_lookup_seconds() -> None:
+    enrich = _reload_enrich()
+    assert enrich.estimate_lookup_seconds(0) == 0
+    assert enrich.estimate_lookup_seconds(10) == pytest.approx(10 * (0.15 + 7.5))
+
+
+def test_circuit_breaker_stops_false_flood(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    enrich = _reload_enrich()
+    monkeypatch.setattr(sys, "argv", ["enrich_hltb.py"])
+    monkeypatch.setattr(enrich.time, "sleep", lambda _s: None)
+
+    class EmptyClient:
+        def lookup(self, _name: str):
+            return None
+
+    monkeypatch.setattr(enrich, "HltbClient", EmptyClient)
+    code = enrich.main()
+    assert code == 1
+    mapping = json.loads((workspace / "cache" / "hltb_map.json").read_text(encoding="utf-8"))
+    falses = [k for k, v in mapping.items() if k != "fetched_at" and v is False]
+    assert len(falses) == enrich.CONSECUTIVE_EMPTY_ABORT
+    assert len(falses) < 40
+
+
+def test_catalog_checkpoint_mid_run(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    enrich = _reload_enrich()
+    monkeypatch.setattr(sys, "argv", ["enrich_hltb.py"])
+    monkeypatch.setattr(enrich.time, "sleep", lambda _s: None)
+    flush_counts: list[int] = []
+
+    real_flush = enrich._flush_catalog
+
+    def counting_flush(rel, data, games):
+        flush_counts.append(sum(1 for g in games if g.get("hltb_main_hours") is not None))
+        return real_flush(rel, data, games)
+
+    monkeypatch.setattr(enrich, "_flush_catalog", counting_flush)
+
+    class HitClient:
+        def lookup(self, name: str):
+            return {
+                "hltb_id": 1,
+                "hltb_name": name,
+                "hltb_main_hours": 5.0,
+                "hltb_main_extra_hours": 6.0,
+                "hltb_completionist_hours": 7.0,
+                "hltb_match_confidence": 1.0,
+            }
+
+    monkeypatch.setattr(enrich, "HltbClient", HitClient)
+    assert enrich.main() == 0
+    # Mid-run flushes every 25 updates + final flush.
+    assert any(c == 25 for c in flush_counts)
+    assert flush_counts[-1] == 40
+    written = json.loads((workspace / "games_steam.json").read_text(encoding="utf-8"))
+    assert all(g.get("hltb_main_hours") == 5.0 for g in written["games"])

--- a/tests/test_hltb_live.py
+++ b/tests/test_hltb_live.py
@@ -1,0 +1,24 @@
+"""Pre-release smoke: live HowLongToBeat search must return results.
+
+Run before tagging (also in release.yml and test-all.ps1 -Full):
+
+    python -m pytest -q -m release_smoke
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from clients.hltb_client import HltbClient
+
+
+@pytest.mark.release_smoke
+def test_hltb_search_returns_portal_2() -> None:
+    """howlongtobeatpy must track HLTB site changes; empty search means bump the lib."""
+    hit = HltbClient().lookup("Portal 2")
+    assert hit is not None, (
+        "HLTB search returned no results for Portal 2 - "
+        "bump howlongtobeatpy (site API likely changed again)"
+    )
+    assert hit.get("hltb_main_hours") is not None
+    assert float(hit["hltb_main_hours"]) > 0


### PR DESCRIPTION
## Summary
- Bump howlongtobeatpy to 1.0.23 (fixes empty search after HLTB site API change) and floor >=1.0.23
- Enricher stops after 15 consecutive empty lookups so outages do not flood hltb_map with False; flushes games_*.json every 25 matches
- Pre-run ETA confirm modal for large HLTB chip clicks; clearer Shift+click = retry-misses copy/logs
- release_smoke live Portal 2 probe + unit/Vitest coverage

## Test plan
- [ ] pytest tests/test_enrich_hltb_circuit.py -q
- [ ] pytest tests/test_hltb_live.py -m release_smoke -q
- [ ] npm test -- tests/hltb-estimate-modal.test.js
- [ ] Manual: Fetcher health HLTB with a large pending backlog shows Cancel / Run ETA modal
- [ ] After merge: Shift+click HLTB on Tray once the new client is installed to clear poisoned misses