### PR TITLE
fix: mid-line library-count +1 popup placement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ review-report.json
 scripts/_diag_personal.py
 scripts/perf-last-run.json
 scripts/drill-geometry-last-run.json
+scripts/library-count-geometry-last-run.json
 scripts/responsive-overflow-last-run.json
 
 # Local SEO operator (OpenSEO compose, secrets, crawl snapshots). Commit seo-god.json only.

--- a/app.css
+++ b/app.css
@@ -12816,13 +12816,13 @@ html[data-theme="ember"] .conn-primary:hover {
   top: auto;
   margin-left: 0;
   z-index: 120;
-  font-size: clamp(28px, 4.5vw, 48px);
-  transform-origin: left top;
+  font-size: clamp(22px, 3.2vw, 40px);
+  transform-origin: left center;
   animation: baklog-libcount-pop-hero 700ms ease-out forwards;
 }
-/* Summary chip + row count: smaller than hero, still clearly readable. */
+/* Summary chip + row count: pill-scaled, smaller than the chip digits. */
 .library-count-popup--floated-chip {
-  font-size: clamp(20px, 2.4vw, 32px);
+  font-size: clamp(14px, 1.6vw, 22px);
   transform-origin: left center;
   animation: baklog-libcount-pop 820ms ease-out forwards;
 }
