### PR TITLE
Epic Connect: reuse fresh flag on already-open retry

### DIFF
--- a/js/connections.js
+++ b/js/connections.js
@@ -1719,9 +1719,10 @@ async function startBrowserConnect(provider) {
         if (log) log.textContent = "Previous sign-in cancelled. Retrying…";
         hideConnectCancelControl(card);
         try {
-          res = await baklogFetch(`/api/auth/${provider}/start?fresh=1`, {
-            method: "POST",
-          });
+          res = await baklogFetch(
+            `/api/auth/${provider}/start${fresh ? "?fresh=1" : ""}`,
+            { method: "POST" },
+          );
           data = await res.json().catch(() => ({}));
         } catch {
           if (log)


### PR DESCRIPTION
## Summary
- Epic library profile preserve on reconnect was already shipped in 0.8.42 (`PRESERVE_PROFILE_ON_RECONNECT`).
- The Connections **already open** retry still hardcoded `?fresh=1`; it now reuses the same `fresh` flag as the first POST (Epic/wishlist keep profile; other providers still clear on reconnect).

## Test plan
- [ ] Epic Reconnect (connected/expired): network tab shows `/start` without `?fresh=1` on first POST and on already-open retry
- [ ] Non-Epic Reconnect (e.g. GOG): still uses `?fresh=1` on both attempts
- [ ] Disconnect then Connect Epic: still clears ghost profile (server disconnected path unchanged)