### PR TITLE
Virtualize hosted /mirror table + geometry audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ scripts/drill-geometry-last-run.json
 scripts/modal-geometry-last-run.json
 scripts/library-count-geometry-last-run.json
 scripts/responsive-overflow-last-run.json
+scripts/mirror-overflow-last-run.json
 
 # Local SEO operator (OpenSEO compose, secrets, crawl snapshots). Commit seo-god.json only.
 .seo-god/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Fixed
 
+- Hosted cloud library scrolls large catalogs with virtual rows so the page does not freeze when thousands of games load.
 - Cloud mirror page no longer hits "Too many requests" when loading a full library (higher limits for `/api/mirror` and `/api/auth-config`).
 - Ubisoft wishlist Connect retries once on a transient browser navigation error before failing.
 - Add-game dialog footer uses the shared modal actions layout so body copy cannot overlap buttons on short viewports.

--- a/landing/mirror-virtual.js
+++ b/landing/mirror-virtual.js
@@ -1,0 +1,39 @@
+/** Pure virtual-window math for hosted /mirror (no DOM). */
+
+export const MIRROR_VIRTUAL_THRESHOLD = 60;
+export const MIRROR_VIRTUAL_OVERSCAN = 12;
+export const MIRROR_ROW_HEIGHT_DESKTOP = 40;
+export const MIRROR_ROW_HEIGHT_PHONE = 120;
+
+/**
+ * @param {number} listLen
+ * @param {{ scrollY: number, viewportH: number, rowHeight: number, tableTop: number, overscan?: number }} opts
+ * @returns {{ start: number, end: number }}
+ */
+export function computeMirrorVirtualRange(listLen, opts) {
+  const len = Math.max(0, Math.floor(Number(listLen) || 0));
+  if (len <= 0) return { start: 0, end: 0 };
+  const rh = Math.max(1, Number(opts.rowHeight) || MIRROR_ROW_HEIGHT_DESKTOP);
+  const overscan = Number.isFinite(opts.overscan) ? opts.overscan : MIRROR_VIRTUAL_OVERSCAN;
+  const scrollY = Math.max(0, Number(opts.scrollY) || 0);
+  const viewportH = Math.max(1, Number(opts.viewportH) || 1);
+  const tableTop = Number(opts.tableTop) || 0;
+
+  let start = Math.max(0, Math.floor((scrollY - tableTop) / rh) - overscan);
+  let end = Math.min(len, Math.ceil((scrollY + viewportH - tableTop) / rh) + overscan);
+  if (end <= start) {
+    end = Math.min(len, start + Math.ceil(viewportH / rh) + overscan * 2);
+  }
+  if (start >= len) {
+    const windowRows = Math.ceil(viewportH / rh) + overscan * 2;
+    start = Math.max(0, len - windowRows);
+    end = len;
+  }
+  start = Math.max(0, Math.min(start, len));
+  end = Math.max(start, Math.min(end, len));
+  return { start, end };
+}
+
+export function usesMirrorVirtualScroll(listLen, threshold = MIRROR_VIRTUAL_THRESHOLD) {
+  return (Number(listLen) || 0) > threshold;
+}

--- a/landing/mirror.css
+++ b/landing/mirror.css
@@ -424,6 +424,17 @@ table.mirror-table {
   display: none !important;
 }
 
