### PR TITLE
feat: modal geometry audit, claims refresh, Ubisoft wishlist retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ review-report.json
 scripts/_diag_personal.py
 scripts/perf-last-run.json
 scripts/drill-geometry-last-run.json
+scripts/modal-geometry-last-run.json
 scripts/library-count-geometry-last-run.json
 scripts/responsive-overflow-last-run.json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,19 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ## [Unreleased]
 
-## [0.9.01] - 2026-09-01
+### Added
+
+- Opt-in Playwright modal geometry audit (`npm run test:modal-geometry`) for HLTB confirm, notes, and add-game dialogs on short and phone viewports.
+
+### Changed
+
+- Free claims feed refreshed; stale approved-only ids pruned from the maintainer list.
+
+### Fixed
+
+- Ubisoft wishlist Connect retries once on a transient browser navigation error before failing.
+- Add-game dialog footer uses the shared modal actions layout so body copy cannot overlap buttons on short viewports.
+
 
 ### Added
 

--- a/app.css
+++ b/app.css
@@ -9688,6 +9688,7 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
 .app-modal > .baklog-bug-report-card {
   display: flex;
   flex-direction: column;
+  gap: 0.25rem;
 }
 .app-modal > [role="dialog"] > .flex-1,
 .app-modal > [role="dialog"] > .overflow-y-auto,