@@ -12833,26 +12833,26 @@ html[data-theme="ember"] .conn-primary:hover {
   }
   18% {
     opacity: 1;
-    transform: translate(calc(var(--baklog-dx, 0) + 0.12em), -0.28em)
-      scale(1.18);
+    transform: translate(calc(var(--baklog-dx, 0) + 0.1em), -0.18em)
+      scale(1.12);
   }
   100% {
     opacity: 0;
-    transform: translate(calc(var(--baklog-dx, 0) + 0.38em), -1.65em) scale(1);
+    transform: translate(calc(var(--baklog-dx, 0) + 0.28em), -0.85em) scale(1);
   }
 }
 @keyframes baklog-libcount-pop {
   0% {
     opacity: 0;
-    transform: translate(var(--baklog-dx, 0px), 8px) scale(0.85);
+    transform: translate(var(--baklog-dx, 0px), 4px) scale(0.85);
   }
   18% {
     opacity: 1;
-    transform: translate(calc(var(--baklog-dx, 0px) + 5px), -14px) scale(1.18);
+    transform: translate(calc(var(--baklog-dx, 0px) + 4px), -8px) scale(1.12);
   }
   100% {
     opacity: 0;
-    transform: translate(calc(var(--baklog-dx, 0px) + 14px), -72px) scale(1);
+    transform: translate(calc(var(--baklog-dx, 0px) + 10px), -36px) scale(1);
   }
 }
 @media (prefers-reduced-motion: reduce) {

--- a/js/library-count-animation.js
+++ b/js/library-count-animation.js
@@ -127,6 +127,53 @@ export function strictSyncRollMs(delta, popupCap) {
   return Math.max(120, durationMs);
 }
 
+/**
+ * Pure placement for body-fixed +1 popups (hero digits or summary/rowcount pills).
+ * Mid-line vertical anchor; pill-scaled type; stack hugs the glyph.
+ *
+ * @param {{
+ *   rect: { top: number, right: number, height: number, width?: number },
+ *   fontSize: number,
+ *   kind: 'hero' | 'chip',
+ *   stackIndex?: number,
+ *   viewport?: { width: number, height: number } | null,
+ * }} opts
+ * @returns {{ left: number, top: number, popupFs: number, kind: 'hero' | 'chip' }}
+ */
+export function computeLibraryCountPopupPlacement({
+  rect,
+  fontSize,
+  kind,
+  stackIndex = 0,
+  viewport = null,
+}) {
+  const fs = Number.isFinite(fontSize) && fontSize > 0 ? fontSize : 16;
+  const stack = Math.max(0, Math.round(stackIndex) || 0);
+  const isHero = kind === 'hero';
+  const popupFs = isHero
+    ? Math.max(22, Math.min(40, fs * 0.38))
+    : Math.max(14, Math.min(22, fs * 1.12));
+  const gapX = Math.max(2, fs * 0.12);
+  let left = rect.right + gapX;
+  // Optical center of the digit/pill, then stack up (hero) or down (chip).
+  let top = rect.top + rect.height / 2 - popupFs * 0.45;
+  if (isHero) {
+    top -= stack * popupFs * 0.4;
+  } else {
+    top += stack * popupFs * 0.4;
+  }
+  if (viewport && Number.isFinite(viewport.width) && Number.isFinite(viewport.height)) {
+    left = Math.min(left, viewport.width - 48);
+    left = Math.max(4, left);
+    // Soft clamp: only pull when the spawn would leave the viewport entirely.
+    const minTop = 4;
+    const maxTop = viewport.height - popupFs - 8;
+    if (top < minTop) top = minTop;
+    else if (top > maxTop) top = maxTop;
+  }
+  return { left, top, popupFs, kind: isHero ? 'hero' : 'chip' };
+}
+
 /** Mount one scrolling-combat-text +1 popup beside `anchorNode`. */
 function mountOnePopup(host, anchorNode, stackIndex = null) {
   if (!host || !host.isConnected) return;
@@ -144,31 +191,21 @@ function mountOnePopup(host, anchorNode, stackIndex = null) {
   if (hasRect && typeof document !== 'undefined') {
     const fs = parseFloat(getComputedStyle(anchorEl).fontSize) || 16;
     const isHero = anchorEl.id === 'dashHeroCount';
-    el.classList.add('library-count-popup--floated');
-    let popupFs;
-    if (!isHero) {
-      el.classList.add('library-count-popup--floated-chip');
-      popupFs = Math.max(20, Math.min(32, fs * 1.75));
-      el.style.fontSize = `${popupFs.toFixed(1)}px`;
-    } else {
-      popupFs = Math.max(28, Math.min(52, fs * 0.48));
-      el.style.fontSize = `${popupFs.toFixed(1)}px`;
-    }
     const stack = Number.isFinite(stackIndex) ? stackIndex : activePopupStackIndex(anchorNode);
-    let left = rect.right + Math.max(3, fs * 0.25);
-    let top;
-    if (isHero) {
-      // Top-right anchor; stack upward so bursts do not pile at the bottom-right.
-      top = rect.top - stack * popupFs * 0.55;
-    } else {
-      top = rect.top + stack * fs * 0.55;
-    }
-    if (typeof window !== 'undefined') {
-      left = Math.min(left, window.innerWidth - 80);
-      top = Math.max(8, Math.min(top, window.innerHeight - 40));
-    }
-    el.style.left = `${left}px`;
-    el.style.top = `${top}px`;
+    const place = computeLibraryCountPopupPlacement({
+      rect,
+      fontSize: fs,
+      kind: isHero ? 'hero' : 'chip',
+      stackIndex: stack,
+      viewport: typeof window !== 'undefined'
+        ? { width: window.innerWidth, height: window.innerHeight }
+        : null,
+    });
+    el.classList.add('library-count-popup--floated');
+    if (place.kind === 'chip') el.classList.add('library-count-popup--floated-chip');
+    el.style.fontSize = `${place.popupFs.toFixed(1)}px`;
+    el.style.left = `${place.left}px`;
+    el.style.top = `${place.top}px`;
     document.body.appendChild(el);
   } else {
     host.appendChild(el);

--- a/landing/demo.css
+++ b/landing/demo.css
@@ -697,7 +697,7 @@ html.ui-resizing .dash-ribbon-chart canvas {
   transform-origin: left center;
   font-weight: 800;
   font-variant-numeric: tabular-nums;
-  font-size: clamp(24px, 3.5vw, 40px);
+  font-size: clamp(22px, 3.2vw, 40px);
   line-height: 1;
   color: #6ee7b7;
   text-shadow: 0 0 10px rgba(110, 231, 183, 0.65), 0 1px 3px rgba(0, 0, 0, 0.65);
@@ -724,14 +724,14 @@ html.ui-resizing .dash-ribbon-chart canvas {
   animation: baklog-libcount-pop 700ms ease-out forwards;
 }
 @keyframes baklog-libcount-pop-hero {
-  0% { opacity: 0; transform: translate(var(--baklog-dx, 0), 0.15em) scale(0.85); }
-  18% { opacity: 1; transform: translate(calc(var(--baklog-dx, 0) + 0.12em), -0.28em) scale(1.18); }
-  100% { opacity: 0; transform: translate(calc(var(--baklog-dx, 0) + 0.38em), -1.65em) scale(1); }
+  0% { opacity: 0; transform: translate(var(--baklog-dx, 0), 0em) scale(0.85); }
+  18% { opacity: 1; transform: translate(calc(var(--baklog-dx, 0) + 0.1em), -0.18em) scale(1.12); }
+  100% { opacity: 0; transform: translate(calc(var(--baklog-dx, 0) + 0.28em), -0.85em) scale(1); }
 }
 @keyframes baklog-libcount-pop {
-  0% { opacity: 0; transform: translate(var(--baklog-dx,0), 6px) scale(0.85); }
-  18% { opacity: 1; transform: translate(calc(var(--baklog-dx,0) + 4px), -10px) scale(1.15); }
-  100% { opacity: 0; transform: translate(calc(var(--baklog-dx,0) + 12px), -58px) scale(1); }
+  0% { opacity: 0; transform: translate(var(--baklog-dx,0), 4px) scale(0.85); }
+  18% { opacity: 1; transform: translate(calc(var(--baklog-dx,0) + 4px), -8px) scale(1.12); }
+  100% { opacity: 0; transform: translate(calc(var(--baklog-dx,0) + 10px), -36px) scale(1); }
 }
 
 /* Funnel: logo wall */

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "check:perf": "npm run test:perf",
     "perf:audit": "node scripts/perf-audit.mjs",
     "test:drill-geometry": "node scripts/drill-geometry-audit.mjs",
+    "test:libcount-geometry": "node scripts/library-count-geometry-audit.mjs",
     "test:responsive": "node scripts/responsive-overflow-audit.mjs",
     "perf:profile": "node scripts/generate-perf-profile.mjs",
     "audit:header": "node scripts/audit-header-rule.mjs",

--- a/scripts/library-count-geometry-audit.mjs
+++ b/scripts/library-count-geometry-audit.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/**
+ * Library-count +1 geometry audit — Playwright viewport matrix.
+ * Usage: node scripts/library-count-geometry-audit.mjs [baseUrl]
+ * Expects a live dashboard (dev or frozen) on baseUrl.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const BASE = (process.argv[2] || 'http://127.0.0.1:8765').replace(/\/$/, '');
+const OUT = path.join(root, 'scripts', 'library-count-geometry-last-run.json');
+
+const VIEWPORTS = [
+  { name: 'phone390', width: 390, height: 844 },
+  { name: 'tablet768', width: 768, height: 1024 },
+  { name: 'desk1024', width: 1024, height: 768 },
+];
+
+async function waitBoot(page, timeoutMs = 90000) {
+  await page.waitForFunction(
+    () => !document.documentElement.hasAttribute('data-boot-loading'),
+    null,
+    { timeout: timeoutMs },
+  ).catch(() => {});
+  await page.waitForSelector('#dashHeroCount, [data-count-target="library"]', {
+    timeout: timeoutMs,
+  }).catch(() => {});
+}
+
+async function measureHeroPopup(page) {
+  return page.evaluate(async () => {
+    const hero = document.getElementById('dashHeroCount');
+    if (!hero) return { ok: false, reason: 'no-hero' };
+    document.querySelectorAll('.library-count-popup').forEach((el) => el.remove());
+    const run =
+      typeof window.baklogDemoLibraryCountSmall === 'function'
+        ? window.baklogDemoLibraryCountSmall
+        : null;
+    if (!run) return { ok: false, reason: 'no-demo-helper' };
+    run();
+    await new Promise((r) => setTimeout(r, 450));
+    const popup = document.querySelector(
+      '.library-count-popup--floated:not(.library-count-popup--floated-chip)',
+    );
+    if (!popup) return { ok: false, reason: 'no-popup' };
+    const a = hero.getBoundingClientRect();
+    const p = popup.getBoundingClientRect();
+    const gapX = p.left - a.right;
+    const midY = p.top + p.height / 2;
+    const bandLo = a.top + a.height * 0.2;
+    const bandHi = a.top + a.height * 0.85;
+    const inBand = midY >= bandLo && midY <= bandHi;
+    const tightX = gapX >= -2 && gapX <= 18;
+    return {
+      ok: inBand && tightX,
+      kind: 'hero',
+      gapX,
+      midY,
+      bandLo,
+      bandHi,
+      anchor: { top: a.top, right: a.right, height: a.height, width: a.width },
+      popup: { top: p.top, left: p.left, height: p.height, width: p.width },
+      inBand,
+      tightX,
+    };
+  });
+}
+
+async function measureChipPopup(page) {
+  return page.evaluate(async () => {
+    const tab = document.querySelector('.view-tab[data-view="library"]');
+    tab?.click();
+    await new Promise((r) => setTimeout(r, 400));
+    const chip = document.querySelector('[data-count-target="library"]');
+    if (!chip) return { ok: false, reason: 'no-chip', soft: true };
+    document.querySelectorAll('.library-count-popup').forEach((el) => el.remove());
+    const host = chip.closest('[data-libcount-host]') || chip.parentElement;
+    if (!host) return { ok: false, reason: 'no-host', soft: true };
+    // Drive flashCountUp if exposed via demo cancel + manual import is not available;
+    // synthesize a minimal body-fixed popup using the same placement helper when present.
+    const placeFn = window.__baklogComputeLibCountPlacement;
+    const rect = chip.getBoundingClientRect();
+    const fs = parseFloat(getComputedStyle(chip).fontSize) || 14;
+    let left;
+    let top;
+    let popupFs;
+    if (typeof placeFn === 'function') {
+      const place = placeFn({
+        rect: { top: rect.top, right: rect.right, height: rect.height, width: rect.width },
+        fontSize: fs,
+        kind: 'chip',
+        stackIndex: 0,
+        viewport: { width: window.innerWidth, height: window.innerHeight },
+      });
+      left = place.left;
+      top = place.top;
+      popupFs = place.popupFs;
+    } else {
+      popupFs = Math.max(14, Math.min(22, fs * 1.12));
+      left = rect.right + Math.max(2, fs * 0.12);
+      top = rect.top + rect.height / 2 - popupFs * 0.45;
+    }
+    const el = document.createElement('span');
+    el.className = 'library-count-popup library-count-popup--floated library-count-popup--floated-chip';
+    el.textContent = '+1';
+    el.style.fontSize = `${popupFs}px`;
+    el.style.left = `${left}px`;
+    el.style.top = `${top}px`;
+    document.body.appendChild(el);
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    const p = el.getBoundingClientRect();
+    const a = chip.getBoundingClientRect();
+    const gapX = p.left - a.right;
+    const midY = p.top + p.height / 2;
+    const bandLo = a.top + a.height * 0.15;
+    const bandHi = a.top + a.height * 0.9;
+    const inBand = midY >= bandLo && midY <= bandHi;
+    const tightX = gapX >= -2 && gapX <= 18;
+    const sizeOk = popupFs <= fs * 1.35 + 0.5;
+    el.remove();
+    return {
+      ok: inBand && tightX && sizeOk,
+      kind: 'chip',
+      gapX,
+      midY,
+      popupFs,
+      chipFs: fs,
+      inBand,
+      tightX,
+      sizeOk,
+      anchor: { top: a.top, right: a.right, height: a.height },
+    };
+  });
+}
+
+async function runViewport(browser, vp) {
+  const context = await browser.newContext({
+    viewport: { width: vp.width, height: vp.height },
+  });
+  const page = await context.newPage();
+  const cases = [];
+  try {
+    await page.goto(`${BASE}/?demo=count-small`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await waitBoot(page);
+    // Expose placement helper for chip path when module graph is available.
+    await page.addInitScript(() => {}).catch(() => {});
+    await page.evaluate(async () => {
+      try {
+        const mod = await import('/js/library-count-animation.js');
+        window.__baklogComputeLibCountPlacement = mod.computeLibraryCountPopupPlacement;
+      } catch {
+        /* built dist may not expose raw ESM; chip path falls back to inline math */
+      }
+    }).catch(() => {});
+
+    const hero = await measureHeroPopup(page);
+    cases.push({ viewport: vp.name, ...hero });
+    const chip = await measureChipPopup(page);
+    cases.push({ viewport: vp.name, ...chip });
+  } finally {
+    await context.close();
+  }
+  return cases;
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const all = [];
+  try {
+    for (const vp of VIEWPORTS) {
+      console.log(`viewport ${vp.name} ${vp.width}x${vp.height}`);
+      const cases = await runViewport(browser, vp);
+      for (const c of cases) {
+        const tag = c.ok ? 'OK' : c.soft ? 'SOFT' : 'FAIL';
+        console.log(
+          `  [${tag}] ${c.kind || '?'}`,
+          c.reason || `gapX=${c.gapX?.toFixed?.(1)} midY=${c.midY?.toFixed?.(1)}`,
+        );
+        all.push(c);
+      }
+    }
+  } finally {
+    await browser.close();
+  }
+
+  const hardFails = all.filter((c) => !c.ok && !c.soft);
+  fs.writeFileSync(OUT, JSON.stringify({ base: BASE, at: new Date().toISOString(), cases: all }, null, 2));
+  console.log(`wrote ${OUT}`);
+  if (hardFails.length) {
+    console.error(`${hardFails.length} hard failure(s)`);
+    process.exit(1);
+  }
+  console.log('library-count geometry audit OK');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/library-count-hero-visibility.test.js
+++ b/tests/library-count-hero-visibility.test.js
@@ -1,16 +1,21 @@
 /**
  * Regression: dashboard hero "+N" combat-text must be readable and not clipped
- * by .dash-mega overflow. Popups float to document.body via position:fixed.
+ * by .dash-mega overflow. Popups float to document.body via position:fixed,
+ * mid-line anchored beside the digit/pill.
  */
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { flashCountUp, strictSyncRollMs } from '../js/library-count-animation.js';
+import {
+  computeLibraryCountPopupPlacement,
+  flashCountUp,
+  strictSyncRollMs,
+} from '../js/library-count-animation.js';
 import { countUpDurationForDelta } from '../js/dashboard-shared.js';
 
 const APP_CSS = readFileSync(join(import.meta.dirname, '..', 'app.css'), 'utf8');
-/** Keep in sync with js/library-count-animation.js SEQ_POPUP_GAP_MS. */
-const SEQ_POPUP_GAP_MS = 300;
+/** Capture once — vi.spyOn(getComputedStyle) must not nest mocks across tests. */
+const nativeGetComputedStyle = window.getComputedStyle.bind(window);
 
 function extractRuleBlock(css, selector) {
   const re = new RegExp(`${selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\{([^}]*)\\}`, 'm');
@@ -43,6 +48,23 @@ function mountDashHeroSurface({ w = 220, h = 84, left = 100, top = 200 } = {}) {
     </div>`;
   const hero = document.getElementById('dashHeroCount');
   stubLayoutRect(hero, { w, h, left, top });
+  Object.defineProperty(hero, 'style', {
+    configurable: true,
+    value: { fontSize: '72px' },
+  });
+  // getComputedStyle in happy-dom may not see fixture CSS; stub fontSize.
+  vi.spyOn(window, 'getComputedStyle').mockImplementation((el) => {
+    const cs = nativeGetComputedStyle(el);
+    if (el === hero || el?.id === 'dashHeroCount') {
+      return new Proxy(cs, {
+        get(target, prop) {
+          if (prop === 'fontSize') return '72px';
+          return Reflect.get(target, prop);
+        },
+      });
+    }
+    return cs;
+  });
   return hero;
 }
 
@@ -65,6 +87,75 @@ function rafSync() {
     }
   };
 }
+
+describe('computeLibraryCountPopupPlacement', () => {
+  const desktopHero = { top: 180, right: 320, height: 84, width: 220 };
+  const phoneHero = { top: 120, right: 200, height: 48, width: 140 };
+  const pill = { top: 64, right: 120, height: 22, width: 36 };
+
+  it('anchors hero mid-band beside digits (desktop)', () => {
+    const p = computeLibraryCountPopupPlacement({
+      rect: desktopHero,
+      fontSize: 72,
+      kind: 'hero',
+      stackIndex: 0,
+      viewport: { width: 1280, height: 800 },
+    });
+    const mid = desktopHero.top + desktopHero.height / 2;
+    expect(p.top).toBeGreaterThanOrEqual(desktopHero.top + desktopHero.height * 0.25);
+    expect(p.top).toBeLessThanOrEqual(desktopHero.top + desktopHero.height * 0.75);
+    expect(Math.abs(p.top + p.popupFs * 0.45 - mid)).toBeLessThan(2);
+    expect(p.left).toBeGreaterThanOrEqual(desktopHero.right);
+    expect(p.left - desktopHero.right).toBeLessThanOrEqual(12);
+    expect(p.popupFs).toBeGreaterThanOrEqual(22);
+    expect(p.popupFs).toBeLessThanOrEqual(40);
+  });
+
+  it('anchors hero mid-band on phone-sized digits', () => {
+    const p = computeLibraryCountPopupPlacement({
+      rect: phoneHero,
+      fontSize: 40,
+      kind: 'hero',
+      stackIndex: 0,
+      viewport: { width: 390, height: 844 },
+    });
+    expect(p.top).toBeGreaterThanOrEqual(phoneHero.top + phoneHero.height * 0.2);
+    expect(p.top).toBeLessThanOrEqual(phoneHero.top + phoneHero.height * 0.8);
+    expect(p.popupFs).toBeLessThanOrEqual(40);
+  });
+
+  it('sizes chip popups near pill digit size (not larger than 1.35x)', () => {
+    const chipFs = 14;
+    const p = computeLibraryCountPopupPlacement({
+      rect: pill,
+      fontSize: chipFs,
+      kind: 'chip',
+      stackIndex: 0,
+      viewport: { width: 1024, height: 768 },
+    });
+    expect(p.popupFs).toBeLessThanOrEqual(chipFs * 1.35);
+    expect(p.popupFs).toBeGreaterThanOrEqual(14);
+    expect(p.top).toBeGreaterThanOrEqual(pill.top + pill.height * 0.15);
+    expect(p.top).toBeLessThanOrEqual(pill.top + pill.height * 0.85);
+  });
+
+  it('stacks hero upward and chip downward within a short train', () => {
+    const h0 = computeLibraryCountPopupPlacement({
+      rect: desktopHero, fontSize: 72, kind: 'hero', stackIndex: 0,
+    });
+    const h1 = computeLibraryCountPopupPlacement({
+      rect: desktopHero, fontSize: 72, kind: 'hero', stackIndex: 1,
+    });
+    expect(h1.top).toBeLessThan(h0.top);
+    const c0 = computeLibraryCountPopupPlacement({
+      rect: pill, fontSize: 14, kind: 'chip', stackIndex: 0,
+    });
+    const c2 = computeLibraryCountPopupPlacement({
+      rect: pill, fontSize: 14, kind: 'chip', stackIndex: 2,
+    });
+    expect(c2.top - c0.top).toBeLessThanOrEqual(pill.height * 1.5 + c0.popupFs);
+  });
+});
 
 describe('library-count hero visibility CSS contract', () => {
   it('escapes .dash-mega overflow via fixed floated popups', () => {
@@ -98,14 +189,9 @@ describe('library-count hero visibility CSS contract', () => {
     expect(APP_CSS).toMatch(/@keyframes baklog-libcount-pop-hero/);
   });
 
-  it('anchors hero floats from left top (spawn point matches fixed top/left)', () => {
-    const heroFloat = extractRuleBlock(
-      APP_CSS,
-      '.library-count-popup--floated:not(.library-count-popup--floated-chip)',
-    );
+  it('anchors floated popups from left center (mid-line spawn)', () => {
     const floated = extractRuleBlock(APP_CSS, '.library-count-popup--floated');
-    const origin = heroFloat || floated;
-    expect(origin).toMatch(/transform-origin:\s*left\s+top/);
+    expect(floated).toMatch(/transform-origin:\s*left\s+center/);
   });
 
   it('does not start hero keyframes below the anchor (no positive 0% Y offset)', () => {
@@ -115,6 +201,11 @@ describe('library-count hero visibility CSS contract', () => {
     const frame0 = heroKeyframes.match(/0%\s*\{([^}]*)\}/)?.[1] ?? '';
     expect(frame0).not.toMatch(/translate\([^)]*,\s*0\.15em\)/);
     expect(frame0).toMatch(/,\s*0em\)\s*scale/);
+  });
+
+  it('keeps hero climb short (end Y around -0.85em, not -1.65em)', () => {
+    expect(APP_CSS).toMatch(/baklog-libcount-pop-hero[\s\S]*?-0\.85em/);
+    expect(APP_CSS).not.toMatch(/baklog-libcount-pop-hero[\s\S]*?-1\.65em/);
   });
 });
 
@@ -152,6 +243,7 @@ describe('library-count hero popup mount (happy-dom + app.css)', () => {
     document.head.innerHTML = '';
     document.body.innerHTML = '';
     vi.useRealTimers();
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -164,7 +256,7 @@ describe('library-count hero popup mount (happy-dom + app.css)', () => {
     expect(popup, 'popup element').toBeTruthy();
     expect(popup.parentElement).toBe(document.body);
     expect(popup.classList.contains('library-count-popup--floated')).toBe(true);
-    const px = parseFloat(getComputedStyle(popup).fontSize);
+    const px = parseFloat(popup.style.fontSize) || parseFloat(getComputedStyle(popup).fontSize);
     expect(px, 'floated hero font-size').toBeGreaterThanOrEqual(20);
     expect(px, 'regression: 0.5em body trap').not.toBe(8);
   });
@@ -177,10 +269,11 @@ describe('library-count hero popup mount (happy-dom + app.css)', () => {
     const popup = document.querySelector('.library-count-popup--floated');
     expect(popup?.isConnected).toBe(true);
     expect(popup?.textContent).toBe('+1');
-    expect(parseFloat(getComputedStyle(popup).fontSize)).toBeGreaterThanOrEqual(20);
+    const px = parseFloat(popup.style.fontSize) || parseFloat(getComputedStyle(popup).fontSize);
+    expect(px).toBeGreaterThanOrEqual(20);
   });
 
-  it('anchors single +1 at the hero top-right (not bottom-right of digits)', () => {
+  it('anchors single +1 in the hero mid-band (beside digits)', () => {
     const heroTop = 200;
     const heroHeight = 84;
     const hero = mountDashHeroSurface({ top: heroTop, h: heroHeight });
@@ -191,10 +284,11 @@ describe('library-count hero popup mount (happy-dom + app.css)', () => {
     expect(popup, 'hero popup').toBeTruthy();
     const popupTop = parseFloat(popup.style.top);
     const rect = hero.getBoundingClientRect();
-    expect(popupTop, 'spawn near hero top edge').toBeLessThanOrEqual(rect.top + 4);
-    expect(popupTop, 'not middle/bottom anchored').toBeLessThan(rect.top + rect.height * 0.35);
+    expect(popupTop, 'mid-band lower bound').toBeGreaterThanOrEqual(rect.top + rect.height * 0.25);
+    expect(popupTop, 'mid-band upper bound').toBeLessThanOrEqual(rect.top + rect.height * 0.75);
     const popupLeft = parseFloat(popup.style.left);
     expect(popupLeft, 'spawn to the right of digits').toBeGreaterThanOrEqual(rect.right);
+    expect(popupLeft - rect.right, 'tight horizontal gap').toBeLessThanOrEqual(16);
   });
 
   it('stacks hero +1 popups upward on strict-sync bursts', () => {
@@ -213,26 +307,41 @@ describe('library-count hero popup mount (happy-dom + app.css)', () => {
     expect(tops[2], 'third popup stacks above second').toBeLessThan(tops[1]);
   });
 
-  it('chip popups still stack downward (unchanged chip behavior)', () => {
+  it('chip popups are pill-scaled and stack downward tightly', () => {
     document.body.innerHTML = `
       <span class="library-count-host" data-libcount-host>
         <span data-count-target="library">10</span>
       </span>`;
     const chip = document.querySelector('[data-count-target="library"]');
     stubLayoutRect(chip, { w: 40, h: 20, left: 50, top: 60 });
+    vi.spyOn(window, 'getComputedStyle').mockImplementation((el) => {
+      const cs = nativeGetComputedStyle(el);
+      if (el === chip) {
+        return new Proxy(cs, {
+          get(target, prop) {
+            if (prop === 'fontSize') return '14px';
+            return Reflect.get(target, prop);
+          },
+        });
+      }
+      return cs;
+    });
     flashCountUp(chip, 10, 12, (n) => String(Math.round(n)), { popups: true });
     const dur = strictSyncRollMs(2, 2);
     flushRaf(dur + 50);
     vi.advanceTimersByTime(Math.ceil(dur));
-    const popups = document.querySelectorAll('.library-count-popup');
+    const popups = [...document.querySelectorAll('.library-count-popup')];
     expect(popups.length).toBe(2);
     for (const el of popups) {
       expect(el.classList.contains('library-count-popup--floated')).toBe(true);
       expect(el.classList.contains('library-count-popup--floated-chip')).toBe(true);
       expect(el.parentElement).toBe(document.body);
       expect(el.textContent).toBe('+1');
+      const fs = parseFloat(el.style.fontSize);
+      expect(fs).toBeLessThanOrEqual(14 * 1.35);
     }
-    const tops = [...popups].map(el => parseFloat(el.style.top));
+    const tops = popups.map(el => parseFloat(el.style.top));
     expect(tops[1]).toBeGreaterThan(tops[0]);
+    expect(tops[1] - tops[0]).toBeLessThanOrEqual(20 * 1.5);
   });
 });


### PR DESCRIPTION
## Summary
- Re-anchor library-count +1 popups to digit/pill mid-line with tighter chip sizing and shorter climb
- Export computeLibraryCountPopupPlacement for unit tests; rewrite Vitest mid-band contracts
- Add Playwright viewport geometry audit (390/768/1024) via npm run test:libcount-geometry

## Test plan
- [ ] npm test -- tests/library-count-hero-visibility.test.js tests/library-count-animation.test.js
- [ ] With server up: npm run test:libcount-geometry
- [ ] Manual ?demo=count-small at phone and desktop widths