+.mirror-virtual-spacer td {
+  padding: 0 !important;
+  border: none !important;
+  line-height: 0;
+  background: transparent !important;
+}
+
+.mirror-virtual-spacer:hover td {
+  background: transparent !important;
+}
+
 /* --- Tablet --- */
 @media (max-width: 1023.98px) {
   .mirror-toolbar {
@@ -526,6 +537,16 @@ table.mirror-table {
     border: 1px solid var(--border-subtle);
     border-radius: 0.5rem;
     background: var(--bg-panel);
+    min-height: 7.5rem;
+  }
+
+  .mirror-table tbody tr.mirror-virtual-spacer {
+    margin: 0;
+    padding: 0;
+    border: none;
+    border-radius: 0;
+    background: transparent;
+    min-height: 0;
   }
 
   .mirror-table tbody tr:hover {

--- a/landing/mirror.js
+++ b/landing/mirror.js
@@ -8,6 +8,12 @@ import {
   sortMirrorRows,
   summarizeMirrorRows,
 } from './mirror-merge.js';
+import {
+  MIRROR_ROW_HEIGHT_DESKTOP,
+  MIRROR_ROW_HEIGHT_PHONE,
+  computeMirrorVirtualRange,
+  usesMirrorVirtualScroll,
+} from './mirror-virtual.js';
 
 const signInPanel = document.getElementById('mirrorSignInPanel');
 const libraryPanel = document.getElementById('mirrorLibraryPanel');
@@ -25,11 +31,23 @@ const storeFilter = document.getElementById('mirrorStoreFilter');
 const tableBody = document.getElementById('mirrorTableBody');
 const emptyFiltered = document.getElementById('mirrorEmptyFiltered');
 const lead = document.getElementById('mirrorLead');
+const tableWrap = document.querySelector('.mirror-table-wrap');
+
+const PHONE_MQ = '(max-width: 639.98px), (max-height: 480px) and (hover: none)';
+const CATALOG_FETCH_CONCURRENCY = 5;
+const COLSPAN = 5;
 
 /** @type {ReturnType<typeof mergeMirrorLibrary>} */
 let allRows = [];
+/** @type {ReturnType<typeof mergeMirrorLibrary>} */
+let filteredRows = [];
 /** @type {import('@supabase/supabase-js').SupabaseClient | null} */
 let supabase = null;
+
+let _rowHeightPx = MIRROR_ROW_HEIGHT_DESKTOP;
+let _virtualWindow = { start: 0, end: 0 };
+let _virtualScrollRaf = 0;
+let _virtualScrollBound = false;
 
 function showAlert(message, { error = false } = {}) {
   if (!message) {
@@ -68,6 +86,22 @@ function statusClass(status) {
   if (status === 'finished') return 'mirror-status mirror-status--finished';
   if (status === 'next') return 'mirror-status mirror-status--next';
   return 'mirror-status';
+}
+
+function isPhoneLayout() {
+  return typeof matchMedia === 'function' && matchMedia(PHONE_MQ).matches;
+}
+
+function estimateRowHeight() {
+  return isPhoneLayout() ? MIRROR_ROW_HEIGHT_PHONE : MIRROR_ROW_HEIGHT_DESKTOP;
+}
+
+function refreshMeasuredRowHeight() {
+  const row = tableBody?.querySelector('tr[data-row-index]');
+  if (!row) return;
+  const h = row.getBoundingClientRect().height;
+  if (!(h > 0) || Math.abs(h - _rowHeightPx) < 0.5) return;
+  _rowHeightPx = h;
 }
 
 const AUTH_CONFIG_CACHE_KEY = 'baklog-mirror-auth-config';
@@ -124,6 +158,27 @@ async function mirrorFetch(path, token, profile) {
   return body;
 }
 
+/**
+ * @template T
+ * @param {T[]} items
+ * @param {number} concurrency
+ * @param {(item: T, index: number) => Promise<unknown>} worker
+ */
+async function mapPool(items, concurrency, worker) {
+  const results = new Array(items.length);
+  let next = 0;
+  const limit = Math.max(1, Math.min(concurrency, items.length || 1));
+  async function run() {
+    while (next < items.length) {
+      const i = next;
+      next += 1;
+      results[i] = await worker(items[i], i);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, () => run()));
+  return results;
+}
+
 function populateFilters(rows) {
   const summary = summarizeMirrorRows(rows);
   const currentStatus = statusFilter.value;
@@ -150,8 +205,78 @@ function populateFilters(rows) {
   storeFilter.value = [...storeFilter.options].some((o) => o.value === currentStore) ? currentStore : '';
 }
 
+function rowHtml(row, index) {
+  const note = row.notes ? `<div class="mirror-note">${escapeHtml(row.notes)}</div>` : '';
+  return `<tr data-row-index="${index}">
+        <td data-label="Title">${escapeHtml(row.title)}${note}</td>
+        <td data-label="Store">${escapeHtml(row.storeLabel)}</td>
+        <td data-label="Status"><span class="${statusClass(row.status)}">${escapeHtml(row.statusLabel)}</span></td>
+        <td class="col-num" data-label="Playtime">${formatHours(row.playtimeHours)}</td>
+        <td class="col-num" data-label="HLTB">${formatHours(row.hltbMain)}</td>
+      </tr>`;
+}
+
+function spacerHtml(kind, heightPx) {
+  const h = Math.max(0, heightPx);
+  return `<tr class="mirror-virtual-spacer mirror-virtual-spacer--${kind}" aria-hidden="true"><td colspan="${COLSPAN}" style="height:${h}px"></td></tr>`;
+}
+
+function tableTopY() {
+  const el = tableWrap || tableBody?.closest('table');
+  if (!el) return 0;
+  return el.getBoundingClientRect().top + window.scrollY;
+}
+
+function ensureVirtualScrollBound() {
+  if (_virtualScrollBound) return;
+  _virtualScrollBound = true;
+  const onScrollOrResize = () => {
+    if (_virtualScrollRaf) return;
+    _virtualScrollRaf = requestAnimationFrame(() => {
+      _virtualScrollRaf = 0;
+      if (!usesMirrorVirtualScroll(filteredRows.length)) return;
+      paintMirrorSlice();
+    });
+  };
+  window.addEventListener('scroll', onScrollOrResize, { passive: true });
+  window.addEventListener('resize', onScrollOrResize, { passive: true });
+}
+
+function paintMirrorSlice() {
+  const list = filteredRows;
+  const len = list.length;
+  if (!usesMirrorVirtualScroll(len)) {
+    tableBody.innerHTML = list.map((row, i) => rowHtml(row, i)).join('');
+    _virtualWindow = { start: 0, end: len };
+    refreshMeasuredRowHeight();
+    return;
+  }
+
+  ensureVirtualScrollBound();
+  _rowHeightPx = _rowHeightPx || estimateRowHeight();
+  const { start, end } = computeMirrorVirtualRange(len, {
+    scrollY: window.scrollY,
+    viewportH: window.innerHeight,
+    rowHeight: _rowHeightPx,
+    tableTop: tableTopY(),
+  });
+
+  if (start === _virtualWindow.start && end === _virtualWindow.end && tableBody.querySelector('tr[data-row-index]')) {
+    return;
+  }
+  _virtualWindow = { start, end };
+
+  const parts = [spacerHtml('top', start * _rowHeightPx)];
+  for (let i = start; i < end; i += 1) {
+    parts.push(rowHtml(list[i], i));
+  }
+  parts.push(spacerHtml('bottom', (len - end) * _rowHeightPx));
+  tableBody.innerHTML = parts.join('');
+  refreshMeasuredRowHeight();
+}
+
 function renderTable() {
-  const filtered = sortMirrorRows(
+  filteredRows = sortMirrorRows(
     filterMirrorRows(allRows, {
       search: searchInput.value,
       status: statusFilter.value,
@@ -164,23 +289,14 @@ function renderTable() {
   statsEl.innerHTML = `
     <span><strong>${summary.total}</strong> games mirrored</span>
     <span><strong>${summary.stores.length}</strong> store${summary.stores.length === 1 ? '' : 's'}</span>
-    <span>Showing <strong>${filtered.length}</strong></span>
+    <span>Showing <strong>${filteredRows.length}</strong></span>
   `;
 
-  tableBody.innerHTML = filtered
-    .map((row) => {
-      const note = row.notes ? `<div class="mirror-note">${escapeHtml(row.notes)}</div>` : '';
-      return `<tr>
-        <td data-label="Title">${escapeHtml(row.title)}${note}</td>
-        <td data-label="Store">${escapeHtml(row.storeLabel)}</td>
-        <td data-label="Status"><span class="${statusClass(row.status)}">${escapeHtml(row.statusLabel)}</span></td>
-        <td class="col-num" data-label="Playtime">${formatHours(row.playtimeHours)}</td>
-        <td class="col-num" data-label="HLTB">${formatHours(row.hltbMain)}</td>
-      </tr>`;
-    })
-    .join('');
+  _rowHeightPx = estimateRowHeight();
+  _virtualWindow = { start: -1, end: -1 };
+  paintMirrorSlice();
 
-  emptyFiltered.classList.toggle('hidden', filtered.length > 0 || allRows.length === 0);
+  emptyFiltered.classList.toggle('hidden', filteredRows.length > 0 || allRows.length === 0);
 }
 
 async function loadLibrary(session) {
@@ -192,7 +308,7 @@ async function loadLibrary(session) {
   refreshBtn.disabled = true;
   try {
     const list = await mirrorFetch('', token);
-    const catalogRows = (list.artifacts || []).filter((row) => catalogArtifactPaths([row]).length);
+    let catalogRows = (list.artifacts || []).filter((row) => catalogArtifactPaths([row]).length);
     const personalRows = (list.artifacts || []).filter((row) => row.path === 'data/personal.json');
 
     if (!catalogRows.length) {
@@ -201,12 +317,20 @@ async function loadLibrary(session) {
       return;
     }
 
-    const catalogs = await Promise.all(
-      catalogRows.map(async (row) => ({
-        path: row.path,
-        doc: await mirrorFetch(row.path, token, row.profile),
-      })),
-    );
+    catalogRows = [...catalogRows].sort((a, b) => {
+      const rank = (row) => {
+        const p = String(row.profile || '');
+        if (userId && p === userId) return 0;
+        if (p === 'default') return 1;
+        return 2;
+      };
+      return rank(a) - rank(b);
+    });
+
+    const catalogs = await mapPool(catalogRows, CATALOG_FETCH_CONCURRENCY, async (row) => ({
+      path: row.path,
+      doc: await mirrorFetch(row.path, token, row.profile),
+    }));
     let personal = null;
     if (personalRows.length) {
       const pref =
@@ -308,6 +432,7 @@ refreshBtn.addEventListener('click', async () => {
 signOutBtn.addEventListener('click', async () => {
   if (supabase) await supabase.auth.signOut();
   allRows = [];
+  filteredRows = [];
   tableBody.innerHTML = '';
   showAlert('');
   showPanel('signin');
@@ -317,5 +442,28 @@ signOutBtn.addEventListener('click', async () => {
 searchInput.addEventListener('input', renderTable);
 statusFilter.addEventListener('change', renderTable);
 storeFilter.addEventListener('change', renderTable);
+
+/** Test hook for geometry audits (synthetic rows, no auth). */
+window.__baklogMirrorTest = {
+  setRows(rows) {
+    allRows = Array.isArray(rows) ? rows : [];
+    populateFilters(allRows);
+    showPanel('library');
+    lead.textContent = 'Test library';
+    renderTable();
+  },
+  render() {
+    renderTable();
+  },
+  getPaintedRowCount() {
+    return tableBody.querySelectorAll('tr[data-row-index]').length;
+  },
+  getFilteredCount() {
+    return filteredRows.length;
+  },
+  usesVirtual() {
+    return usesMirrorVirtualScroll(filteredRows.length);
+  },
+};
 
 boot();

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:modal-geometry": "node scripts/modal-geometry-audit.mjs",
     "test:libcount-geometry": "node scripts/library-count-geometry-audit.mjs",
     "test:responsive": "node scripts/responsive-overflow-audit.mjs",
+    "test:mirror-responsive": "node scripts/mirror-overflow-audit.mjs",
     "perf:profile": "node scripts/generate-perf-profile.mjs",
     "audit:header": "node scripts/audit-header-rule.mjs",
     "audit:tab-curtain": "node scripts/audit-tab-curtain.mjs",

--- a/scripts/mirror-overflow-audit.mjs
+++ b/scripts/mirror-overflow-audit.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * Hosted /mirror overflow + virtual-scroll audit.
+ * Usage:
+ *   node scripts/mirror-overflow-audit.mjs [baseUrl]
+ *
+ * Serves landing/ on an ephemeral port when baseUrl is omitted.
+ * Injects 2000 synthetic rows via window.__baklogMirrorTest (no auth).
+ *
+ * Matrix: 1024×800, 768×900, 390×844, 360×740, 844×390
+ */
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const landingRoot = path.join(root, 'landing');
+const OUT = path.join(root, 'scripts', 'mirror-overflow-last-run.json');
+
+const VIEWPORTS = [
+  { width: 1024, height: 800, label: '1024' },
+  { width: 768, height: 900, label: '768' },
+  { width: 390, height: 844, label: '390' },
+  { width: 360, height: 740, label: '360' },
+  { width: 844, height: 390, label: '844x390' },
+];
+
+const SYNTHETIC_N = 2000;
+const MAX_PAINTED = 80;
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.json': 'application/json',
+};
+
+function startStaticServer() {
+  const server = http.createServer((req, res) => {
+    try {
+      const url = new URL(req.url || '/', 'http://127.0.0.1');
+      let rel = decodeURIComponent(url.pathname);
+      if (rel === '/' || rel === '/mirror') rel = '/mirror.html';
+      if (rel.includes('..')) {
+        res.writeHead(400);
+        res.end('bad path');
+        return;
+      }
+      const filePath = path.join(landingRoot, rel.replace(/^\//, ''));
+      if (!filePath.startsWith(landingRoot) || !fs.existsSync(filePath) || fs.statSync(filePath).isDirectory()) {
+        res.writeHead(404);
+        res.end('not found');
+        return;
+      }
+      const ext = path.extname(filePath);
+      res.writeHead(200, { 'Content-Type': MIME[ext] || 'application/octet-stream' });
+      fs.createReadStream(filePath).pipe(res);
+    } catch (err) {
+      res.writeHead(500);
+      res.end(String(err));
+    }
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({ server, baseUrl: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+function makeSyntheticRows(n) {
+  const stores = ['Steam', 'Epic', 'GOG', 'Xbox', 'PlayStation'];
+  const statuses = ['backlog', 'playing', 'finished', 'next'];
+  const rows = [];
+  for (let i = 0; i < n; i += 1) {
+    rows.push({
+      title: `Synthetic Game ${String(i + 1).padStart(4, '0')}`,
+      store: stores[i % stores.length].toLowerCase(),
+      storeLabel: stores[i % stores.length],
+      status: statuses[i % statuses.length],
+      statusLabel: statuses[i % statuses.length],
+      playtimeHours: (i % 40) + 0.5,
+      hltbMain: (i % 20) + 1,
+      notes: i % 17 === 0 ? 'note' : '',
+    });
+  }
+  return rows;
+}
+
+async function measureViewport(page, vp) {
+  await page.setViewportSize({ width: vp.width, height: vp.height });
+  await page.waitForTimeout(120);
+  await page.evaluate(() => window.scrollTo(0, 0));
+  await page.waitForTimeout(80);
+  await page.evaluate(() => {
+    window.__baklogMirrorTest?.render?.();
+  });
+  await page.waitForTimeout(100);
+
+  const top = await page.evaluate(() => {
+    const de = document.documentElement;
+    const body = document.body;
+    const painted = document.querySelectorAll('#mirrorTableBody tr[data-row-index]').length;
+    const spacers = document.querySelectorAll('#mirrorTableBody tr.mirror-virtual-spacer').length;
+    return {
+      overflowX: de.scrollWidth > de.clientWidth + 1 || body.scrollWidth > body.clientWidth + 1,
+      scrollWidth: de.scrollWidth,
+      clientWidth: de.clientWidth,
+      painted,
+      spacers,
+      filtered: window.__baklogMirrorTest?.getFilteredCount?.() ?? -1,
+      usesVirtual: window.__baklogMirrorTest?.usesVirtual?.() ?? false,
+    };
+  });
+
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight * 0.45));
+  await page.waitForTimeout(120);
+  const mid = await page.evaluate(() => ({
+    painted: document.querySelectorAll('#mirrorTableBody tr[data-row-index]').length,
+  }));
+
+  return { ...top, paintedMid: mid.painted };
+}
+
+async function main() {
+  const argUrl = process.argv.slice(2).find((a) => !a.startsWith('--'));
+  let server = null;
+  let baseUrl = argUrl;
+  if (!baseUrl) {
+    ({ server, baseUrl } = await startStaticServer());
+  }
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const results = [];
+  let failed = false;
+
+  try {
+    await page.goto(`${baseUrl.replace(/\/$/, '')}/mirror.html`, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+    await page.waitForFunction(() => typeof window.__baklogMirrorTest?.setRows === 'function', null, {
+      timeout: 15_000,
+    });
+    const rows = makeSyntheticRows(SYNTHETIC_N);
+    await page.evaluate((payload) => {
+      window.__baklogMirrorTest.setRows(payload);
+    }, rows);
+
+    for (const vp of VIEWPORTS) {
+      const m = await measureViewport(page, vp);
+      const okOverflow = !m.overflowX;
+      const okVirtual = m.usesVirtual === true;
+      const okPainted = m.painted <= MAX_PAINTED && m.paintedMid <= MAX_PAINTED;
+      const okSpacers = m.spacers >= 1;
+      const ok = okOverflow && okVirtual && okPainted && okSpacers;
+      if (!ok) failed = true;
+      results.push({
+        viewport: vp.label,
+        ok,
+        okOverflow,
+        okVirtual,
+        okPainted,
+        okSpacers,
+        ...m,
+      });
+      const mark = ok ? 'PASS' : 'FAIL';
+      console.log(
+        `${mark} ${vp.label}: overflowX=${m.overflowX} virtual=${m.usesVirtual} painted=${m.painted}/${m.paintedMid} spacers=${m.spacers}`,
+      );
+    }
+
+    // Small filter → oneshot paint (no virtual)
+    await page.setViewportSize({ width: 1024, height: 800 });
+    await page.fill('#mirrorSearch', 'Synthetic Game 0001');
+    await page.waitForTimeout(150);
+    const small = await page.evaluate(() => ({
+      filtered: window.__baklogMirrorTest.getFilteredCount(),
+      painted: window.__baklogMirrorTest.getPaintedRowCount(),
+      usesVirtual: window.__baklogMirrorTest.usesVirtual(),
+    }));
+    const smallOk = small.filtered <= 5 && small.usesVirtual === false && small.painted === small.filtered;
+    if (!smallOk) failed = true;
+    results.push({ viewport: 'filter-small', ok: smallOk, ...small });
+    console.log(
+      `${smallOk ? 'PASS' : 'FAIL'} filter-small: filtered=${small.filtered} painted=${small.painted} virtual=${small.usesVirtual}`,
+    );
+  } finally {
+    await browser.close();
+    if (server) server.close();
+  }
+
+  fs.writeFileSync(OUT, JSON.stringify({ baseUrl, results, failed }, null, 2));
+  console.log(`Wrote ${OUT}`);
+  if (failed) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/tests/mirror-virtual.test.js
+++ b/tests/mirror-virtual.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MIRROR_VIRTUAL_THRESHOLD,
+  computeMirrorVirtualRange,
+  usesMirrorVirtualScroll,
+} from '../landing/mirror-virtual.js';
+
+describe('mirror-virtual', () => {
+  it('uses virtual scroll only above the threshold', () => {
+    expect(usesMirrorVirtualScroll(MIRROR_VIRTUAL_THRESHOLD)).toBe(false);
+    expect(usesMirrorVirtualScroll(MIRROR_VIRTUAL_THRESHOLD + 1)).toBe(true);
+  });
+
+  it('returns an empty window for empty lists', () => {
+    expect(computeMirrorVirtualRange(0, {
+      scrollY: 0,
+      viewportH: 800,
+      rowHeight: 40,
+      tableTop: 100,
+    })).toEqual({ start: 0, end: 0 });
+  });
+
+  it('windows around the viewport with overscan', () => {
+    const range = computeMirrorVirtualRange(2000, {
+      scrollY: 2000,
+      viewportH: 800,
+      rowHeight: 40,
+      tableTop: 200,
+      overscan: 10,
+    });
+    // First visible index ≈ (2000-200)/40 = 45; with overscan start ≈ 35
+    expect(range.start).toBeGreaterThanOrEqual(30);
+    expect(range.start).toBeLessThanOrEqual(45);
+    expect(range.end).toBeGreaterThan(range.start);
+    expect(range.end - range.start).toBeLessThan(80);
+    expect(range.end).toBeLessThanOrEqual(2000);
+  });
+
+  it('clamps to list bounds near the end', () => {
+    const range = computeMirrorVirtualRange(100, {
+      scrollY: 50_000,
+      viewportH: 800,
+      rowHeight: 40,
+      tableTop: 0,
+      overscan: 5,
+    });
+    expect(range.end).toBe(100);
+    expect(range.start).toBeLessThan(100);
+    expect(range.start).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Diagnose: `/mirror` painted every filtered row via `innerHTML` (~12k+ DOM nodes for 2k games; phone cards made layout worse).
- Self-contained virtual scroll (`landing/mirror-virtual.js` + spacers) on desktop and phone; threshold 60.
- Catalog downloads concurrency-limited to 5.
- `npm run test:mirror-responsive` injects 2000 rows and checks 1024/768/390/360/844x390 overflow + painted row count.

## Test plan
- [x] `npx vitest run tests/mirror-virtual.test.js`
- [x] `npm run test:mirror-responsive` (all PASS)
- [ ] Hard-refresh baklog.app/mirror with a large library: scroll stays smooth; filter still works
