### PR TITLE
Harden localhost CSRF, secrets profile import, and Unix reclaim

### DIFF
--- a/auth/connect_log.py
+++ b/auth/connect_log.py
@@ -33,7 +33,9 @@ def connect_log(provider: str, message: str, *, key: str | None = None) -> None:
         stale = [k for k, t in _last_log_by_key.items() if t < cutoff]
         for k in stale:
             _last_log_by_key.pop(k, None)
-    line = f"[{prov}] {message}"
+    from shared.log_redact import redact_log_line
+
+    line = redact_log_line(f"[{prov}] {message}")
     print(line, file=sys.stderr, flush=True)
     try:
         path = _log_paths.get(prov)

--- a/auth/manager.py
+++ b/auth/manager.py
@@ -515,43 +515,32 @@ def migrate_existing_itch_local_opt_in() -> list[str]:
 def import_env_credentials(*, profile_id: str = DEFAULT_PROFILE_ID) -> list[str]:
     """One-time migration: copy legacy ``.env`` creds into a profile's encrypted blob.
 
-    Writes to ``profile_id``'s ``secrets.bin`` regardless of the active profile by
-    temporarily pointing the secrets module at that profile's auth dir. Providers
-    already explicitly connected/expired are left untouched. Returns the list of
-    provider keys that were imported.
+    Writes to ``profile_id``'s ``secrets.bin`` via ``_with_profile_secrets`` so the
+    HKDF profile subkey matches the target dir (not only the live active profile).
+    Providers already explicitly connected/expired are left untouched. Returns the
+    list of provider keys that were imported.
     """
-    import auth.secrets as _secrets
-
-    target_dir = auth_dir(profile_id=profile_id)
-    saved = (_secrets.AUTH_DIR, _secrets.SECRETS_FILE, _secrets.MASTER_KEY_FILE, _secrets._cache)
     imported: list[str] = []
-    with _secrets._lock:
-        _secrets.AUTH_DIR = target_dir
-        _secrets.SECRETS_FILE = target_dir / "secrets.bin"
-        _secrets.MASTER_KEY_FILE = target_dir / ".master_key"
-        _secrets._cache = None
-        try:
-            for provider, spec in PROVIDERS.items():
-                if spec.kind == "local" or not spec.env_keys:
-                    continue
-                existing = get_provider_blob(provider).get("status")
-                if existing in ("connected", "expired"):
-                    continue
-                creds: dict[str, str] = {}
-                for key in spec.env_keys:
-                    val = os.getenv(key, "").strip()
-                    if val:
-                        creds[key] = val
-                for alias in _LEGACY_ENV_ALIASES.get(provider, ()):  # legacy cookie names
-                    val = os.getenv(alias, "").strip()
-                    if val:
-                        creds[alias] = val
-                if not creds:
-                    continue
-                mark_connected(provider, creds)
-                imported.append(provider)
-        finally:
-            _secrets.AUTH_DIR, _secrets.SECRETS_FILE, _secrets.MASTER_KEY_FILE, _secrets._cache = saved
+    with _with_profile_secrets(profile_id):
+        for provider, spec in PROVIDERS.items():
+            if spec.kind == "local" or not spec.env_keys:
+                continue
+            existing = get_provider_blob(provider).get("status")
+            if existing in ("connected", "expired"):
+                continue
+            creds: dict[str, str] = {}
+            for key in spec.env_keys:
+                val = os.getenv(key, "").strip()
+                if val:
+                    creds[key] = val
+            for alias in _LEGACY_ENV_ALIASES.get(provider, ()):  # legacy cookie names
+                val = os.getenv(alias, "").strip()
+                if val:
+                    creds[alias] = val
+            if not creds:
+                continue
+            mark_connected(provider, creds)
+            imported.append(provider)
     return imported
 
 

--- a/server.py
+++ b/server.py
@@ -713,13 +713,6 @@ SCHEDULER: Any = None
 _DEV_HTTPD: ThreadingHTTPServer | None = None
 
 
