### PR TITLE
Fix Cloud sync Sync now button visibility

### DIFF
--- a/js/connections.js
+++ b/js/connections.js
@@ -532,10 +532,14 @@ function renderConnPrefs() {
     capabilityStatus("cloud_sync_mirror") === "live";
   if (cloudWrap) cloudWrap.hidden = !showCloudMirror;
   if (syncBtn) {
+    syncBtn.classList.toggle("hidden", !showCloudMirror);
     syncBtn.hidden = !showCloudMirror;
     syncBtn.disabled = !showCloudMirror || getProSettings().cloudMirrorEnabled !== true;
   }
-  if (importBtn) importBtn.hidden = !showCloudMirror;
+  if (importBtn) {
+    importBtn.classList.toggle("hidden", !showCloudMirror);
+    importBtn.hidden = !showCloudMirror;
+  }
   if (cloudToggle && showCloudMirror) {
     cloudToggle.checked = getProSettings().cloudMirrorEnabled === true;
   }


### PR DESCRIPTION
## Summary
- Toggle the Tailwind ``hidden`` class when showing Connections Sync now / Import (``.hidden`` property alone left the CSS class in place)

## Test plan
- [ ] CAP=live + Pro + Cloud sync: Sync now and Import visible under prefs
- [ ] Capability soon: both stay hidden