### PR TITLE
Raise cloud mirror page rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Fixed
 
+- Cloud mirror page no longer hits "Too many requests" when loading a full library (higher limits for `/api/mirror` and `/api/auth-config`).
 - Ubisoft wishlist Connect retries once on a transient browser navigation error before failing.
 - Add-game dialog footer uses the shared modal actions layout so body copy cannot overlap buttons on short viewports.
 

--- a/landing/README.md
+++ b/landing/README.md
@@ -159,7 +159,7 @@ Sign-up and password-reset emails redirect to **baklog.app**, not `127.0.0.1`, s
 
 - Never set `BAKLOG_SUPABASE_ANON_KEY` to the **service_role** key. Use the public **anon** key only.
 - The anon key is public by design (same as the local app `/api/config`). The security boundary is Supabase Auth settings + RLS on any `anon`-accessible tables.
-- `/api/auth-config` is rate-limited by client IP (5 requests per minute), same as `/api/subscribe`. Production requires Vercel KV / Upstash credentials or the endpoint returns `503`.
+- `/api/auth-config` is rate-limited by client IP (60 requests per minute). `/api/mirror` allows 120/min so a full library boot (list + per-artifact GETs) fits. Write endpoints (`/api/subscribe`, `/api/report`, `/api/metrics`) stay at 5/min. Production requires Vercel KV / Upstash credentials or these endpoints return `503`.
 
 Deploy landing, then add redirect URLs in Supabase before shipping an app build that points at these pages.
 
@@ -178,7 +178,7 @@ Supabase sends confirm / reset / invite mail. Branding is configured in the **Su
 
 ## Rate limiting (required for production)
 
-`/api/subscribe` rate-limits by client IP (5 requests per minute). `/api/auth-config` uses the same limit and KV requirement. Production uses a **distributed** store so limits survive Vercel cold starts and scale-out. Without KV credentials in production, `/api/subscribe` and `/api/auth-config` return `503 Server not configured`.
+`/api/subscribe` rate-limits by client IP (5 requests per minute). `/api/auth-config` allows 60/min (public anon config for `/mirror` and `/auth-reset`). `/api/mirror` allows 120/min so one library load does not trip the limit. Production uses a **distributed** store so limits survive Vercel cold starts and scale-out. Without KV credentials in production, `/api/subscribe` and `/api/auth-config` return `503 Server not configured`.
 
 1. Vercel project (root `landing/`) → **Storage** → **Create Database** → **KV** → connect to this project.
 2. Redeploy so Production receives the auto-injected credentials below.

--- a/landing/api/_rate-limit.js
+++ b/landing/api/_rate-limit.js
@@ -2,6 +2,7 @@
 // Falls back to in-memory buckets in dev/test when KV creds are absent.
 
 const RATE_WINDOW_MS = 60_000;
+/** Default max for write-ish / abuse-sensitive endpoints (subscribe, report, metrics). */
 const RATE_MAX = 5;
 
 /** @type {Map<string, { start: number, count: number }>} */
@@ -23,8 +24,8 @@ function isProductionWithoutKv() {
   return process.env.VERCEL_ENV === "production" && !kvCredentials();
 }
 