-def _header_hostname(value: str | None) -> str | None:
-    if not value:
-        return None
-    host = (urlparse(value).hostname or "").lower()
-    return host or None
-
-
 def _normalize_host(raw: str | None) -> str:
     """Lowercased hostname with IPv6 brackets and any :port stripped.
 
@@ -743,29 +736,12 @@ def _request_host_is_local(handler: SimpleHTTPRequestHandler) -> bool:
     return _normalize_host(handler.headers.get("Host", "")) in _LOCAL_HOSTNAMES
 
 
-def _origin_is_local(handler: SimpleHTTPRequestHandler) -> bool:
-    for name in ("Origin", "Referer"):
-        host = _header_hostname(handler.headers.get(name))
-        if host in _LOCAL_HOSTNAMES:
-            return True
-    return False
-
-
-def _csrf_allowed(handler: SimpleHTTPRequestHandler) -> bool:
-    """Block cross-site POST/PUT/DELETE to localhost while the dev server runs."""
-    from shared.supabase_auth import auth_enabled, verify_bearer_user
-
-    if auth_enabled() and verify_bearer_user(handler.headers.get("Authorization")):
-        return True
-    if not _request_host_is_local(handler):
-        return False
-    if handler.headers.get(_BAKLOG_LOCAL_HEADER) == "1":
-        return True
-    return _origin_is_local(handler)
-
-
 def _csrf_allowed_strict(handler: SimpleHTTPRequestHandler) -> bool:
-    """Stricter CSRF for profile mutations — require explicit app header or bearer."""
+    """Mutating-route CSRF gate: localhost Host plus X-BAKLOG-Local (or bearer).
+
+    Origin/Referer alone is never enough — that loose path was removed so new
+    routes cannot accidentally reintroduce it.
+    """
     from shared.supabase_auth import auth_enabled, verify_bearer_user
 
     if auth_enabled() and verify_bearer_user(handler.headers.get("Authorization")):
@@ -1132,25 +1108,19 @@ class Handler(SimpleHTTPRequestHandler):
         finally:
             clear_request_profile_id()
 
-    def _reject_if_csrf(self) -> bool:
-        """Return True when the request was rejected (caller should return)."""
-        if _csrf_allowed(self):
-            return False
-        _send_json(
-            self,
-            HTTPStatus.FORBIDDEN,
-            {"error": "cross-origin request blocked — open BAKLOG from http://127.0.0.1 and retry"},
-        )
-        return True
-
     def _reject_if_csrf_strict(self) -> bool:
-        """Stricter CSRF gate for profile admin routes."""
+        """Return True when the request was rejected (caller should return)."""
         if _csrf_allowed_strict(self):
             return False
         _send_json(
             self,
             HTTPStatus.FORBIDDEN,
-            {"error": "cross-origin request blocked — open BAKLOG from http://127.0.0.1 and retry"},
+            {
+                "error": (
+                    "cross-origin request blocked - open BAKLOG from "
+                    "http://127.0.0.1 and retry"
+                )
+            },
         )
         return True
 

--- a/shared/dev_server_pids.py
+++ b/shared/dev_server_pids.py
@@ -61,25 +61,53 @@ def terminate_pid(pid: int) -> None:
             pass
 
 
+def _cmdline_looks_like_baklog_server(cmdline: str) -> bool:
+    """True when process cmdline/exe text looks like our server or frozen tray."""
+    low = cmdline.lower()
+    return (
+        "server.py" in low
+        or "baklog" in low
+        or ("python" in low and "steam-backlog" in low)
+    )
+
+
 def pid_is_python_server(pid: int) -> bool:
     """Best-effort confirm pid is a live BAKLOG server process (dev python.exe or
     a frozen BAKLOG.exe) so reclaim never kills an unrelated process that reused
     the pid. Frozen tester builds run as ``BAKLOG.exe``, not ``python``."""
     if not pid_alive(pid):
         return False
-    if sys.platform != "win32":
-        return True
+    if sys.platform == "win32":
+        try:
+            out = subprocess.run(
+                ["tasklist", "/FI", f"PID eq {pid}", "/FO", "CSV", "/NH"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            )
+            name = (out.stdout or "").lower()
+            return "python" in name or "baklog" in name
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+    # Non-Windows: require cmdline evidence (never treat any live PID as ours).
+    try:
+        proc_cmd = Path(f"/proc/{pid}/cmdline")
+        if proc_cmd.is_file():
+            raw = proc_cmd.read_bytes().replace(b"\x00", b" ").decode("utf-8", "replace")
+            return _cmdline_looks_like_baklog_server(raw)
+    except OSError:
+        pass
     try:
         out = subprocess.run(
-            ["tasklist", "/FI", f"PID eq {pid}", "/FO", "CSV", "/NH"],
+            ["ps", "-p", str(pid), "-o", "args="],
             capture_output=True,
             text=True,
             timeout=5,
             check=False,
-            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
         )
-        name = (out.stdout or "").lower()
-        return "python" in name or "baklog" in name
+        return _cmdline_looks_like_baklog_server(out.stdout or "")
     except (OSError, subprocess.TimeoutExpired):
         return False
 

--- a/tests/test_dev_server_pids.py
+++ b/tests/test_dev_server_pids.py
@@ -121,5 +121,48 @@ def test_reclaim_or_exit_reclaims_then_returns(
     monkeypatch.setattr(dsp, "clear_stale_pid_file", lambda _f: False)
     monkeypatch.setattr(dsp, "port_busy", _busy)
     monkeypatch.setattr(dsp, "reclaim_stale_server", lambda *a, **k: True)
+    monkeypatch.setattr(dsp.time, "sleep", lambda *_a, **_k: None)
     dsp.reclaim_or_exit("127.0.0.1", 8765, tmp_path / "pid", "busy")
     assert calls["busy"] == 2
+
+
+def test_cmdline_looks_like_baklog_server() -> None:
+    assert dsp._cmdline_looks_like_baklog_server("python server.py") is True
+    assert dsp._cmdline_looks_like_baklog_server("/opt/BAKLOG/BAKLOG") is True
+    assert dsp._cmdline_looks_like_baklog_server("nginx: worker process") is False
+
+
+def test_pid_is_python_server_rejects_unrelated_unix_cmdline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(dsp.sys, "platform", "linux")
+    monkeypatch.setattr(dsp, "pid_alive", lambda _pid: True)
+    monkeypatch.setattr(
+        dsp.Path,
+        "is_file",
+        lambda self: str(self).replace("\\", "/").endswith("cmdline"),
+    )
+    monkeypatch.setattr(
+        dsp.Path,
+        "read_bytes",
+        lambda self: b"nginx\x00worker",
+    )
+    assert dsp.pid_is_python_server(4242) is False
+
+
+def test_pid_is_python_server_accepts_server_py_unix_cmdline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(dsp.sys, "platform", "linux")
+    monkeypatch.setattr(dsp, "pid_alive", lambda _pid: True)
+    monkeypatch.setattr(
+        dsp.Path,
+        "is_file",
+        lambda self: str(self).replace("\\", "/").endswith("cmdline"),
+    )
+    monkeypatch.setattr(
+        dsp.Path,
+        "read_bytes",
+        lambda self: b"python\x00server.py",
+    )
+    assert dsp.pid_is_python_server(4242) is True

--- a/tests/test_env_import.py
+++ b/tests/test_env_import.py
@@ -43,18 +43,17 @@ def isolated_default_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     secrets._cache = None
 
 
+def _read_profile_blob(provider: str, profile_id: str = "default") -> dict:
+    """Read a provider blob from a profile's secrets store."""
+    from auth.manager import _with_profile_secrets
+
+    with _with_profile_secrets(profile_id):
+        return get_provider_blob(provider)
+
+
 def _read_default_blob(provider: str) -> dict:
     """Read a provider blob from the default profile's secrets store."""
