### PR TITLE
fix: app modal body/actions layout and responsive max-height

### DIFF
--- a/app.css
+++ b/app.css
@@ -9668,6 +9668,69 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
   margin: auto;
 }
 
+/* === App modal layout contract (always on)
+   Panels stay inside the viewport; body scrolls; actions never overlap copy.
+   Prefer .app-modal-body / .app-modal-actions over purged spacing utilities. === */
+.app-modal > [role="dialog"],
+.app-modal > .app-modal-panel,
+.app-modal > .update-modal-panel,
+.app-modal > .profile-modal-card,
+.app-modal > .baklog-bug-report-card {
+  max-height: min(85vh, calc(100dvh - 2rem));
+  min-height: 0;
+  overflow-x: hidden;
+  box-sizing: border-box;
+}
+.app-modal > .app-modal-panel,
+.app-modal > .update-modal-panel,
+.app-modal > [role="dialog"].flex,
+.app-modal > .profile-modal-card,
+.app-modal > .baklog-bug-report-card {
+  display: flex;
+  flex-direction: column;
+}
+.app-modal > [role="dialog"] > .flex-1,
+.app-modal > [role="dialog"] > .overflow-y-auto,
+.app-modal > [role="dialog"] > .app-modal-body,
+.app-modal > .profile-modal-card > .overflow-y-auto,
+.app-modal > .baklog-bug-report-card .baklog-bug-report-body {
+  min-height: 0;
+}
+.app-modal-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+.app-modal-actions {
+  flex-shrink: 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+/* Bordered footers already separate from the body. */
+.app-modal-actions.border-t {
+  margin-top: 0;
+}
+
+/* Short desktop / zoomed windows: keep panels scrollable (sheet MQ needs hover:none). */
+@media (max-height: 640px) {
+  .app-modal > [role="dialog"],
+  .app-modal > .app-modal-panel,
+  .app-modal > .update-modal-panel,
+  .app-modal > .profile-modal-card,
+  .app-modal > .baklog-bug-report-card {
+    max-height: min(92dvh, calc(100dvh - 1rem));
+  }
+  .cover-gallery-frame {
+    height: auto;
+    max-height: min(70dvh, 760px);
+  }
+}
+
 /* === Phone / short-viewport modal sheets (R4+) — bottom-anchored, safe-area.
    Sheet mode: portrait phone OR short coarse viewport (phone landscape). === */
 @media (max-width: 639.98px), (max-height: 480px) and (hover: none) {
@@ -9708,6 +9771,7 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
   }
   .app-modal > [role="dialog"] > .flex-1,
   .app-modal > [role="dialog"] > .overflow-y-auto,
+  .app-modal > [role="dialog"] > .app-modal-body,
   .app-modal > .profile-modal-card > .overflow-y-auto,
   .app-modal > .baklog-bug-report-card .baklog-bug-report-body {
     min-height: 0;
@@ -9723,7 +9787,9 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
   .app-modal .update-modal-later,
   .app-modal .update-modal-apply,
   .app-modal .update-install-decline,
-  .app-modal .update-install-confirm {
+  .app-modal .update-install-confirm,
+  .app-modal .hltb-estimate-cancel,
+  .app-modal .hltb-estimate-run {
     min-width: var(--touch-min, 44px);
     min-height: var(--touch-min, 44px);
     display: inline-flex;
@@ -9772,6 +9838,10 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
     overscroll-behavior: contain;
     border-radius: 0.75rem 0.75rem 0 0;
     padding-bottom: max(1rem, env(safe-area-inset-bottom, 0px));
+  }
+  .cover-gallery-frame {
+    height: auto;
+    max-height: min(70dvh, 760px);
   }
   .claim-detail-close,
   .cover-gallery-dialog button {

--- a/index.html
+++ b/index.html
@@ -3236,13 +3236,13 @@
       role="presentation"
     >
       <div
-        class="bg-slate-800 rounded-lg shadow-xl border border-slate-700 w-full max-w-md flex flex-col"
+        class="bg-slate-800 rounded-lg shadow-xl border border-slate-700 w-full max-w-md max-h-[85vh] flex flex-col"
         role="dialog"
         aria-modal="true"
         aria-labelledby="notesDialogTitle"
       >
         <div
-          class="flex items-center justify-between border-b border-slate-700 p-3"
+          class="flex items-center justify-between border-b border-slate-700 p-3 shrink-0"
         >
           <h3
             id="notesDialogTitle"
@@ -3259,7 +3259,7 @@
             &times;
           </button>
         </div>
-        <div class="p-3">
+        <div class="app-modal-body p-3">
           <label class="sr-only" for="notesDialogInput">Personal notes</label>
           <textarea
             id="notesDialogInput"
@@ -3270,7 +3270,7 @@
           ></textarea>
         </div>
         <div
-          class="border-t border-slate-700 p-3 flex justify-end gap-2 text-sm"
+          class="app-modal-actions border-t border-slate-700 p-3 text-sm"
         >
           <button
             type="button"
@@ -3319,7 +3319,7 @@
             &times;
           </button>
         </div>
-        <div class="p-4 space-y-3 overflow-y-auto theme-scrollbar">
+        <div class="app-modal-body p-4 space-y-3 theme-scrollbar">
           <div
             class="inline-flex rounded border border-slate-600 overflow-hidden text-xs"
             role="group"

--- a/js/hltb-estimate-modal.js
+++ b/js/hltb-estimate-modal.js
@@ -88,18 +88,20 @@ export function confirmHltbEstimate(pending, { refresh = false } = {}) {
     modal.insertAdjacentHTML(
       'beforeend',
       `<div class="app-modal-panel bg-slate-800 border border-slate-600 rounded-lg shadow-xl max-w-md w-full mx-4 p-6" role="dialog" aria-modal="true" aria-labelledby="hltbEstimateTitle">
-        <h2 id="hltbEstimateTitle" class="text-lg font-semibold text-slate-100">Run HowLongToBeat?</h2>
-        <p class="text-sm text-slate-300 mt-3">
-          About <strong>${escapeHtml(formatNum(lookups))}</strong> lookups
-          (${escapeHtml(formatNum(unchecked))} new${refresh && noMatch ? `, ${escapeHtml(formatNum(noMatch))} retries` : ''}).
-          Rough ETA: <strong>${escapeHtml(eta)}</strong>.
-        </p>
-        ${retryLine}
-        <p class="text-xs text-slate-400 mt-3">
-          Keep this machine awake. Leaving the dashboard open is fine - progress streams in Fetcher health.
-          Matched hours save as the run goes.
-        </p>
-        <div class="flex justify-end gap-2 mt-5">
+        <div class="app-modal-body">
+          <h2 id="hltbEstimateTitle" class="text-lg font-semibold text-slate-100">Run HowLongToBeat?</h2>
+          <p class="text-sm text-slate-300 mt-3">
+            About <strong>${escapeHtml(formatNum(lookups))}</strong> lookups
+            (${escapeHtml(formatNum(unchecked))} new${refresh && noMatch ? `, ${escapeHtml(formatNum(noMatch))} retries` : ''}).
+            Rough ETA: <strong>${escapeHtml(eta)}</strong>.
+          </p>
+          ${retryLine}
+          <p class="text-xs text-slate-400 mt-3">
+            Keep this machine awake. Leaving the dashboard open is fine - progress streams in Fetcher health.
+            Matched hours save as the run goes.
+          </p>
+        </div>
+        <div class="app-modal-actions">
           <button type="button" class="hltb-estimate-cancel text-sm px-3 py-2 rounded hover:bg-slate-700 text-slate-300">Cancel</button>
           <button type="button" class="hltb-estimate-run bg-cyan-700 hover:bg-cyan-600 px-3 py-2 rounded text-sm text-white">Run HLTB</button>
         </div>

--- a/js/update-check.js
+++ b/js/update-check.js
@@ -342,11 +342,13 @@ export function renderUpdateModalHtml(parsed) {
     : "";
   return (
     `<div class="update-modal-panel app-modal-panel bg-slate-800 border border-slate-600 rounded-lg shadow-xl max-w-lg w-full mx-4 p-6" role="dialog" aria-modal="true" aria-labelledby="updateModalTitle">` +
+    `<div class="app-modal-body">` +
     `<h2 id="updateModalTitle" class="text-lg font-semibold text-slate-100">Update available: v${escapeHtml(parsed.latest || "")}</h2>` +
     `<p class="text-sm text-slate-400 mt-1">You have v${escapeHtml(parsed.current)}.</p>` +
     renderApplyBlockedHint(parsed) +
     notes +
-    `<div class="flex flex-wrap gap-2 justify-end mt-4">` +
+    `</div>` +
+    `<div class="app-modal-actions">` +
     `<a href="${escapeHtml(href)}" class="update-modal-release text-sm text-sky-300 hover:underline px-3 py-2" target="_blank" rel="noopener noreferrer">Release page</a>` +
     '<button type="button" class="update-modal-later text-sm px-3 py-2 rounded hover:bg-slate-700 text-slate-300">Remind me later</button>' +
     updateBtn +
@@ -357,10 +359,12 @@ export function renderUpdateModalHtml(parsed) {
 function renderInstallConfirmModalHtml(hints = _installHints) {
   return (
     `<div class="update-modal-panel app-modal-panel bg-slate-800 border border-slate-600 rounded-lg shadow-xl max-w-md w-full mx-4 p-6" role="dialog" aria-modal="true" aria-labelledby="updateInstallTitle">` +
+    '<div class="app-modal-body">' +
     '<h2 id="updateInstallTitle" class="text-lg font-semibold text-slate-100">Install and restart?</h2>' +
     '<p class="text-sm text-slate-400 mt-2">The update is downloaded and verified. BAKLOG will restart to finish installing. Your library data stays where it is.</p>' +
     renderSetupArpFootnote(hints) +
-    '<div class="flex flex-wrap gap-2 justify-end mt-4">' +
+    "</div>" +
+    '<div class="app-modal-actions">' +
     '<button type="button" class="update-install-decline text-sm px-3 py-2 rounded hover:bg-slate-700 text-slate-300">Not yet</button>' +
     '<button type="button" class="update-install-confirm bg-cyan-700 hover:bg-cyan-600 px-3 py-2 rounded text-sm text-white">Install &amp; restart</button>' +
     "</div></div>"

--- a/tests/hltb-estimate-modal.test.js
+++ b/tests/hltb-estimate-modal.test.js
@@ -1,8 +1,9 @@
 /**
  * HLTB pre-run estimate modal thresholds + ETA helpers.
  */
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
+  confirmHltbEstimate,
   estimateHltbSeconds,
   hltbPendingLookupCount,
   HLTB_LOOKUP_SEC,
@@ -36,5 +37,51 @@ describe('hltb estimate modal helpers', () => {
   it('requires confirm for large Shift+click miss retries', () => {
     expect(shouldConfirmHltbRun({ unchecked: 0, noMatch: 49 }, { refresh: true })).toBe(false);
     expect(shouldConfirmHltbRun({ unchecked: 0, noMatch: 50 }, { refresh: true })).toBe(true);
+  });
+});
+
+describe('confirmHltbEstimate markup', () => {
+  afterEach(() => {
+    document.getElementById('hltbEstimateModal')?.remove();
+  });
+
+  it('uses body/actions layout without purged mt-5', async () => {
+    const pending = confirmHltbEstimate(
+      { unchecked: 100, noMatch: 0 },
+      { refresh: false },
+    );
+    const modal = document.getElementById('hltbEstimateModal');
+    expect(modal).toBeTruthy();
+    const html = modal.innerHTML;
+    expect(html).toContain('app-modal-body');
+    expect(html).toContain('app-modal-actions');
+    expect(html).not.toContain('mt-5');
+    expect(modal.querySelector('.hltb-estimate-cancel')).toBeTruthy();
+    expect(modal.querySelector('.hltb-estimate-run')).toBeTruthy();
+    modal.querySelector('.hltb-estimate-cancel')?.click();
+    await expect(pending).resolves.toBe(false);
+  });
+
+  it('shows retry copy on Shift+click refresh', async () => {
+    const pending = confirmHltbEstimate(
+      { unchecked: 10, noMatch: 99 },
+      { refresh: true },
+    );
+    const modal = document.getElementById('hltbEstimateModal');
+    expect(modal?.textContent).toMatch(/retry 99 titles/i);
+    modal.querySelector('.hltb-estimate-run')?.click();
+    await expect(pending).resolves.toBe(true);
+  });
+});
+
+describe('modal JS spacing hygiene', () => {
+  it('does not use mt-5 in HLTB or update modal templates', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const root = path.resolve(import.meta.dirname, '..');
+    for (const rel of ['js/hltb-estimate-modal.js', 'js/update-check.js']) {
+      const src = fs.readFileSync(path.join(root, rel), 'utf8');
+      expect(src, rel).not.toMatch(/\bmt-5\b/);
+    }
   });
 });

--- a/tests/update-check.test.js
+++ b/tests/update-check.test.js
@@ -586,8 +586,11 @@ describe('renderUpdateModalHtml', () => {
       applySupported: true,
     });
     expect(html).toContain('app-modal-panel');
+    expect(html).toContain('app-modal-body');
+    expect(html).toContain('app-modal-actions');
     expect(html).toContain('bg-cyan-700');
     expect(html).not.toContain('bg-sky-700');
+    expect(html).not.toContain('mt-5');
   });
 
   it('hides Update now when fetchers are in flight', () => {


### PR DESCRIPTION
## Summary
- Fix HLTB confirm overlap: action row used purged `mt-5`; preflight left no gap under body copy.
- Add shared `.app-modal-body` / `.app-modal-actions` contract in `app.css` with always-on panel max-height and short-height (640px) safety MQ.
- Apply body/actions split to HLTB, update install/available, notes, and add-game modals; cover-gallery frame shrinks on short viewports.
- Vitest: HLTB modal markup structure + mt-5 hygiene guard; update modal HTML asserts body/actions.

## Test plan
- [x] `npm test -- tests/hltb-estimate-modal.test.js tests/update-check.test.js tests/notes-dialog.test.js`
- [ ] Manual: open HLTB confirm on Desktop freeze — Cancel/Run HLTB clear of muted note
- [ ] Manual: notes + add-game modals on phone width and short desktop height (~600px)