-function isRateLimitedInMemory(ip, namespace) {
-  const key = `${namespace}:${ip}`;
+function isRateLimitedInMemory(ip, namespace, max) {
+  const key = `${namespace}:${max}:${ip}`;
   const now = Date.now();
   let entry = memoryBuckets.get(key);
   if (!entry || now - entry.start > RATE_WINDOW_MS) {
@@ -37,11 +38,12 @@ function isRateLimitedInMemory(ip, namespace) {
       if (now - bucket.start > RATE_WINDOW_MS) memoryBuckets.delete(bucketKey);
     }
   }
-  return entry.count > RATE_MAX;
+  return entry.count > max;
 }
 
-async function getKvLimiter(namespace) {
-  let limiter = kvLimiters.get(namespace);
+async function getKvLimiter(namespace, max) {
+  const cacheKey = `${namespace}:${max}`;
+  let limiter = kvLimiters.get(cacheKey);
   if (limiter) return limiter;
 
   const creds = kvCredentials();
@@ -55,30 +57,33 @@ async function getKvLimiter(namespace) {
   const redis = new Redis({ url: creds.url, token: creds.token });
   limiter = new Ratelimit({
     redis,
-    limiter: Ratelimit.slidingWindow(RATE_MAX, `${RATE_WINDOW_MS} ms`),
-    prefix: `${namespace}:rate`,
+    limiter: Ratelimit.slidingWindow(max, `${RATE_WINDOW_MS} ms`),
+    // Include max in prefix so raising a limit does not reuse a stale low bucket.
+    prefix: `${namespace}:rate:${max}`,
   });
-  kvLimiters.set(namespace, limiter);
+  kvLimiters.set(cacheKey, limiter);
   return limiter;
 }
 
 /**
  * @param {string} ip
- * @param {{ namespace?: string }} [options]
+ * @param {{ namespace?: string, max?: number }} [options]
  * @returns {Promise<{ limited: boolean, misconfigured: boolean }>}
  */
-export async function checkRateLimit(ip, { namespace = "default" } = {}) {
+export async function checkRateLimit(ip, { namespace = "default", max = RATE_MAX } = {}) {
+  const limit = Number.isFinite(max) && max > 0 ? Math.floor(max) : RATE_MAX;
+
   if (isProductionWithoutKv()) {
     return { limited: false, misconfigured: true };
   }
 
-  const limiter = await getKvLimiter(namespace);
+  const limiter = await getKvLimiter(namespace, limit);
   if (!limiter) {
     if (!loggedMemoryFallback) {
       console.warn("rate-limit: using in-memory fallback");
       loggedMemoryFallback = true;
     }
-    return { limited: isRateLimitedInMemory(ip, namespace), misconfigured: false };
+    return { limited: isRateLimitedInMemory(ip, namespace, limit), misconfigured: false };
   }
 
   const { success } = await limiter.limit(ip);

--- a/landing/api/auth-config.js
+++ b/landing/api/auth-config.js
@@ -25,7 +25,8 @@ export default {
     }
 
     const ip = clientIp(request);
-    const rate = await checkRateLimit(ip, { namespace: "auth-config" });
+    // Public read of anon key; allow enough reloads for /mirror and /auth-reset.
+    const rate = await checkRateLimit(ip, { namespace: "auth-config", max: 60 });
     if (rate.misconfigured) {
       console.error("auth-config: missing KV rate-limit credentials in production");
       return Response.json({ error: "Server not configured" }, { status: 503 });

--- a/landing/api/mirror.js
+++ b/landing/api/mirror.js
@@ -88,7 +88,8 @@ export default {
     }
 
     const ip = clientIp(request);
-    const rate = await checkRateLimit(ip, { namespace: "mirror" });
+    // Library boot fetches list + one GET per catalog artifact (often 20+).
+    const rate = await checkRateLimit(ip, { namespace: "mirror", max: 120 });
     if (rate.misconfigured) {
       return jsonResponse({ error: "Server not configured" }, 503, request);
     }

--- a/landing/mirror.js
+++ b/landing/mirror.js
@@ -70,10 +70,30 @@ function statusClass(status) {
   return 'mirror-status';
 }
 
+const AUTH_CONFIG_CACHE_KEY = 'baklog-mirror-auth-config';
+
 async function loadConfig() {
+  try {
+    const cached = sessionStorage.getItem(AUTH_CONFIG_CACHE_KEY);
+    if (cached) {
+      const parsed = JSON.parse(cached);
+      if (parsed?.supabaseUrl && parsed?.supabaseAnonKey) return parsed;
+    }
+  } catch {
+    // ignore cache parse / quota errors
+  }
   const res = await fetch('/api/auth-config');
+  if (res.status === 429) {
+    throw new Error('Too many requests - wait about a minute, then refresh once.');
+  }
   if (!res.ok) throw new Error('Auth not configured');
-  return res.json();
+  const cfg = await res.json();
+  try {
+    sessionStorage.setItem(AUTH_CONFIG_CACHE_KEY, JSON.stringify(cfg));
+  } catch {
+    // ignore quota
+  }
+  return cfg;
 }
 
 async function mirrorFetch(path, token, profile) {
@@ -93,7 +113,10 @@ async function mirrorFetch(path, token, profile) {
     body = null;
   }
   if (!res.ok) {
-    const msg = body?.error || `Mirror request failed (${res.status})`;
+    const msg =
+      res.status === 429
+        ? 'Too many requests - wait about a minute, then refresh once.'
+        : (body?.error || `Mirror request failed (${res.status})`);
     const err = new Error(msg);
     err.status = res.status;
     throw err;
@@ -251,9 +274,9 @@ async function boot() {
       return;
     }
     showPanel('signin');
-  } catch {
+  } catch (err) {
     showPanel('signin');
-    showAlert('Cloud mirror sign-in is not available right now.', { error: true });
+    showAlert(err?.message || 'Cloud mirror sign-in is not available right now.', { error: true });
   }
 }
 

--- a/tests/auth-config.test.js
+++ b/tests/auth-config.test.js
@@ -74,11 +74,11 @@ describe('landing/api/auth-config.js', () => {
     expect(res.status).toBe(405);
   });
 
-  it('rate limits more than five requests per IP per minute', async () => {
+  it('rate limits more than sixty requests per IP per minute', async () => {
     process.env.BAKLOG_SUPABASE_URL = 'https://demo.supabase.co';
     process.env.BAKLOG_SUPABASE_ANON_KEY = 'anon';
     const ip = '192.168.2.99';
-    for (let i = 0; i < 5; i += 1) {
+    for (let i = 0; i < 60; i += 1) {
       const res = await handleAuthConfig(makeRequest({ ip }));
       expect(res.status).toBe(200);
     }


### PR DESCRIPTION
## Summary
- `/api/mirror` was capped at 5 requests/min while the hosted viewer does list + one GET per catalog artifact (often 20+), so a successful Sync now still showed **Too many requests** on baklog.app/mirror.
- Raise mirror to 120/min and auth-config to 60/min (new KV prefix so old buckets do not stick). Cache auth-config in sessionStorage; clearer 429 copy.

## Test plan
- [x] `npx vitest run tests/auth-config.test.js`
- [ ] After Vercel deploy: hard-refresh baklog.app/mirror once, sign in, confirm library table loads without 429.
- [ ] Rapid reload still eventually 429s at the new caps (not after 5 boots).
