### PR TITLE
Harden ITAD and free-claims empty/drift refuse contract

### DIFF
--- a/fetchers/_base.py
+++ b/fetchers/_base.py
@@ -183,14 +183,14 @@ def row_key_by_appid(row: dict[str, Any]) -> str:
 
 
 def refuse_empty_result(
-    items: list[Any] | int,
+    items: list[Any] | dict[Any, Any] | int,
     *,
     label: str,
     allow_empty: bool,
     output_path: Path | None = None,
 ) -> int | None:
     """Return exit code 2 when result is empty and --allow-empty was not passed."""
-    count = len(items) if isinstance(items, list) else items
+    count = items if isinstance(items, int) else len(items)
     if count or allow_empty:
         return None
     where = f" ({output_path})" if output_path else ""
@@ -204,8 +204,12 @@ def refuse_empty_result(
 
 
 def _previous_game_count(output_path: Path | None) -> int | None:
-    """Read game_count from the previous on-disk file, if any. Resilient to
-    malformed JSON or schema drift — callers should treat None as 'no baseline'."""
+    """Read a prior catalog size from disk. Resilient to malformed JSON or
+    schema drift — callers should treat None as 'no baseline'.
+
+    Supports library catalogs (``game_count`` / ``games``), free-claims feeds
+    (``items``), and ITAD price files (``count`` / ``by_key``).
+    """
     if output_path is not None:
         output_path = resolve_catalog_path(output_path)
     if output_path is None or not output_path.exists():
@@ -216,17 +220,22 @@ def _previous_game_count(output_path: Path | None) -> int | None:
         return None
     if not isinstance(data, dict):
         return None
-    gc = data.get("game_count")
-    if isinstance(gc, int) and gc >= 0:
-        return gc
-    games = data.get("games")
-    if isinstance(games, list):
-        return len(games)
+    for key in ("game_count", "count"):
+        value = data.get(key)
+        if isinstance(value, int) and value >= 0:
+            return value
+    for key in ("games", "items"):
+        value = data.get(key)
+        if isinstance(value, list):
+            return len(value)
+    by_key = data.get("by_key")
+    if isinstance(by_key, dict):
+        return len(by_key)
     return None
 
 
 def refuse_drift_result(
-    items: list[Any] | int,
+    items: list[Any] | dict[Any, Any] | int,
     *,
     label: str,
     allow_drift: bool,
@@ -246,7 +255,7 @@ def refuse_drift_result(
     First-run behavior: when no previous file exists or it has no count
     field, this function returns None (no baseline → can't measure drift).
     """
-    new_count = len(items) if isinstance(items, list) else items
+    new_count = items if isinstance(items, int) else len(items)
     prev = _previous_game_count(output_path)
     if prev is None or prev <= 0 or allow_drift:
         return None

--- a/fetchers/fetch_free_claims.py
+++ b/fetchers/fetch_free_claims.py
@@ -10,7 +10,12 @@ from datetime import UTC, datetime
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 
-from fetchers._base import configure_stdout
+from fetchers._base import (
+    add_allow_empty_arg,
+    configure_stdout,
+    refuse_drift_result,
+    refuse_empty_result,
+)
 from fetchers._progress import RunStats, started
 from shared.free_claims_sources import has_valid_claim_links
 from shared.profile_paths import free_claims_path
@@ -42,11 +47,7 @@ def main() -> int:
         help="Hosted feed URL (default: BAKLOG_CLAIMS_URL or baklog.app)",
     )
     parser.add_argument("--dry-run", action="store_true", help="Validate only; do not write")
-    parser.add_argument(
-        "--allow-empty",
-        action="store_true",
-        help="Allow writing an empty claims file (e.g. genuinely no live giveaways).",
-    )
+    add_allow_empty_arg(parser)
     args = parser.parse_args()
 
     stats = RunStats()
@@ -81,13 +82,23 @@ def main() -> int:
             f"(need id, store, and valid claim link(s)): {sample}{more}"
         )
 
-    # Refuse to overwrite the user's claims with nothing unless explicitly allowed.
-    if valid == 0 and not args.allow_empty:
-        stats.error(
-            "feed produced 0 valid claim(s) (need id, store, and valid claim link(s)) — refusing to "
-            "overwrite. Re-run with --allow-empty if there are genuinely no live giveaways."
-        )
-        return stats.finish("fetch_free_claims", t0, exit_code=2)
+    out = free_claims_path()
+    empty_exit = refuse_empty_result(
+        valid_items,
+        label="hosted free-claims feed",
+        allow_empty=args.allow_empty,
+        output_path=out,
+    )
+    if empty_exit is not None:
+        return stats.finish("fetch_free_claims", t0, exit_code=empty_exit)
+    drift_exit = refuse_drift_result(
+        valid_items,
+        label="hosted free-claims feed",
+        allow_drift=args.allow_drift,
+        output_path=out,
+    )
+    if drift_exit is not None:
+        return stats.finish("fetch_free_claims", t0, exit_code=drift_exit)
 
     payload = {
         "fetched_at": datetime.now(UTC).isoformat(),
@@ -99,7 +110,6 @@ def main() -> int:
     if isinstance(attribution, list) and attribution:
         payload["attribution"] = attribution
 
-    out = free_claims_path()
     if args.dry_run:
         print(f"dry-run: would write {valid} claim(s) to {out}", flush=True)
     else:

--- a/fetchers/fetch_itad.py
+++ b/fetchers/fetch_itad.py
@@ -15,7 +15,12 @@ from dotenv import load_dotenv
 
 from auth import mark_invalid, resolve_env
 from clients.itad_client import ItadClient, ItadError
-from fetchers._base import add_allow_empty_arg, configure_stdout, refuse_empty_result
+from fetchers._base import (
+    add_allow_empty_arg,
+    configure_stdout,
+    refuse_drift_result,
+    refuse_empty_result,
+)
 from fetchers._progress import EXIT_CODE_AUTH, HeartbeatTimer, RunStats, started
 from shared.fx import ensure_fx_rates
 from shared.money import country_to_currency
@@ -189,7 +194,7 @@ def main() -> int:
         # zero resolution means every wishlist title failed to match - refuse the
         # empty overwrite rather than wipe existing prices.
         empty_exit = refuse_empty_result(
-            plain_by_key,
+            len(plain_by_key),
             label="ITAD price resolution",
             allow_empty=args.allow_empty,
             output_path=ITAD_JSON,
@@ -212,6 +217,23 @@ def main() -> int:
             stats.warn(f"no price data for {key}")
 
     out = itad_path()
+    empty_priced = refuse_empty_result(
+        len(by_key),
+        label="ITAD priced rows",
+        allow_empty=args.allow_empty,
+        output_path=out,
+    )
+    if empty_priced is not None:
+        return stats.finish("fetch_itad", t0, exit_code=empty_priced)
+    drift = refuse_drift_result(
+        len(by_key),
+        label="ITAD priced rows",
+        allow_drift=args.allow_drift,
+        output_path=out,
+    )
+    if drift is not None:
+        return stats.finish("fetch_itad", t0, exit_code=drift)
+
     merged_by_key: dict[str, dict] = {}
     if out.exists():
         try:
@@ -240,11 +262,10 @@ def main() -> int:
             flush=True,
         )
     stats.ok = len(by_key)
-    exit_code = 0 if by_key or args.allow_empty else 2
     return stats.finish(
         "fetch_itad",
         t0,
-        exit_code=exit_code,
+        exit_code=0,
         extra=f"{len(by_key)}/{len(titles)} priced",
     )
 

--- a/tests/test_fetch_free_claims.py
+++ b/tests/test_fetch_free_claims.py
@@ -80,3 +80,19 @@ def test_fetch_error_exits_1(monkeypatch, out_path):
     monkeypatch.setattr(sys, "argv", ["fetchers.fetch_free_claims.py"])
     assert ffc.main() == 1
     assert not out_path.exists()
+
+
+def test_drift_refuses_with_exit_3(monkeypatch, out_path):
+    prior = {"items": [_valid_item(f"g{i}") for i in range(10)]}
+    out_path.write_text(json.dumps(prior), encoding="utf-8")
+    code = _run(monkeypatch, {"items": [_valid_item("only")]})
+    assert code == 3
+    assert json.loads(out_path.read_text(encoding="utf-8")) == prior
+
+
+def test_drift_allowed_with_flag(monkeypatch, out_path):
+    prior = {"items": [_valid_item(f"g{i}") for i in range(10)]}
+    out_path.write_text(json.dumps(prior), encoding="utf-8")
+    code = _run(monkeypatch, {"items": [_valid_item("only")]}, "--allow-drift")
+    assert code == 0
+    assert len(json.loads(out_path.read_text(encoding="utf-8"))["items"]) == 1

--- a/tests/test_fetch_itad_empty.py
+++ b/tests/test_fetch_itad_empty.py
@@ -58,3 +58,37 @@ def test_empty_wishlist_does_not_overwrite_existing_prices(_isolated: Path):
     exit_code = fetch_itad.main()
     assert exit_code == 0
     assert json.loads(existing.read_text(encoding="utf-8")) == prior
+
+
+def test_zero_priced_rows_refuse_before_write(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    catalogs = tmp_path / "catalogs"
+    catalogs.mkdir()
+    existing = catalogs / "itad_prices.json"
+    prior = {"count": 4, "by_key": {f"wishlist:{i}": {"price": 1} for i in range(4)}}
+    existing.write_text(json.dumps(prior), encoding="utf-8")
+    wishlist = catalogs / "games_wishlist.json"
+    wishlist.write_text(
+        json.dumps({"games": [{"appid": 1, "name": "One"}, {"appid": 2, "name": "Two"}]}),
+        encoding="utf-8",
+    )
+
+    class _Client:
+        def __init__(self, *a, **k):
+            pass
+
+        def lookup_title(self, title, appid=None):
+            return f"plain-{title}"
+
+        def prices_for_plains(self, plains):
+            return {}
+
+    monkeypatch.setattr(fetch_itad, "catalog_path", lambda name: catalogs / str(name))
+    monkeypatch.setattr(fetch_itad, "itad_path", lambda: existing)
+    monkeypatch.setattr(fetch_itad, "resolve_env", lambda *a, **k: "test-key")
+    monkeypatch.setattr(fetch_itad, "ensure_fx_rates", lambda **k: None)
+    monkeypatch.setattr(fetch_itad, "ItadClient", _Client)
+    monkeypatch.setattr(fetch_itad, "refresh_wishlist_fx_after_itad", lambda *_a, **_k: (0, 0))
+    monkeypatch.setattr("sys.argv", ["fetchers.fetch_itad.py"])
+
+    assert fetch_itad.main() == 2
+    assert json.loads(existing.read_text(encoding="utf-8")) == prior

--- a/tests/test_fetcher_progress.py
+++ b/tests/test_fetcher_progress.py
@@ -81,6 +81,20 @@ def test_refuse_drift_accepts_int_count(tmp_path):
     assert refuse_drift_result(120, label="x", allow_drift=False, output_path=out) is None
 
 
+def test_refuse_drift_reads_items_and_itad_baselines(tmp_path):
+    claims = tmp_path / "free_claims.json"
+    claims.write_text(json.dumps({"items": [{}] * 20}), encoding="utf-8")
+    assert refuse_drift_result(2, label="claims", allow_drift=False, output_path=claims) == 3
+
+    itad = tmp_path / "itad_prices.json"
+    itad.write_text(
+        json.dumps({"count": 40, "by_key": {str(i): {} for i in range(40)}}),
+        encoding="utf-8",
+    )
+    assert refuse_drift_result(5, label="itad", allow_drift=False, output_path=itad) == 3
+    assert refuse_drift_result(30, label="itad", allow_drift=False, output_path=itad) is None
+
+
 def test_pct_partial_and_total():
     assert pct(0, 10) == "0%"
     assert pct(5, 10) == "50%"


### PR DESCRIPTION
## Summary
- Extend `_previous_game_count` to claims (`items`) and ITAD (`count` / `by_key`)
- Refuse empty ITAD priced rows and sharp shrinks before writing `itad_prices.json` (never exit 2 after write)
- Align `fetch_free_claims` with shared empty/drift helpers + `--allow-drift`

## Test plan
- [x] pytest free-claims / itad empty / fetcher progress
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty or unexpectedly reduced fetch results from overwriting existing output files.
  * Added protection for free-claims and price data when result counts drop sharply.
  * Improved compatibility with multiple catalog formats when validating result counts.

* **New Features**
  * Added an option to allow writing results despite detected catalog drift.
  * Added support for allowing empty results where appropriate.

* **Tests**
  * Added coverage for empty-result protection, drift detection, override behavior, and preserving previous output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->