--- a/curated/free_claims.fallback.json
+++ b/curated/free_claims.fallback.json
@@ -1,6 +1,46 @@
 {
-  "generated_at": "2026-08-31T20:45:40.296305+00:00",
+  "generated_at": "2026-09-01T20:16:13.834771+00:00",
   "items": [
+    {
+      "id": "gamerpower-3421",
+      "store": "itch",
+      "title": "Very Realistic Game Dev Simulator (Itch.io) Giveaway",
+      "claim_url": "https://www.gamerpower.com/open/very-realistic-game-dev-simulator-itch-io-giveaway",
+      "header_image": "https://www.gamerpower.com/offers/1b/6946b7c157bca.jpg",
+      "genres": [],
+      "blurb": "Are you planning on getting into game dev? Then this might be for you! Very Realistic Game Dev Simulator is free on Itch.io for a limited time!",
+      "ends_at": "2026-09-05T23:59:35Z",
+      "source": "gamerpower",
+      "first_seen": "2026-08-01T20:43:42Z"
+    },
+    {
+      "id": "gamerpower-3496",
+      "store": "itch",
+      "title": "Cherophobia (Itch.io) Giveaway",
+      "claim_url": "https://www.gamerpower.com/open/cherophobia-itch-io-giveaway",
+      "header_image": "https://www.gamerpower.com/offers/1b/698fa7369c1f5.jpg",
+      "genres": [],
+      "blurb": "Download Cherophobia for free via Itch.io! Cherophobia is a short 3D psychological horror game.",
+      "ends_at": "2026-09-04T23:59:00Z",
+      "steam_appid": 2994800,
+      "review_percent": 78,
+      "source": "gamerpower",
+      "first_seen": "2026-08-17T18:41:11Z"
+    },
+    {
+      "id": "gamerpower-3422",
+      "store": "itch",
+      "title": "Do You Have a Moment to Talk About Our Lord and Savior? (Itch.io) Giveaway",
+      "claim_url": "https://www.gamerpower.com/open/do-you-have-a-moment-to-talk-about-our-lord-and-savior-itch-io-giveaway",
+      "header_image": "https://www.gamerpower.com/offers/1b/6946b8c46bc9b.jpg",
+      "genres": [],
+      "blurb": "Grab “Do You Have a Moment to Talk About Our Lord and Savior?” for free on itch.io! A short 3D roguelike deckbuilder with retro PSX-style graphics.",
+      "ends_at": "2026-09-04T23:59:00Z",
+      "steam_appid": 3063960,
+      "review_percent": 80,
+      "source": "gamerpower",
+      "first_seen": "2026-08-17T18:41:11Z"
+    },
     {
       "id": "gamerpower-3313",
       "store": "indiegala",
@@ -12,46 +52,6 @@
       "ends_at": "2026-09-14T20:45:20Z",
       "steam_appid": 1532580,
       "review_percent": 62,
-      "source": "gamerpower",
-      "first_seen": "2026-08-31T20:45:20Z"
-    },
-    {
-      "id": "gamerpower-3421",
-      "store": "itch",
-      "title": "Very Realistic Game Dev Simulator (Itch.io) Giveaway",
-      "claim_url": "https://www.gamerpower.com/open/very-realistic-game-dev-simulator-itch-io-giveaway",
-      "header_image": "https://www.gamerpower.com/offers/1b/6946b7c157bca.jpg",
-      "genres": [],
-      "blurb": "Are you planning on getting into game dev? Then this might be for you! Very Realistic Game Dev Simulator is free on Itch.io for a limited time!",
-      "ends_at": "2026-09-05T23:59:35Z",
-      "source": "gamerpower",
-      "first_seen": "2026-08-31T20:45:20Z"
-    },
-    {
-      "id": "gamerpower-3496",
-      "store": "itch",
-      "title": "Cherophobia (Itch.io) Giveaway",
-      "claim_url": "https://www.gamerpower.com/open/cherophobia-itch-io-giveaway",
-      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2994800/header.jpg?t=1771719765",
-      "genres": [],
-      "blurb": "Download Cherophobia for free via Itch.io! Cherophobia is a short 3D psychological horror game.",
-      "ends_at": "2026-09-04T23:59:00Z",
-      "steam_appid": 2994800,
-      "review_percent": 78,
-      "source": "gamerpower",
-      "first_seen": "2026-08-31T20:45:20Z"
-    },
-    {
-      "id": "gamerpower-3422",
-      "store": "itch",
-      "title": "Do You Have a Moment to Talk About Our Lord and Savior? (Itch.io) Giveaway",
-      "claim_url": "https://www.gamerpower.com/open/do-you-have-a-moment-to-talk-about-our-lord-and-savior-itch-io-giveaway",
-      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/3063960/header.jpg?t=1739261833",
-      "genres": [],
-      "blurb": "Grab “Do You Have a Moment to Talk About Our Lord and Savior?” for free on itch.io! A short 3D roguelike deckbuilder with retro PSX-style graphics.",
-      "ends_at": "2026-09-04T23:59:00Z",
-      "steam_appid": 3063960,
-      "review_percent": 80,
       "source": "gamerpower",
       "first_seen": "2026-08-31T20:45:20Z"
     },
@@ -68,45 +68,6 @@
       "review_percent": 96,
       "source": "itad",
       "first_seen": "2026-08-31T20:45:20Z"
-    },
-    {
-      "id": "gamerpower-3621",
-      "store": "itch",
-      "title": "Forget-me-not (itchio) Giveaway",
-      "claim_url": "https://www.gamerpower.com/open/forget-me-not-itchio-giveaway",
-      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/1952260/header.jpg?t=1650154570",
-      "genres": [],
-      "blurb": "Grab Forget-me-not for free on itch.io! Forget-me-not is a yuri Visual Novel. Give it a look!",
-      "ends_at": "2026-08-31T23:59:00Z",
-      "steam_appid": 1952260,
-      "review_percent": 94,
-      "source": "gamerpower",
-      "first_seen": "2026-08-30T18:33:13Z"
-    },
-    {
-      "id": "steam-dwarven-realms",
-      "store": "steam",
-      "title": "Dwarven Realms",
-      "claim_url": "https://www.amdgaming.com/promotions/dwarven-realms-giveaway",
-      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2015240/header.jpg?t=1738315434",
-      "genres": [],
-      "blurb": null,
-      "ends_at": null,
-      "steam_appid": 2015240,
-      "review_percent": 82,
-      "first_seen": "2026-08-24T16:40:14Z"
-    },
-    {
-      "id": "gamerpower-3742",
-      "store": "epic",
-      "title": "Targeted – 10 Days (Epic Games) Giveaway",
-      "claim_url": "https://www.gamerpower.com/open/targeted-10-days-epic-games-giveaway",
-      "header_image": "https://www.gamerpower.com/offers/1b/6a7ce767b76aa.jpg",
-      "genres": [],
-      "blurb": "New Giveaway! Download Targeted – 10 Days for free via Epic Games Store! Targeted – 10 Days is a 3d escape-room-style game with multiple difficulty levels.",
-      "ends_at": "2026-08-31T23:59:00Z",
-      "source": "gamerpower",
-      "first_seen": "2026-08-30T18:33:13Z"
     }
   ],
   "attribution": [

--- a/fetchers/fetch_ubisoft_wishlist.py
+++ b/fetchers/fetch_ubisoft_wishlist.py
@@ -129,28 +129,36 @@ def _fetch_wishlist_html(timeout_s: int = 45) -> tuple[str, str]:
     poll_deadline_s = min(max(timeout_s - 5, 15), 25)
     poll_interval_ms = 500
 
-    ctx = launch_persistent_profile(str(profile), headless=True)
+    def _load_page() -> tuple[str, str]:
+        ctx = launch_persistent_profile(str(profile), headless=True)
+        try:
+            page = ctx.pages[0] if ctx.pages else ctx.new_page()
+            page.goto(WISHLIST_URL, wait_until="domcontentloaded", timeout=timeout_s * 1000)
+
+            title = ""
+            html = ""
+            deadline = time.time() + poll_deadline_s
+            while time.time() < deadline:
+                title = page.title() or ""
+                html = page.content()
+                if _wishlist_page_ready(html):
+                    break
+                if "sign in" in title.lower():
+                    break
+                page.wait_for_timeout(poll_interval_ms)
+
+            return title, html
+        finally:
+            close_browser_bounded(ctx, profile=profile)
+
     try:
-        page = ctx.pages[0] if ctx.pages else ctx.new_page()
-        page.goto(WISHLIST_URL, wait_until="domcontentloaded", timeout=timeout_s * 1000)
-
-        title = ""
-        html = ""
-        deadline = time.time() + poll_deadline_s
-        while time.time() < deadline:
-            title = page.title() or ""
-            html = page.content()
-            if _wishlist_page_ready(html):
-                break
-            if "sign in" in title.lower():
-                break
-            page.wait_for_timeout(poll_interval_ms)
-
-        return title, html
-
-
-    finally:
-        close_browser_bounded(ctx, profile=profile)
+        return _load_page()
+    except Exception as first_err:
+        # Transient navigation flakes (timeout, net::ERR_*) — one bounded retry.
+        try:
+            return _load_page()
+        except Exception:
+            raise first_err from None
 
 def _classify_kind(name: str, edition: str | None) -> str:
     """Best-effort split between base games and DLC/cosmetics/currency packs.

--- a/index.html
+++ b/index.html
@@ -3464,7 +3464,7 @@
           <div id="addGameResults" class="space-y-2"></div>
         </div>
         <div
-          class="border-t border-slate-700 p-3 flex justify-between items-center gap-2"
+          class="app-modal-actions border-t border-slate-700 p-3 flex justify-between items-center gap-2"
         >
           <button
             id="addGameSkipSteam"

--- a/js/app.js
+++ b/js/app.js
@@ -105,6 +105,7 @@ import {
   resizeRibbonCharts,
 } from "./dashboard-charts.js";
 import { prewarmTableQueryForView, tableFingerprint, installDrillGeomApi } from "./table-ui.js";
+import { installModalGeomApi } from "./modal-geom-api.js";
 import {
   dashDrillStore,
   dashDrillStatus,
@@ -231,6 +232,7 @@ async function bootstrap() {
   savePrefs();
   bindEvents();
   installDrillGeomApi();
+  installModalGeomApi();
   if (typeof window !== "undefined" && window.__baklogDrillGeom) {
     Object.assign(window.__baklogDrillGeom, {
       dashDrillStore,

--- a/js/modal-geom-api.js
+++ b/js/modal-geom-api.js
@@ -1,0 +1,96 @@
+/**
+ * Playwright modal geometry helpers (window.__baklogModalGeom).
+ * Pass: body bottom + gapPx <= actions top; actions bottom inside panel.
+ */
+
+export const MODAL_GEOM_GAP_PX = 4;
+
+/**
+ * @param {string} modalId
+ * @returns {{ ok: boolean, reason?: string, gap?: number, bodyBottom?: number, actionsTop?: number, actionsBottom?: number, panelBottom?: number }}
+ */
+export function measureModalLayout(modalId) {
+  const modal = document.getElementById(modalId);
+  if (!modal || modal.classList.contains('hidden')) {
+    return { ok: false, reason: 'modal-hidden' };
+  }
+  const panel =
+    modal.querySelector('[role="dialog"]') ||
+    modal.querySelector('.app-modal-panel');
+  if (!panel) return { ok: false, reason: 'no-panel' };
+  const body = panel.querySelector('.app-modal-body');
+  const actions = panel.querySelector('.app-modal-actions');
+  if (!body || !actions) return { ok: false, reason: 'missing-body-actions' };
+
+  const bodyRect = body.getBoundingClientRect();
+  const actionsRect = actions.getBoundingClientRect();
+  const panelRect = panel.getBoundingClientRect();
+  const gap = actionsRect.top - bodyRect.bottom;
+  const bodyActionsOk = gap >= MODAL_GEOM_GAP_PX - 0.5;
+  const actionsInPanel = actionsRect.bottom <= panelRect.bottom + 1;
+  const bodyVisible = bodyRect.height > 0 && bodyRect.bottom > panelRect.top;
+  const actionsVisible = actionsRect.height > 0;
+
+  let reason;
+  if (!bodyActionsOk) reason = `overlap gap=${Math.round(gap * 10) / 10}`;
+  else if (!actionsInPanel) reason = 'actions-outside-panel';
+  else if (!bodyVisible) reason = 'body-not-visible';
+  else if (!actionsVisible) reason = 'actions-not-visible';
+
+  return {
+    ok: bodyActionsOk && actionsInPanel && bodyVisible && actionsVisible,
+    gap: Math.round(gap * 10) / 10,
+    bodyBottom: Math.round(bodyRect.bottom),
+    actionsTop: Math.round(actionsRect.top),
+    actionsBottom: Math.round(actionsRect.bottom),
+    panelBottom: Math.round(panelRect.bottom),
+    reason,
+  };
+}
+
+function firstListKey() {
+  return window.__baklogDrillGeom?.visibleListKeys?.()?.[0] || null;
+}
+
+/** Expose modal geometry helpers for Playwright audits. */
+export function installModalGeomApi() {
+  if (typeof window === 'undefined') return;
+  window.__baklogModalGeom = {
+    gapPx: MODAL_GEOM_GAP_PX,
+    measure: measureModalLayout,
+    firstGameKey: firstListKey,
+    async openHltb() {
+      const { confirmHltbEstimate } = await import('./hltb-estimate-modal.js');
+      void confirmHltbEstimate({ unchecked: 100, noMatch: 0 });
+      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    },
+    closeHltb() {
+      document.querySelector('#hltbEstimateModal .hltb-estimate-cancel')?.click();
+      const modal = document.getElementById('hltbEstimateModal');
+      modal?.classList.add('hidden');
+      modal?.replaceChildren();
+    },
+    async openNotes(key) {
+      const k = key || firstListKey();
+      if (!k) return false;
+      const { openNotesDialog } = await import('./notes-dialog.js');
+      openNotesDialog(k);
+      return true;
+    },
+    closeNotes() {
+      import('./notes-dialog.js').then((m) => m.closeNotesDialog());
+    },
+    async openAddGame() {
+      document.getElementById('addGameBtn')?.click();
+      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      const modal = document.getElementById('addGameModal');
+      return !!(modal && !modal.classList.contains('hidden'));
+    },
+    closeAddGame() {
+      document.getElementById('addGameClose')?.click();
+      const modal = document.getElementById('addGameModal');
+      modal?.classList.add('hidden');
+      modal?.classList.remove('flex');
+    },
+  };
+}

--- a/landing/free-claims.json
+++ b/landing/free-claims.json
@@ -1,6 +1,46 @@
 {
-  "generated_at": "2026-08-31T20:45:40.296305+00:00",
+  "generated_at": "2026-09-01T20:16:13.834771+00:00",
   "items": [
+    {
+      "id": "gamerpower-3421",
+      "store": "itch",
+      "title": "Very Realistic Game Dev Simulator (Itch.io) Giveaway",
+      "claim_url": "https://www.gamerpower.com/open/very-realistic-game-dev-simulator-itch-io-giveaway",
+      "header_image": "https://www.gamerpower.com/offers/1b/6946b7c157bca.jpg",
+      "genres": [],
+      "blurb": "Are you planning on getting into game dev? Then this might be for you! Very Realistic Game Dev Simulator is free on Itch.io for a limited time!",
+      "ends_at": "2026-09-05T23:59:35Z",
+      "source": "gamerpower",
+      "first_seen": "2026-08-01T20:43:42Z"
+    },
+    {
+      "id": "gamerpower-3496",
+      "store": "itch",
+      "title": "Cherophobia (Itch.io) Giveaway",
+      "claim_url": "https://www.gamerpower.com/open/cherophobia-itch-io-giveaway",
+      "header_image": "https://www.gamerpower.com/offers/1b/698fa7369c1f5.jpg",
+      "genres": [],
+      "blurb": "Download Cherophobia for free via Itch.io! Cherophobia is a short 3D psychological horror game.",
+      "ends_at": "2026-09-04T23:59:00Z",
+      "steam_appid": 2994800,
+      "review_percent": 78,
+      "source": "gamerpower",
+      "first_seen": "2026-08-17T18:41:11Z"
+    },
+    {
+      "id": "gamerpower-3422",
+      "store": "itch",
+      "title": "Do You Have a Moment to Talk About Our Lord and Savior? (Itch.io) Giveaway",
+      "claim_url": "https://www.gamerpower.com/open/do-you-have-a-moment-to-talk-about-our-lord-and-savior-itch-io-giveaway",
+      "header_image": "https://www.gamerpower.com/offers/1b/6946b8c46bc9b.jpg",
+      "genres": [],
+      "blurb": "Grab “Do You Have a Moment to Talk About Our Lord and Savior?” for free on itch.io! A short 3D roguelike deckbuilder with retro PSX-style graphics.",
+      "ends_at": "2026-09-04T23:59:00Z",
+      "steam_appid": 3063960,
+      "review_percent": 80,
+      "source": "gamerpower",
+      "first_seen": "2026-08-17T18:41:11Z"
+    },
     {
       "id": "gamerpower-3313",
       "store": "indiegala",
@@ -12,46 +52,6 @@
       "ends_at": "2026-09-14T20:45:20Z",
       "steam_appid": 1532580,
       "review_percent": 62,
-      "source": "gamerpower",
-      "first_seen": "2026-08-31T20:45:20Z"
-    },
-    {
-      "id": "gamerpower-3421",
-      "store": "itch",
-      "title": "Very Realistic Game Dev Simulator (Itch.io) Giveaway",
-      "claim_url": "https://www.gamerpower.com/open/very-realistic-game-dev-simulator-itch-io-giveaway",
-      "header_image": "https://www.gamerpower.com/offers/1b/6946b7c157bca.jpg",
-      "genres": [],
-      "blurb": "Are you planning on getting into game dev? Then this might be for you! Very Realistic Game Dev Simulator is free on Itch.io for a limited time!",
-      "ends_at": "2026-09-05T23:59:35Z",
-      "source": "gamerpower",
-      "first_seen": "2026-08-31T20:45:20Z"
-    },
-    {
-      "id": "gamerpower-3496",
-      "store": "itch",
-      "title": "Cherophobia (Itch.io) Giveaway",
-      "claim_url": "https://www.gamerpower.com/open/cherophobia-itch-io-giveaway",
-      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2994800/header.jpg?t=1771719765",
-      "genres": [],
-      "blurb": "Download Cherophobia for free via Itch.io! Cherophobia is a short 3D psychological horror game.",
-      "ends_at": "2026-09-04T23:59:00Z",
-      "steam_appid": 2994800,
-      "review_percent": 78,
-      "source": "gamerpower",
-      "first_seen": "2026-08-31T20:45:20Z"
-    },
-    {
-      "id": "gamerpower-3422",
-      "store": "itch",
-      "title": "Do You Have a Moment to Talk About Our Lord and Savior? (Itch.io) Giveaway",
-      "claim_url": "https://www.gamerpower.com/open/do-you-have-a-moment-to-talk-about-our-lord-and-savior-itch-io-giveaway",
-      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/3063960/header.jpg?t=1739261833",
-      "genres": [],
-      "blurb": "Grab “Do You Have a Moment to Talk About Our Lord and Savior?” for free on itch.io! A short 3D roguelike deckbuilder with retro PSX-style graphics.",
-      "ends_at": "2026-09-04T23:59:00Z",
-      "steam_appid": 3063960,
-      "review_percent": 80,
       "source": "gamerpower",
       "first_seen": "2026-08-31T20:45:20Z"
     },
@@ -68,45 +68,6 @@
       "review_percent": 96,
       "source": "itad",
       "first_seen": "2026-08-31T20:45:20Z"
-    },
-    {
-      "id": "gamerpower-3621",
-      "store": "itch",
-      "title": "Forget-me-not (itchio) Giveaway",
-      "claim_url": "https://www.gamerpower.com/open/forget-me-not-itchio-giveaway",
-      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/1952260/header.jpg?t=1650154570",
-      "genres": [],
-      "blurb": "Grab Forget-me-not for free on itch.io! Forget-me-not is a yuri Visual Novel. Give it a look!",
-      "ends_at": "2026-08-31T23:59:00Z",
-      "steam_appid": 1952260,
-      "review_percent": 94,
-      "source": "gamerpower",
-      "first_seen": "2026-08-30T18:33:13Z"
-    },
-    {
-      "id": "steam-dwarven-realms",
-      "store": "steam",
-      "title": "Dwarven Realms",
-      "claim_url": "https://www.amdgaming.com/promotions/dwarven-realms-giveaway",
-      "header_image": "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2015240/header.jpg?t=1738315434",
-      "genres": [],
-      "blurb": null,
-      "ends_at": null,
-      "steam_appid": 2015240,
-      "review_percent": 82,
-      "first_seen": "2026-08-24T16:40:14Z"
-    },
-    {
-      "id": "gamerpower-3742",
-      "store": "epic",
-      "title": "Targeted – 10 Days (Epic Games) Giveaway",
-      "claim_url": "https://www.gamerpower.com/open/targeted-10-days-epic-games-giveaway",
-      "header_image": "https://www.gamerpower.com/offers/1b/6a7ce767b76aa.jpg",
-      "genres": [],
-      "blurb": "New Giveaway! Download Targeted – 10 Days for free via Epic Games Store! Targeted – 10 Days is a 3d escape-room-style game with multiple difficulty levels.",
-      "ends_at": "2026-08-31T23:59:00Z",
-      "source": "gamerpower",
-      "first_seen": "2026-08-30T18:33:13Z"
     }
   ],
   "attribution": [

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "check:perf": "npm run test:perf",
     "perf:audit": "node scripts/perf-audit.mjs",
     "test:drill-geometry": "node scripts/drill-geometry-audit.mjs",
+    "test:modal-geometry": "node scripts/modal-geometry-audit.mjs",
     "test:libcount-geometry": "node scripts/library-count-geometry-audit.mjs",
     "test:responsive": "node scripts/responsive-overflow-audit.mjs",
     "perf:profile": "node scripts/generate-perf-profile.mjs",

--- a/scripts/modal-geometry-audit.mjs
+++ b/scripts/modal-geometry-audit.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+/**
+ * Modal geometry audit — Playwright matrix for app-modal body/actions layout.
+ * Usage: node scripts/modal-geometry-audit.mjs [baseUrl]
+ * Requires: live server with BAKLOG_PROFILE=perf (see start-modal-geometry.ps1).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium, devices } from 'playwright';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const BASE = process.argv[2] || 'http://127.0.0.1:8765';
+const OUT = path.join(root, 'scripts', 'modal-geometry-last-run.json');
+
+const VIEWPORTS = [
+  {
+    name: 'shortLand',
+    width: 800,
+    height: 480,
+    isMobile: true,
+    hasTouch: true,
+  },
+  { name: 'phone390', width: 390, height: 844 },
+  { name: 'mid640', width: 640, height: 800 },
+  { name: 'desk1280', width: 1280, height: 800 },
+];
+
+const MODALS = [
+  { id: 'hltb', modalId: 'hltbEstimateModal', open: 'openHltb', close: 'closeHltb' },
+  { id: 'notes', modalId: 'notesDialogModal', open: 'openNotes', close: 'closeNotes' },
+  { id: 'addGame', modalId: 'addGameModal', open: 'openAddGame', close: 'closeAddGame' },
+];
+
+async function waitBoot(page, timeoutMs = 60000) {
+  await page.waitForFunction(
+    () => !document.documentElement.hasAttribute('data-boot-loading'),
+    null,
+    { timeout: timeoutMs },
+  );
+  await page.waitForFunction(
+    () => !!window.__baklogModalGeom?.measure,
+    null,
+    { timeout: timeoutMs },
+  );
+}
+
+async function clickViewTab(page, view) {
+  await page.evaluate((v) => {
+    document.querySelector(`.view-tab[data-view="${v}"]`)?.click();
+  }, view);
+  await page.waitForFunction(
+    (v) => document.documentElement.getAttribute('data-init-view') === v,
+    view,
+    { timeout: 12000 },
+  ).catch(() => {});
+  await page.waitForTimeout(300);
+}
+
+function record(cases, entry) {
+  cases.push(entry);
+  const tag = entry.skipped ? 'SKIP' : entry.ok ? 'OK' : 'FAIL';
+  const detail = entry.skipped
+    ? entry.reason
+    : entry.reason || (entry.gap != null ? `gap=${entry.gap}` : '');
+  console.log(`  [${tag}] ${entry.viewport} ${entry.id} ${detail}`);
+}
+
+async function openModal(page, fnName, args = []) {
+  return page.evaluate(
+    async ({ fnName, args }) => {
+      const g = window.__baklogModalGeom;
+      const fn = g?.[fnName];
+      if (typeof fn !== 'function') throw new Error(`missing ${fnName}`);
+      return fn(...args);
+    },
+    { fnName, args },
+  );
+}
+
+async function measureModal(page, modalId) {
+  return page.evaluate((id) => window.__baklogModalGeom.measure(id), modalId);
+}
+
+async function closeModal(page, fnName) {
+  await page.evaluate((name) => window.__baklogModalGeom?.[name]?.(), fnName);
+  await page.waitForTimeout(80);
+}
+
+async function runModalCase(page, viewport, cases, spec) {
+  try {
+    if (spec.id === 'notes' || spec.id === 'addGame') {
+      await clickViewTab(page, 'library');
+      await page.waitForFunction(
+        () => (window.__baklogDrillGeom?.visibleListKeys?.() || []).length > 0,
+        null,
+        { timeout: 15000 },
+      ).catch(() => {});
+    }
+
+    const opened = await openModal(page, spec.open);
+    if (spec.id === 'notes' && opened === false) {
+      record(cases, {
+        viewport: viewport.name,
+        id: spec.id,
+        skipped: true,
+        reason: 'no-game-key',
+      });
+      return;
+    }
+    if (spec.id === 'addGame' && opened === false) {
+      record(cases, {
+        viewport: viewport.name,
+        id: spec.id,
+        skipped: true,
+        reason: 'add-game-not-opened',
+      });
+      return;
+    }
+
+    await page.waitForTimeout(120);
+    const result = await measureModal(page, spec.modalId);
+    record(cases, {
+      viewport: viewport.name,
+      id: spec.id,
+      modalId: spec.modalId,
+      ...result,
+    });
+    await closeModal(page, spec.close);
+  } catch (err) {
+    record(cases, {
+      viewport: viewport.name,
+      id: spec.id,
+      ok: false,
+      reason: String(err?.message || err).slice(0, 200),
+    });
+    await closeModal(page, spec.close).catch(() => {});
+  }
+}
+
+async function suiteForViewport(page, viewport, cases) {
+  console.log(`\n== viewport ${viewport.name} ${viewport.width}x${viewport.height} ==`);
+  for (const spec of MODALS) {
+    await runModalCase(page, viewport, cases, spec);
+  }
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const report = {
+    capturedAt: new Date().toISOString(),
+    baseUrl: BASE,
+    viewports: VIEWPORTS.map((v) => v.name),
+    modals: MODALS.map((m) => m.id),
+    cases: [],
+    failures: [],
+    skipped: 0,
+  };
+
+  try {
+    for (const vp of VIEWPORTS) {
+      const contextOpts = {
+        viewport: { width: vp.width, height: vp.height },
+        actionTimeout: 8000,
+      };
+      if (vp.isMobile) {
+        contextOpts.isMobile = true;
+        contextOpts.hasTouch = true;
+        contextOpts.userAgent = devices['iPhone 12'].userAgent;
+      }
+      const context = await browser.newContext(contextOpts);
+      const page = await context.newPage();
+      page.setDefaultTimeout(8000);
+      await page.addInitScript(() => {
+        try {
+          localStorage.setItem('baklog-perf', '1');
+        } catch (_) { /* noop */ }
+      });
+      await page.goto(`${BASE}/?perf=1`, { waitUntil: 'domcontentloaded', timeout: 30000 });
+      await waitBoot(page);
+
+      const before = report.cases.length;
+      await suiteForViewport(page, vp, report.cases);
+      const slice = report.cases.slice(before);
+      for (const c of slice) {
+        if (c.skipped) report.skipped += 1;
+        else if (!c.ok) {
+          report.failures.push(`${c.viewport}:${c.id} ${c.reason || `gap=${c.gap}`}`);
+        }
+      }
+      await context.close();
+    }
+  } finally {
+    await browser.close();
+  }
+
+  fs.writeFileSync(OUT, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  console.log(`\nWrote ${OUT}`);
+  console.log(
+    `cases=${report.cases.length} failures=${report.failures.length} skipped=${report.skipped}`,
+  );
+  if (report.failures.length) {
+    console.error('HARD FAILURES:');
+    for (const f of report.failures) console.error(`  ${f}`);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/start-modal-geometry.ps1
+++ b/scripts/start-modal-geometry.ps1
@@ -1,0 +1,68 @@
+# Sync perf profile fixture, start server, run Playwright modal geometry audit, stop server.
+param(
+    [switch]$SkipBuild,
+    [string]$BaseUrl = 'http://127.0.0.1:8765'
+)
+
+$ErrorActionPreference = 'Stop'
+$root = Split-Path -Parent $PSScriptRoot
+Set-Location $root
+
+$py = Join-Path $root '.venv\Scripts\python.exe'
+if (-not (Test-Path $py)) {
+    Write-Error "Missing $py - create .venv first."
+}
+
+Write-Host '==> generate + sync perf profile fixture (index active=perf)'
+node scripts/generate-perf-profile.mjs
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+$fixtureRoot = Join-Path $root 'tests\fixtures\perf-profile'
+$profilesDir = Join-Path $root 'profiles'
+$destPerf = Join-Path $profilesDir 'perf'
+New-Item -ItemType Directory -Force -Path $destPerf | Out-Null
+Copy-Item -Force (Join-Path $fixtureRoot 'index.json') (Join-Path $profilesDir 'index.json')
+Copy-Item -Recurse -Force (Join-Path $fixtureRoot 'perf\*') $destPerf
+
+if (-not $SkipBuild) {
+    Write-Host '==> npm run build'
+    npm run build
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}
+
+$env:BAKLOG_PROFILE = 'perf'
+$env:BAKLOG_SERVE_BUILT = '1'
+$env:BAKLOG_ADMIN = '0'
+$env:BAKLOG_AUTH_DISABLED = '1'
+
+Write-Host '==> stop stray servers'
+& $py scripts/stop_baklog.py 2>$null | Out-Null
+
+Write-Host '==> starting server (perf profile, BAKLOG_SERVE_BUILT=1, AUTH_DISABLED)'
+$server = Start-Process -FilePath $py -ArgumentList 'server.py' -WorkingDirectory $root -PassThru -WindowStyle Hidden
+
+function Stop-Server {
+    if ($server -and -not $server.HasExited) {
+        & $py scripts/stop_baklog.py 2>$null | Out-Null
+        if (-not $server.HasExited) { Stop-Process -Id $server.Id -Force -ErrorAction SilentlyContinue }
+    }
+}
+
+try {
+    $deadline = (Get-Date).AddSeconds(45)
+    $ready = $false
+    while ((Get-Date) -lt $deadline) {
+        try {
+            $r = Invoke-WebRequest -Uri "$BaseUrl/api/config" -UseBasicParsing -TimeoutSec 2
+            if ($r.StatusCode -eq 200) { $ready = $true; break }
+        } catch { Start-Sleep -Milliseconds 400 }
+    }
+    if (-not $ready) {
+        Write-Error "Server did not become ready at $BaseUrl"
+    }
+
+    Write-Host '==> modal geometry audit'
+    node scripts/modal-geometry-audit.mjs $BaseUrl
+    exit $LASTEXITCODE
+} finally {
+    Stop-Server
+}

--- a/tests/modal-geom-api.test.js
+++ b/tests/modal-geom-api.test.js
@@ -1,0 +1,69 @@
+/**
+ * Modal geometry measure helpers (Vitest).
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { measureModalLayout, MODAL_GEOM_GAP_PX } from '../js/modal-geom-api.js';
+
+function mountModal(html) {
+  document.body.insertAdjacentHTML('beforeend', html);
+}
+
+describe('measureModalLayout', () => {
+  afterEach(() => {
+    document.getElementById('testModal')?.remove();
+  });
+
+  it('passes when body and actions have required gap', () => {
+    mountModal(`
+      <div id="testModal" class="app-modal">
+        <div role="dialog" class="flex flex-col" style="display:flex;flex-direction:column;gap:4px">
+          <div class="app-modal-body" style="height:40px">body</div>
+          <div class="app-modal-actions" style="height:32px">actions</div>
+        </div>
+      </div>
+    `);
+    const panel = document.querySelector('#testModal [role="dialog"]');
+    const body = panel.querySelector('.app-modal-body');
+    const actions = panel.querySelector('.app-modal-actions');
+    body.getBoundingClientRect = () => ({
+      top: 0, bottom: 40, left: 0, right: 100, width: 100, height: 40, x: 0, y: 0, toJSON() {},
+    });
+    actions.getBoundingClientRect = () => ({
+      top: 44, bottom: 76, left: 0, right: 100, width: 100, height: 32, x: 0, y: 44, toJSON() {},
+    });
+    panel.getBoundingClientRect = () => ({
+      top: 0, bottom: 80, left: 0, right: 100, width: 100, height: 80, x: 0, y: 0, toJSON() {},
+    });
+
+    const result = measureModalLayout('testModal');
+    expect(result.ok).toBe(true);
+    expect(result.gap).toBeGreaterThanOrEqual(MODAL_GEOM_GAP_PX);
+  });
+
+  it('fails when body overlaps actions', () => {
+    mountModal(`
+      <div id="testModal" class="app-modal">
+        <div role="dialog">
+          <div class="app-modal-body">body</div>
+          <div class="app-modal-actions">actions</div>
+        </div>
+      </div>
+    `);
+    const panel = document.querySelector('#testModal [role="dialog"]');
+    const body = panel.querySelector('.app-modal-body');
+    const actions = panel.querySelector('.app-modal-actions');
+    body.getBoundingClientRect = () => ({
+      top: 0, bottom: 50, left: 0, right: 100, width: 100, height: 50, x: 0, y: 0, toJSON() {},
+    });
+    actions.getBoundingClientRect = () => ({
+      top: 48, bottom: 80, left: 0, right: 100, width: 100, height: 32, x: 0, y: 48, toJSON() {},
+    });
+    panel.getBoundingClientRect = () => ({
+      top: 0, bottom: 80, left: 0, right: 100, width: 100, height: 80, x: 0, y: 0, toJSON() {},
+    });
+
+    const result = measureModalLayout('testModal');
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/overlap/);
+  });
+});

--- a/tests/test_fetch_ubisoft_wishlist_retry.py
+++ b/tests/test_fetch_ubisoft_wishlist_retry.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/tests/test_fetch_ubisoft_wishlist_retry.py
+++ b/tests/test_fetch_ubisoft_wishlist_retry.py
@@ -1,0 +1,69 @@
+"""Ubisoft wishlist fetch retry on transient navigation failure."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def wishlist_mod(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    import fetchers.fetch_ubisoft_wishlist as mod
+
+    profile = tmp_path / "ubisoft"
+    profile.mkdir()
+    monkeypatch.setattr(mod, "profile_dir", lambda _k: profile)
+    monkeypatch.setattr(mod, "WISHLIST_URL", "https://example.test/wishlist")
+    return mod
+
+
+def test_fetch_wishlist_html_retries_once_on_transient_error(wishlist_mod, monkeypatch):
+    calls = {"n": 0}
+
+    def fake_launch(*_a, **_k):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise TimeoutError("navigation timeout")
+        ctx = MagicMock()
+        page = MagicMock()
+        page.title.return_value = "Wishlist"
+        page.content.return_value = (
+            '<div class="product-tile  wishlist-product-tile" data-pid="1"></div>'
+            + "x" * 250_000
+        )
+        ctx.pages = [page]
+        ctx.new_page.return_value = page
+        return ctx
+
+    monkeypatch.setattr(
+        "auth.cdp_browser.launch_persistent_profile",
+        fake_launch,
+    )
+    monkeypatch.setattr(
+        "auth.cdp_browser.close_browser_bounded",
+        lambda *_a, **_k: None,
+    )
+
+    title, html = wishlist_mod._fetch_wishlist_html(timeout_s=30)
+    assert calls["n"] == 2
+    assert title == "Wishlist"
+    assert "wishlist-product-tile" in html
+
+
+def test_fetch_wishlist_html_raises_after_two_failures(wishlist_mod, monkeypatch):
+    def always_fail(*_a, **_k):
+        raise TimeoutError("navigation timeout")
+
+    monkeypatch.setattr(
+        "auth.cdp_browser.launch_persistent_profile",
+        always_fail,
+    )
+    monkeypatch.setattr(
+        "auth.cdp_browser.close_browser_bounded",
+        lambda *_a, **_k: None,
+    )
+
+    with pytest.raises(TimeoutError, match="navigation timeout"):
+        wishlist_mod._fetch_wishlist_html(timeout_s=30)


### PR DESCRIPTION
## Summary
- Add opt-in Playwright modal geometry audit (HLTB, notes, add-game) with layout fixes for short viewports
- Refresh hosted free-claims feed after pruning stale approved orphans; local audit --fail-on high green
- Ubisoft wishlist fetch retries once on transient browser navigation errors

## Test plan
- [x] `npm run test:modal-geometry` green (12 cases across 4 viewports)
- [x] `pytest tests/test_fetch_ubisoft_wishlist_retry.py` passes
- [x] `npm test -- tests/modal-geom-api.test.js` passes
- [x] `audit_free_surface_data.py --fail-on high` passes
- [ ] Vercel redeploy after merge; verify `baklog.app/free-claims.json`

Made with [Cursor](https://cursor.com)