### PR TITLE
Grant authenticated privileges on cloud_mirror_snapshots

### DIFF
--- a/landing/sql/cloud_mirror.sql
+++ b/landing/sql/cloud_mirror.sql
@@ -40,6 +40,10 @@ alter table public.cloud_mirror_snapshots
 
 alter table public.cloud_mirror_snapshots enable row level security;
 
+-- Table privileges (RLS alone is not enough; PostgREST needs GRANT for authenticated).
+-- Owner E2E 2026-09-08: without this, upserts return 42501 permission denied.
+grant select, insert, update on public.cloud_mirror_snapshots to authenticated;
+
 -- JWT plan helper (Pro / paid / premium aliases).
 create or replace function public.mirror_is_pro_jwt()
 returns boolean


### PR DESCRIPTION
## Summary
- Add `GRANT SELECT, INSERT, UPDATE ON public.cloud_mirror_snapshots TO authenticated` to `landing/sql/cloud_mirror.sql`.
- Owner E2E hit HTTP 403 / Postgres 42501 until this was run manually in the SQL editor; keep the script complete for fresh projects and re-runs.

## Test plan
- [ ] Re-run (or skim) `landing/sql/cloud_mirror.sql` in Supabase SQL editor on a project that already has the table - grant is idempotent.
- [ ] With Pro + CAP live, Sync now uploads with empty `errors` in `[cloud_mirror] upload flush`.
- [ ] Confirm baklog.app/mirror can list snapshots after sign-in (wait if auth-config 429).