-    target = profile_paths.auth_dir(profile_id="default")
-    saved = (secrets.AUTH_DIR, secrets.SECRETS_FILE, secrets.MASTER_KEY_FILE, secrets._cache)
-    secrets.AUTH_DIR = target
-    secrets.SECRETS_FILE = target / "secrets.bin"
-    secrets.MASTER_KEY_FILE = target / ".master_key"
-    secrets._cache = None
-    try:
-        return get_provider_blob(provider)
-    finally:
-        secrets.AUTH_DIR, secrets.SECRETS_FILE, secrets.MASTER_KEY_FILE, secrets._cache = saved
+    return _read_profile_blob(provider, "default")
 
 
 def test_imports_env_into_default_blob(monkeypatch: pytest.MonkeyPatch):
@@ -193,3 +192,18 @@ def test_remediates_existing_env_imported_archive(tmp_path: Path):
     assert err is None
     assert count == 0
     assert not stale.exists()
+
+
+def test_import_into_non_active_profile_uses_matching_hkdf(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Import must encrypt with the *target* profile id, not the live active one."""
+    other = "work"
+    (tmp_path / "profiles" / other).mkdir(parents=True, exist_ok=True)
+    # Keep index active on default while writing into ``work``.
+    monkeypatch.setenv("ITCH_API_KEY", "itch-for-work")
+    imported = import_env_credentials(profile_id=other)
+    assert "itch" in imported
+    blob = _read_profile_blob("itch", other)
+    assert blob["status"] == "connected"
+    assert blob["ITCH_API_KEY"] == "itch-for-work"


### PR DESCRIPTION
## Summary
- Remove dead Origin/Referer-only CSRF helpers; mutating routes keep strict `X-BAKLOG-Local` / bearer gate
- Fix `.env` credential import to use `_with_profile_secrets` so HKDF matches the target profile
- Require cmdline evidence before treating a non-Windows PID as BAKLOG for port reclaim
- Redact Connect diagnostic log lines at write time

## Test plan
- [x] `pytest tests/test_server_csrf.py tests/test_csrf_profiles.py tests/test_env_import.py tests/test_dev_server_pids.py`
- [ ] CodeRabbit review on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Tightened CSRF protection to allow local requests only with explicit validation or a valid bearer token.
  - Expanded error details for rejected cross-origin requests.
  - Sensitive provider-prefixed messages are now redacted from error output and log files.

- **Authentication**
  - Environment credential imports now correctly use the selected profile’s encryption context.

- **Reliability**
  - Improved server process detection across Windows and Unix-like systems, reducing false identification of unrelated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->