### PR TITLE
Cap mirror brand size for denser header match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Changed
 
-- Hosted cloud library (`/mirror`) header uses the same brand lockup as the desktop app (logo, wordmark, Cloud chip); Refresh and Sign out stay in the header.
+- Hosted cloud library (`/mirror`) header uses the same brand lockup as the desktop app (logo, wordmark, Cloud chip) at a denser size so it does not read oversized without the app nav beside it; Refresh and Sign out stay in the header.
 - Free claims feed refreshed; stale approved-only ids pruned from the maintainer list.
 - Library watch no longer ships with a default Pico Park watch; only watches you arm stay armed.
 - Pro tab label is Back BAKLOG; Pro page hero is a flat brand strip; sample sponsor games are out of the shipped feed.

--- a/landing/mirror.css
+++ b/landing/mirror.css
@@ -79,7 +79,9 @@ a {
 
 .brand-logo-mark {
   display: inline-flex;
-  height: 30px;
+  /* 26px matches the app phone/header-sheet density; 30px reads oversized
+     when the brand sits alone without view tabs beside it. */
+  height: 26px;
   flex-shrink: 0;
   color: #fff;
 }
@@ -94,7 +96,8 @@ a {
   fill: currentColor;
 }
 
-/* Match app: text-2xl (1.5rem), md:text-3xl (1.875rem). */
+/* Cap at text-2xl (1.5rem). The app also uses md:text-3xl, but that only
+   balances next to tabs/actions - alone on /mirror it looks scaled up. */
 .brand-wordmark {
   margin: 0;
   font-size: 1.5rem;
@@ -103,12 +106,6 @@ a {
   line-height: 1;
   white-space: nowrap;
   color: #fff;
-}
-
-@media (min-width: 768px) {
-  .brand-wordmark {
-    font-size: 1.875rem;
-  }
 }
 
 .brand-beta {
@@ -442,5 +439,20 @@ table.mirror-table {
   .mirror-table th:nth-child(5),
   .mirror-table td:nth-child(5) {
     display: none;
+  }
+}
+
+@media (max-width: 400px) {
+  .brand-wordmark {
+    font-size: 1.125rem;
+  }
+
+  .brand-logo-mark {
+    height: 22px;
+  }
+
+  .brand-beta {
+    font-size: 0.52rem;
+    padding: 0.14em 0.35em;
   }
 }


### PR DESCRIPTION
## Summary
- Measured prod wordmark at **30px** (`md:text-3xl`) with a **30px** logo - same CSS as the app, but on `/mirror` the brand sits alone (no tabs), so it reads oversized.
- Cap wordmark at **1.5rem** (`text-2xl`) and logo at **26px**; keep phone breakpoints aligned with the app sheet sizes.

## Test plan
- [ ] Hard-refresh baklog.app/mirror: BAKLOG + logo look closer to desktop header weight
- [ ] Cloud chip still present; no Beta
