### PR TITLE
Declutter Connections top prefs strip

### DIFF
--- a/app.css
+++ b/app.css
@@ -11167,20 +11167,16 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
 }
 .conn-hint-row {
   display: flex;
+  flex-direction: column;
   align-items: stretch;
   gap: 10px;
   margin: 0 0 14px;
 }
-.conn-hint-row > .conn-hint,
-.conn-hint-row > .conn-prefs {
-  flex: 1 1 50%;
-  min-width: 0;
+.conn-hint-row > .conn-hint {
   margin: 0;
 }
-@media (max-width: 1023.98px) {
-  .conn-hint-row {
-    flex-direction: column;
-  }
+.conn-hint-row > .conn-prefs {
+  margin: 0;
 }
 .conn-prefs {
   margin: 0.5rem 0 0.85rem;
@@ -11194,8 +11190,27 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
   flex-direction: row;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: flex-start;
   gap: 0.35rem 0.85rem;
+}
+.conn-cloud-prefs {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.conn-cloud-prefs[hidden] {
+  display: none;
+}
+.conn-cloud-prefs-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.75rem;
+}
+.conn-cloud-prefs .conn-prefs-import {
+  flex-basis: auto;
+  margin: 0;
+  align-self: center;
 }
 .conn-prefs-note {
   flex-basis: 100%;
@@ -11203,7 +11218,7 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
   font-size: 0.66rem;
   line-height: 1.35;
   color: var(--text-mute, #94a3b8);
-  text-align: right;
+  text-align: left;
 }
 .conn-prefs-note--pro {
   color: var(--accent, #38bdf8);
@@ -14617,13 +14632,12 @@ body {
 }
 
 .conn-prefs-note--mirror-status {
-  color: var(--text-dim, #cbd5e1);
+  text-align: left;
 }
 .conn-prefs-note--mirror-status.conn-prefs-note--error {
   color: var(--danger, #f87171);
 }
 .conn-prefs-import {
-  flex-basis: 100%;
   margin: 0.35rem 0 0;
   padding: 0.35rem 0.65rem;
   border-radius: 0.4rem;
@@ -14633,7 +14647,6 @@ body {
   font-size: 0.72rem;
   font-weight: 600;
   cursor: pointer;
-  align-self: flex-end;
 }
 .conn-prefs-import:hover {
   border-color: var(--accent, #38bdf8);

--- a/index.html
+++ b/index.html
@@ -1005,7 +1005,7 @@
               </label>
               <label
                 class="fh-toggle"
-                title="While BAKLOG is open - including minimized or unfocused - quietly refresh any store whose data is older than 24 hours, one store at a time (~30 min apart). Does not run while fully closed."
+                title="While BAKLOG is open - including minimized or unfocused - quietly refresh any store whose data is older than 24 hours, one store at a time (~30 min apart). Does not run while fully closed. Pro: background refresh keeps stale stores fresh even when BAKLOG is closed to the tray."
               >
                 <input
                   id="autoFetchStale24hToggle"
@@ -1024,39 +1024,48 @@
                   type="checkbox"
                   class="rounded"
                 />
-                Share anonymous usage counts (helps fund BAKLOG)
+                Share anonymous usage counts
               </label>
-              <label
-                class="fh-toggle"
-                id="cloudMirrorToggleWrap"
-                hidden
-                title="Upload catalog JSON to your BAKLOG account with Sync now. Credentials stay on this PC. Browse read-only at baklog.app/mirror."
-              >
-                <input id="cloudMirrorEnabledToggle" type="checkbox" class="rounded" />
-                Cloud sync to your account
-              </label>
-              <p id="cloudMirrorPlanNote" class="conn-prefs-note" hidden></p>
+              <p id="bgRefreshPlanNote" class="conn-prefs-note" hidden></p>
+            </div>
+            <div
+              id="connCloudPrefs"
+              class="conn-prefs conn-cloud-prefs"
+              role="group"
+              aria-label="Cloud sync"
+              hidden
+            >
+              <div class="conn-cloud-prefs-row">
+                <label
+                  class="fh-toggle"
+                  id="cloudMirrorToggleWrap"
+                  title="Upload catalog JSON to your BAKLOG account with Sync now. Credentials stay on this PC. Browse read-only at baklog.app/mirror."
+                >
+                  <input id="cloudMirrorEnabledToggle" type="checkbox" class="rounded" />
+                  Cloud sync to your account
+                </label>
+                <button
+                  type="button"
+                  id="cloudMirrorSyncBtn"
+                  class="conn-prefs-import hidden"
+                  title="Upload library catalogs and personal data to your cloud mirror now"
+                >
+                  Sync now
+                </button>
+                <button
+                  type="button"
+                  id="cloudMirrorImportBtn"
+                  class="conn-prefs-import hidden"
+                  title="Replace local catalogs and personal data with your cloud mirror"
+                >
+                  Import from cloud mirror
+                </button>
+              </div>
               <p
                 id="cloudMirrorUploadStatus"
                 class="conn-prefs-note conn-prefs-note--mirror-status"
                 hidden
               ></p>
-              <button
-                type="button"
-                id="cloudMirrorSyncBtn"
-                class="conn-prefs-import hidden"
-                title="Upload library catalogs and personal data to your cloud mirror now"
-              >
-                Sync now
-              </button>
-              <button
-                type="button"
-                id="cloudMirrorImportBtn"
-                class="conn-prefs-import hidden"
-                title="Replace local catalogs and personal data with your cloud mirror"
-              >
-                Import from cloud mirror
-              </button>
               <dialog
                 id="cloudMirrorImportDialog"
                 class="conn-mirror-import-dialog"
@@ -1082,7 +1091,6 @@
                   </div>
                 </form>
               </dialog>
-              <p id="bgRefreshPlanNote" class="conn-prefs-note" hidden></p>
             </div>
           </div>
           <div id="connOnboard" hidden></div>

--- a/js/connections.js
+++ b/js/connections.js
@@ -520,9 +520,9 @@ function renderConnPrefs() {
   if (stale24h) stale24h.checked = state.prefs.autoFetchStale24h === true;
   if (shareStats) shareStats.checked = state.prefs.shareAnonStats === true;
 
+  const cloudStrip = document.getElementById("connCloudPrefs");
   const cloudWrap = document.getElementById("cloudMirrorToggleWrap");
   const cloudToggle = document.getElementById("cloudMirrorEnabledToggle");
-  const cloudNote = document.getElementById("cloudMirrorPlanNote");
   const syncBtn = document.getElementById("cloudMirrorSyncBtn");
   const importBtn = document.getElementById("cloudMirrorImportBtn");
   const showCloudMirror =
@@ -530,6 +530,7 @@ function renderConnPrefs() {
     isAccountAuthMode() &&
     !!getAccessToken() &&
     capabilityStatus("cloud_sync_mirror") === "live";
+  if (cloudStrip) cloudStrip.hidden = !showCloudMirror;
   if (cloudWrap) cloudWrap.hidden = !showCloudMirror;
   if (syncBtn) {
     syncBtn.classList.toggle("hidden", !showCloudMirror);
@@ -542,17 +543,6 @@ function renderConnPrefs() {
   }
   if (cloudToggle && showCloudMirror) {
     cloudToggle.checked = getProSettings().cloudMirrorEnabled === true;
-  }
-  if (cloudNote) {
-    if (showCloudMirror) {
-      cloudNote.hidden = false;
-      cloudNote.classList.add("conn-prefs-note--pro");
-      cloudNote.textContent = getProSettings().cloudMirrorEnabled
-        ? "Cloud sync is on. Use Sync now to upload catalogs (credentials stay on this PC). Browse at baklog.app/mirror."
-        : "Enable Cloud sync, then use Sync now to upload catalog JSON to your account (credentials stay on this PC).";
-    } else {
-      cloudNote.hidden = true;
-    }
   }
 
   const note = document.getElementById("bgRefreshPlanNote");

--- a/tests/connections-rail-render.test.js
+++ b/tests/connections-rail-render.test.js
@@ -294,17 +294,22 @@ describe('cloud mirror prefs visibility', () => {
       <div id="connOnboard" hidden></div>
       <nav id="connRail" role="listbox"></nav>
       <div id="connPane"></div>
-      <label id="cloudMirrorToggleWrap" hidden>
-        <input id="cloudMirrorEnabledToggle" type="checkbox" />
-      </label>
-      <p id="cloudMirrorPlanNote" hidden></p>
-      <p id="cloudMirrorUploadStatus" hidden></p>
-      <button id="cloudMirrorSyncBtn" type="button" hidden>Sync now</button>
-      <button id="cloudMirrorImportBtn" type="button" hidden>Import</button>
-      <p id="bgRefreshPlanNote" hidden></p>
-      <input id="autoFetchOnConnectToggle" type="checkbox" />
-      <input id="autoFetchStale24hToggle" type="checkbox" />
-      <input id="shareAnonStatsToggle" type="checkbox" />
+      <div id="connPrefs" class="conn-prefs">
+        <input id="autoFetchOnConnectToggle" type="checkbox" />
+        <input id="autoFetchStale24hToggle" type="checkbox" />
+        <input id="shareAnonStatsToggle" type="checkbox" />
+        <p id="bgRefreshPlanNote" hidden></p>
+      </div>
+      <div id="connCloudPrefs" class="conn-prefs conn-cloud-prefs" hidden>
+        <div class="conn-cloud-prefs-row">
+          <label id="cloudMirrorToggleWrap" hidden>
+            <input id="cloudMirrorEnabledToggle" type="checkbox" />
+          </label>
+          <button id="cloudMirrorSyncBtn" type="button" class="hidden" hidden>Sync now</button>
+          <button id="cloudMirrorImportBtn" type="button" class="hidden" hidden>Import</button>
+        </div>
+        <p id="cloudMirrorUploadStatus" hidden></p>
+      </div>
     `;
   }
 
@@ -320,10 +325,10 @@ describe('cloud mirror prefs visibility', () => {
     const { refreshConnections } = await import('../js/connections.js');
     await refreshConnections();
 
+    expect(document.getElementById('connCloudPrefs')?.hidden).toBe(true);
     expect(document.getElementById('cloudMirrorToggleWrap')?.hidden).toBe(true);
     expect(document.getElementById('cloudMirrorImportBtn')?.hidden).toBe(true);
     expect(document.getElementById('cloudMirrorSyncBtn')?.hidden).toBe(true);
-    expect(document.getElementById('cloudMirrorPlanNote')?.hidden).toBe(true);
   });
 
   it('shows cloud sync controls when capability is live for Pro account', async () => {
@@ -339,6 +344,7 @@ describe('cloud mirror prefs visibility', () => {
     const { refreshConnections } = await import('../js/connections.js');
     await refreshConnections();
 
+    expect(document.getElementById('connCloudPrefs')?.hidden).toBe(false);
     expect(document.getElementById('cloudMirrorToggleWrap')?.hidden).toBe(false);
     expect(document.getElementById('cloudMirrorImportBtn')?.hidden).toBe(false);
     expect(document.getElementById('cloudMirrorSyncBtn')?.hidden).toBe(false);


### PR DESCRIPTION
## Summary
- Stack Connections hint, fetch prefs, and Cloud sync as full-width strips (no empty left column)
- Move Cloud sync toggle / Sync now / Import into ``#connCloudPrefs`` one-row strip with status below
- Drop redundant cloud plan note; shorten share-anon label

## Test plan
- [x] ``npm test -- tests/connections-rail-render.test.js``
- [ ] CAP=live + Pro: cloud strip shows toggle + Sync now + Import inline
- [ ] Free / soon: cloud strip hidden; fetch prefs still balanced under hint
- [ ] Phone/tablet: stacked strips still readable