### PR TITLE
Mirror profile clarity + Import source pick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Changed
 
+- Hosted cloud library About this view explains read-only sync vs desktop Import; when more than one cloud profile is uploaded it notes that the table is merged.
+- Import from cloud mirror can choose which cloud profile folder to pull into the current local profile.
 - Hosted cloud library (`/mirror`) is usable on phone and tablet: app breakpoint ladder, touch-sized controls, and card rows on narrow viewports.
 - Hosted cloud library (`/mirror`) header uses the same brand lockup as the desktop app (logo, wordmark, Cloud chip) at a denser size so it does not read oversized without the app nav beside it; Refresh and Sign out stay in the header.
 - Free claims feed refreshed; stale approved-only ids pruned from the maintainer list.

--- a/app.css
+++ b/app.css
@@ -14679,6 +14679,24 @@ body {
   line-height: 1.45;
   color: var(--text-mute, #94a3b8);
 }
+.conn-mirror-import-source {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+}
+.conn-mirror-import-source-label {
+  font-weight: 600;
+  color: var(--text-dim, #cbd5e1);
+}
+.conn-mirror-import-source select {
+  min-height: 2.25rem;
+  border-radius: 0.375rem;
+  border: 1px solid color-mix(in srgb, currentColor 22%, transparent);
+  background: color-mix(in srgb, currentColor 6%, transparent);
+  color: inherit;
+  padding: 0.35rem 0.5rem;
+}
 .conn-mirror-import-list {
   margin: 0;
   padding-left: 1.1rem;

--- a/index.html
+++ b/index.html
@@ -1074,8 +1074,13 @@
                 <form method="dialog" class="conn-mirror-import-form">
                   <h3 id="cloudMirrorImportDialogTitle">Import from cloud mirror</h3>
                   <p id="cloudMirrorImportIntro" class="conn-mirror-import-intro">
-                    Matching local files will be replaced. Store credentials are not copied.
+                    Matching files in the <strong>current local profile</strong> will be replaced
+                    from the selected cloud folder. Store credentials are not copied.
                   </p>
+                  <label class="conn-mirror-import-source hidden" id="cloudMirrorImportSourceWrap" hidden>
+                    <span class="conn-mirror-import-source-label">Cloud profile</span>
+                    <select id="cloudMirrorImportSourceProfile" aria-label="Cloud profile to import from"></select>
+                  </label>
                   <ul id="cloudMirrorImportArtifactList" class="conn-mirror-import-list"></ul>
                   <label class="fh-toggle conn-mirror-import-personal">
                     <input id="cloudMirrorImportPersonal" type="checkbox" class="rounded" checked />

--- a/js/cloud-mirror-import.js
+++ b/js/cloud-mirror-import.js
@@ -2,12 +2,13 @@ import { baklogFetch } from './api-client.js';
 
 /**
  * Pull mirrored catalogs + personal data from Supabase into the active profile.
- * @param {{ includePersonal?: boolean, paths?: string[] }} [options]
+ * @param {{ includePersonal?: boolean, paths?: string[], sourceProfile?: string }} [options]
  */
 export async function importFromCloudMirror(options = {}) {
   const body = {};
   if (options.includePersonal === false) body.includePersonal = false;
   if (Array.isArray(options.paths) && options.paths.length) body.paths = options.paths;
+  if (options.sourceProfile) body.sourceProfile = String(options.sourceProfile);
 
   const res = await baklogFetch('/api/mirror/import', {
     method: 'POST',

--- a/js/cloud-mirror-status.js
+++ b/js/cloud-mirror-status.js
@@ -5,9 +5,13 @@ import { baklogFetch } from './api-client.js';
  * @typedef {{ artifacts?: Record<string, { status?: string, uploaded_at?: string }>, last_upload_at?: string | null }} LocalUploadState
  */
 
-/** @returns {Promise<{ artifacts: MirrorArtifactRow[], localUploadState: LocalUploadState }>} */
-export async function fetchMirrorSnapshot() {
-  const res = await baklogFetch('/api/mirror');
+/**
+ * @param {string} [profile]
+ * @returns {Promise<{ artifacts: MirrorArtifactRow[], profiles: string[], profile: string | null, localUploadState: LocalUploadState }>}
+ */
+export async function fetchMirrorSnapshot(profile) {
+  const qs = profile ? `?profile=${encodeURIComponent(profile)}` : '';
+  const res = await baklogFetch(`/api/mirror${qs}`);
   let data;
   try {
     data = await res.json();
@@ -19,11 +23,43 @@ export async function fetchMirrorSnapshot() {
   }
   return {
     artifacts: Array.isArray(data.artifacts) ? data.artifacts : [],
+    profiles: Array.isArray(data.profiles) ? data.profiles.map(String).filter(Boolean) : [],
+    profile: data.profile != null ? String(data.profile) : null,
     localUploadState:
       data.localUploadState && typeof data.localUploadState === 'object'
         ? data.localUploadState
         : { artifacts: {}, last_upload_at: null },
   };
+}
+
+/**
+ * Prefer active local id, then account uuid, then default.
+ * @param {string[]} profiles
+ * @param {{ activeId?: string, accountId?: string }} [opts]
+ */
+export function preferMirrorSourceProfile(profiles, opts = {}) {
+  const ids = (profiles || []).map((p) => String(p || '').trim()).filter(Boolean);
+  if (!ids.length) return null;
+  const active = String(opts.activeId || '').trim();
+  const account = String(opts.accountId || '').trim();
+  if (active && ids.includes(active)) return active;
+  if (account && ids.includes(account)) return account;
+  if (ids.includes('default')) return 'default';
+  return ids[0];
+}
+
+/**
+ * @param {string} profileId
+ * @param {{ accountId?: string }} [opts]
+ */
+export function labelMirrorSourceProfile(profileId, opts = {}) {
+  const id = String(profileId || '').trim();
+  if (!id) return '';
+  if (id === 'default') return 'Default';
+  const account = String(opts.accountId || '').trim();
+  if (account && id === account) return 'This account';
+  if (id.length > 12) return `${id.slice(0, 8)}…`;
+  return id;
 }
 
 /**

--- a/js/connections.js
+++ b/js/connections.js
@@ -1,6 +1,7 @@
 import { baklogFetch, urlWithStreamTicket } from "./api-client.js";
 import {
   getAccessToken,
+  getAccountProfileId,
   isAccountAuthMode,
   isPro,
   refreshAccountPlan,
@@ -20,6 +21,7 @@ import { state } from "./state.js";
 import { storeLogoHtml } from "./store-logos.js";
 import { STORE_BRAND_COLORS } from "./store-brand-colors.js";
 import { formatPlatformList } from "./platform-labels.js";
+import { activeProfileId } from "./profiles.js";
 import {
   authStatusLoaded,
   connectedProviderCount,
@@ -49,7 +51,9 @@ import {
   describeImportScope,
   fetchMirrorSnapshot,
   formatLastUploadedBy,
+  labelMirrorSourceProfile,
   listImportableArtifactPaths,
+  preferMirrorSourceProfile,
   summarizeLocalUploadState,
 } from "./cloud-mirror-status.js";
 
@@ -682,25 +686,88 @@ async function handleCloudMirrorToggle(ev) {
   }
 }
 
-async function openCloudMirrorImportDialog(artifacts) {
+async function openCloudMirrorImportDialog(initialSnap) {
   const dialog = document.getElementById("cloudMirrorImportDialog");
   const listEl = document.getElementById("cloudMirrorImportArtifactList");
   const personalToggle = document.getElementById("cloudMirrorImportPersonal");
   const intro = document.getElementById("cloudMirrorImportIntro");
+  const sourceWrap = document.getElementById("cloudMirrorImportSourceWrap");
+  const sourceSelect = document.getElementById("cloudMirrorImportSourceProfile");
   if (!dialog || !listEl || !personalToggle) return null;
 
-  const paths = listImportableArtifactPaths(artifacts);
-  if (!paths.length) return null;
+  const accountId = getAccountProfileId() || "";
+  const profiles = Array.isArray(initialSnap?.profiles) ? initialSnap.profiles : [];
+  let sourceProfile =
+    preferMirrorSourceProfile(profiles, {
+      activeId: activeProfileId(),
+      accountId,
+    }) ||
+    initialSnap?.profile ||
+    activeProfileId();
+  let importableCount = 0;
 
-  const scope = describeImportScope(paths);
-  if (intro) {
-    intro.textContent =
-      `This replaces local mirrorable files with your cloud copy (${scope.join(", ")}). ` +
-      "Store credentials are not copied - reconnect stores afterward.";
+  const fillPaths = (artifacts) => {
+    const paths = listImportableArtifactPaths(artifacts);
+    importableCount = paths.length;
+    const scope = describeImportScope(paths);
+    if (intro) {
+      const sourceLabel = labelMirrorSourceProfile(sourceProfile, { accountId });
+      intro.textContent =
+        `Replaces matching files in the current local profile from cloud folder "${sourceLabel}"` +
+        `${scope.length ? ` (${scope.join(", ")})` : ""}. ` +
+        "Store credentials are not copied - reconnect stores afterward.";
+    }
+    listEl.innerHTML = paths.length
+      ? paths.map((path) => `<li>${escapeHtml(path)}</li>`).join("")
+      : "<li>No importable files in this cloud profile.</li>";
+    personalToggle.checked = paths.includes("data/personal.json");
+    personalToggle.disabled = !paths.includes("data/personal.json");
+    return paths;
+  };
+
+  let artifacts = initialSnap?.artifacts || [];
+  if (sourceProfile && String(initialSnap?.profile || "") !== sourceProfile) {
+    try {
+      const preferred = await fetchMirrorSnapshot(sourceProfile);
+      artifacts = preferred.artifacts;
+    } catch {
+      artifacts = [];
+    }
   }
-  listEl.innerHTML = paths.map((path) => `<li>${escapeHtml(path)}</li>`).join("");
-  personalToggle.checked = paths.includes("data/personal.json");
-  personalToggle.disabled = !paths.includes("data/personal.json");
+  fillPaths(artifacts);
+  if (!importableCount && profiles.length <= 1) return null;
+
+  if (sourceWrap && sourceSelect) {
+    if (profiles.length > 1) {
+      sourceSelect.innerHTML = profiles
+        .map((pid) => {
+          const label = labelMirrorSourceProfile(pid, { accountId });
+          const selected = pid === sourceProfile ? " selected" : "";
+          return `<option value="${escapeAttr(pid)}"${selected}>${escapeHtml(label)}</option>`;
+        })
+        .join("");
+      sourceWrap.hidden = false;
+      sourceWrap.classList.remove("hidden");
+      sourceSelect.onchange = async () => {
+        sourceProfile = sourceSelect.value;
+        try {
+          const next = await fetchMirrorSnapshot(sourceProfile);
+          fillPaths(next.artifacts);
+        } catch (err) {
+          importableCount = 0;
+          listEl.innerHTML = `<li>${escapeHtml(err?.message || "Could not list this cloud profile.")}</li>`;
+          personalToggle.checked = false;
+          personalToggle.disabled = true;
+        }
+      };
+    } else {
+      sourceWrap.hidden = true;
+      sourceWrap.classList.add("hidden");
+      sourceSelect.onchange = null;
+    }
+  }
+
+  if (!importableCount && profiles.length <= 1) return null;
 
   dialog.returnValue = "cancel";
   dialog.showModal();
@@ -708,9 +775,11 @@ async function openCloudMirrorImportDialog(artifacts) {
     dialog.addEventListener(
       "close",
       () => {
+        if (sourceSelect) sourceSelect.onchange = null;
         resolve({
-          confirmed: dialog.returnValue === "confirm",
+          confirmed: dialog.returnValue === "confirm" && importableCount > 0,
           includePersonal: personalToggle.checked,
+          sourceProfile,
         });
       },
       { once: true },
@@ -723,12 +792,13 @@ async function handleCloudMirrorImport() {
   try {
     if (btn) btn.disabled = true;
     const snap = await fetchMirrorSnapshot();
-    const choice = await openCloudMirrorImportDialog(snap.artifacts);
+    const choice = await openCloudMirrorImportDialog(snap);
     if (!choice?.confirmed) return;
 
     const { importFromCloudMirror } = await import("./cloud-mirror-import.js");
     const result = await importFromCloudMirror({
       includePersonal: choice.includePersonal,
+      sourceProfile: choice.sourceProfile || undefined,
     });
     const count = result?.count ?? 0;
     const imported = Array.isArray(result?.imported) ? result.imported.join(", ") : "";

--- a/landing/mirror.css
+++ b/landing/mirror.css
@@ -420,6 +420,20 @@ table.mirror-table {
   margin: 0;
 }
 
+.mirror-scope-note .mirror-scope-note-body p {
+  margin: 0 0 0.45rem;
+}
+
+.mirror-scope-note .mirror-scope-note-body p:last-child {
+  margin-bottom: 0;
+}
+
+.mirror-merge-hint {
+  margin: -0.35rem 0 0.85rem;
+  font-size: 0.78rem;
+  color: var(--text-mute);
+}
+
 .hidden {
   display: none !important;
 }

--- a/landing/mirror.html
+++ b/landing/mirror.html
@@ -93,8 +93,13 @@
     <section class="hidden" id="mirrorLibraryPanel">
       <details class="mirror-scope-note">
         <summary>About this view</summary>
-        <p class="mirror-scope-note-body">Library backlog only  -  wishlists and deal prices sync with your account and appear here after you <strong>Import from cloud mirror</strong> in the desktop app. Claimables stay on the public feed and are not mirrored.</p>
+        <div class="mirror-scope-note-body">
+          <p>Read-only library from your home PC after <strong>Cloud sync</strong> / <strong>Sync now</strong> in BAKLOG. You see store catalogs plus statuses and notes from mirrored personal data.</p>
+          <p>Wishlists, deal prices, and claimables are not shown here. Claimables stay on the public feed. Wishlists and prices may still upload for desktop restore.</p>
+          <p><strong>Import from cloud mirror</strong> is a desktop Connections action that overwrites local files. It does not fill this page.</p>
+        </div>
       </details>
+      <p class="mirror-merge-hint hidden" id="mirrorMergeHint" hidden></p>
       <div class="mirror-stats" id="mirrorStats" aria-live="polite"></div>
       <div class="mirror-toolbar">
         <input type="search" id="mirrorSearch" placeholder="Search title or notes" aria-label="Search library" />

--- a/landing/mirror.js
+++ b/landing/mirror.js
@@ -25,6 +25,7 @@ const signedInActions = document.getElementById('mirrorSignedInActions');
 const refreshBtn = document.getElementById('mirrorRefreshBtn');
 const signOutBtn = document.getElementById('mirrorSignOutBtn');
 const statsEl = document.getElementById('mirrorStats');
+const mergeHintEl = document.getElementById('mirrorMergeHint');
 const searchInput = document.getElementById('mirrorSearch');
 const statusFilter = document.getElementById('mirrorStatusFilter');
 const storeFilter = document.getElementById('mirrorStoreFilter');
@@ -65,6 +66,21 @@ function showPanel(name) {
   libraryPanel.classList.toggle('hidden', name !== 'library');
   setupPanel.classList.toggle('hidden', name !== 'setup');
   signedInActions.classList.toggle('hidden', name === 'signin');
+}
+
+/** @param {string[] | undefined} profiles */
+function setMergeHint(profiles) {
+  if (!mergeHintEl) return;
+  const n = Array.isArray(profiles) ? profiles.filter(Boolean).length : 0;
+  if (n > 1) {
+    mergeHintEl.textContent = `Merged from ${n} cloud profiles.`;
+    mergeHintEl.hidden = false;
+    mergeHintEl.classList.remove('hidden');
+  } else {
+    mergeHintEl.textContent = '';
+    mergeHintEl.hidden = true;
+    mergeHintEl.classList.add('hidden');
+  }
 }
 
 function escapeHtml(value) {
@@ -312,6 +328,7 @@ async function loadLibrary(session) {
     const personalRows = (list.artifacts || []).filter((row) => row.path === 'data/personal.json');
 
     if (!catalogRows.length) {
+      setMergeHint([]);
       lead.textContent = 'Signed in  -  waiting for your home PC to upload a mirror.';
       showPanel('setup');
       return;
@@ -342,13 +359,15 @@ async function loadLibrary(session) {
     allRows = mergeMirrorLibrary(catalogs, personal);
 
     if (!allRows.length) {
+      setMergeHint([]);
       lead.textContent = 'Signed in  -  mirror artifacts found but no playable rows yet.';
       showPanel('setup');
       return;
     }
 
+    setMergeHint(list.profiles);
     populateFilters(allRows);
-    lead.textContent = 'Read-only library backlog  -  use Import in Connections for wishlists and full mirror restore.';
+    lead.textContent = 'Read-only library from your synced home PC.';
     showPanel('library');
     renderTable();
   } finally {

--- a/shared/cloud_mirror.py
+++ b/shared/cloud_mirror.py
@@ -368,10 +368,50 @@ def list_remote_mirror_artifacts(*, authorization: str, profile_id: str | None =
         if not is_allowed_relative(name):
             continue
         out.append(
-            {"path": name, "id": row.get("id"), "updated_at": row.get("updated_at"), "metadata": row.get("metadata")}
+            {
+                "path": name,
+                "profile": pid,
+                "id": row.get("id"),
+                "updated_at": row.get("updated_at"),
+                "metadata": row.get("metadata"),
+            }
         )
     out.sort(key=lambda item: item.get("path") or "")
     return out
+
+
+def list_remote_mirror_profile_ids(*, authorization: str) -> list[str]:
+    """List cloud profile folder ids for the signed-in user."""
+    from shared.supabase_auth import verify_bearer_user
+    from shared.supabase_mirror import list_mirror_profile_ids
+
+    user = verify_bearer_user(authorization)
+    if not user:
+        raise PermissionError("invalid session")
+    user_id = str(user.get("id") or "")
+    token = _bearer_token(authorization)
+    return list_mirror_profile_ids(user_id=user_id, bearer_token=token)
+
+
+def prefer_mirror_source_profile(
+    profiles: list[str],
+    *,
+    active_profile_id: str | None = None,
+    user_id: str | None = None,
+) -> str | None:
+    """Pick a default cloud source: active, then account uuid, then default."""
+    ids = [str(p).strip() for p in (profiles or []) if str(p).strip()]
+    if not ids:
+        return None
+    active = (active_profile_id or "").strip()
+    uid = (user_id or "").strip()
+    if active and active in ids:
+        return active
+    if uid and uid in ids:
+        return uid
+    if "default" in ids:
+        return "default"
+    return ids[0]
 
 
 def download_remote_mirror_artifact(
@@ -456,16 +496,19 @@ def import_remote_mirror_to_profile(
     *,
     authorization: str,
     profile_id: str | None = None,
+    source_profile_id: str | None = None,
     paths: list[str] | None = None,
     include_personal: bool = True,
     allow_empty_catalogs: bool = False,
 ) -> dict[str, Any]:
     """Import mirrored artifacts into the **active** profile only.
 
-    Naming a different ``profile_id`` raises :class:`MirrorProfileMismatch` (HTTP 409).
+    Naming a different destination ``profile_id`` raises :class:`MirrorProfileMismatch`
+    (HTTP 409). ``source_profile_id`` selects which cloud folder to pull from.
     """
     from shared.server_catalog_import import import_catalog_payload, is_allowed_catalog_filename
     from shared.server_personal import save_personal_doc
+    from shared.supabase_auth import verify_bearer_user
 
     active = get_active_profile_id()
     if profile_id is not None and str(profile_id) != active:
@@ -473,7 +516,25 @@ def import_remote_mirror_to_profile(
             f"profile mismatch (active={active!r}, claimed={str(profile_id)!r})"
         )
     pid = active
-    remote_rows = list_remote_mirror_artifacts(authorization=authorization, profile_id=pid)
+    user = verify_bearer_user(authorization)
+    if not user:
+        raise PermissionError("invalid session")
+    user_id = str(user.get("id") or "")
+
+    source_pid = (source_profile_id or "").strip() or None
+    if source_pid is not None:
+        from shared.profile_paths import normalize_profile_id
+
+        source_pid = normalize_profile_id(source_pid)
+    else:
+        profiles = list_remote_mirror_profile_ids(authorization=authorization)
+        source_pid = prefer_mirror_source_profile(
+            profiles, active_profile_id=active, user_id=user_id
+        )
+        if source_pid is None:
+            source_pid = active
+
+    remote_rows = list_remote_mirror_artifacts(authorization=authorization, profile_id=source_pid)
     remote_paths = {str(row.get("path") or "").strip() for row in remote_rows}
     remote_paths.discard("")
     candidates: list[str] = []
@@ -490,7 +551,9 @@ def import_remote_mirror_to_profile(
         raise ValueError("no importable mirror artifacts")
     staged: dict[str, Any] = {}
     for rel in candidates:
-        body = download_remote_mirror_artifact(authorization=authorization, artifact_path=rel, profile_id=pid)
+        body = download_remote_mirror_artifact(
+            authorization=authorization, artifact_path=rel, profile_id=source_pid
+        )
         doc = _parse_mirror_json(body, rel)
         _validate_mirror_staged_doc(rel, doc, allow_empty_catalogs=allow_empty_catalogs)
         staged[rel] = doc
@@ -535,4 +598,11 @@ def import_remote_mirror_to_profile(
             continue
         seen.add(name)
         ordered.append(name)
-    return {"ok": True, "imported": ordered, "count": len(ordered), "personal": personal_saved}
+    return {
+        "ok": True,
+        "imported": ordered,
+        "count": len(ordered),
+        "personal": personal_saved,
+        "sourceProfile": source_pid,
+        "profile": pid,
+    }

--- a/shared/server_mirror.py
+++ b/shared/server_mirror.py
@@ -11,6 +11,7 @@ from shared.cloud_mirror import (
     download_remote_mirror_artifact,
     import_remote_mirror_to_profile,
     list_remote_mirror_artifacts,
+    list_remote_mirror_profile_ids,
     mirror_read_allowed,
     mirror_upload_allowed,
     read_mirror_upload_state,
@@ -53,13 +54,26 @@ def handle_mirror_get(handler) -> None:
                 authorization=authorization, artifact_path=artifact, profile_id=profile
             )
         else:
-            artifacts = list_remote_mirror_artifacts(authorization=authorization, profile_id=profile)
+            profiles = list_remote_mirror_profile_ids(authorization=authorization)
+            list_profile = profile
+            if list_profile is None:
+                from shared.profile_paths import get_active_profile_id
+
+                list_profile = get_active_profile_id()
+            artifacts = list_remote_mirror_artifacts(
+                authorization=authorization, profile_id=list_profile
+            )
             # Local upload status is always for the active profile (never the ?profile= query).
             local_state = read_mirror_upload_state()
             srv._send_json(
                 handler,
                 HTTPStatus.OK,
-                {"artifacts": artifacts, "localUploadState": local_state},
+                {
+                    "artifacts": artifacts,
+                    "profiles": profiles,
+                    "profile": list_profile,
+                    "localUploadState": local_state,
+                },
             )
             return
     except PermissionError as exc:
@@ -116,10 +130,16 @@ def handle_mirror_import_post(handler) -> None:
         paths = paths_raw
     claimed_profile = body.get("profile")
     profile_id = str(claimed_profile).strip() if claimed_profile is not None else None
+    source_raw = body.get("sourceProfile")
+    source_profile_id = str(source_raw).strip() if source_raw is not None else None
+    if source_raw is not None and not source_profile_id:
+        srv._send_json(handler, HTTPStatus.BAD_REQUEST, {"error": "sourceProfile must be a non-empty string"})
+        return
     try:
         result = import_remote_mirror_to_profile(
             authorization=authorization,
             profile_id=profile_id,
+            source_profile_id=source_profile_id,
             paths=paths,
             include_personal=include_personal,
             allow_empty_catalogs=allow_empty_catalogs,

--- a/shared/supabase_mirror.py
+++ b/shared/supabase_mirror.py
@@ -115,6 +115,30 @@ def list_mirror_objects(*, user_id: str, profile_id: str, bearer_token: str, lim
     return _list_prefix(prefix=prefix, bearer_token=bearer_token, limit=limit)
 
 
+def list_mirror_profile_ids(*, user_id: str, bearer_token: str, limit: int = 200) -> list[str]:
+    """List profile folder ids under ``{userId}/`` (non-recursive Storage list)."""
+    from shared.profile_paths import is_valid_profile_id
+
+    uid = (user_id or "").strip()
+    if not uid:
+        return []
+    rows = _list_prefix(prefix=f"{uid}/", bearer_token=bearer_token, limit=limit)
+    out: list[str] = []
+    seen: set[str] = set()
+    for row in rows:
+        name = str(row.get("name") or "").strip().lstrip("/")
+        if not name or "/" in name:
+            continue
+        if not is_valid_profile_id(name):
+            continue
+        if name in seen:
+            continue
+        seen.add(name)
+        out.append(name)
+    out.sort()
+    return out
+
+
 def list_mirror_artifacts(
     *, user_id: str, profile_id: str, bearer_token: str, limit: int = 200
 ) -> list[dict[str, Any]]:

--- a/tests/mirror-artifact-sync.test.js
+++ b/tests/mirror-artifact-sync.test.js
@@ -3,7 +3,9 @@ import { ALLOWED_ARTIFACT_RE_SOURCE, isAllowedMirrorArtifact } from '../js/mirro
 import {
   describeImportScope,
   formatLastUploadedBy,
+  labelMirrorSourceProfile,
   listImportableArtifactPaths,
+  preferMirrorSourceProfile,
   summarizeLocalUploadState,
 } from '../js/cloud-mirror-status.js';
 import { readFileSync } from 'node:fs';
@@ -61,5 +63,23 @@ describe('cloud-mirror-status helpers', () => {
         last_upload_at: '2026-01-01T12:00:00Z',
       }),
     ).toMatch(/Last uploaded by Windows:pc/);
+  });
+
+  it('prefers active then account then default for source profile', () => {
+    const uid = '11111111-1111-1111-1111-111111111111';
+    expect(
+      preferMirrorSourceProfile(['guest', 'default', uid], { activeId: 'default', accountId: uid }),
+    ).toBe('default');
+    expect(preferMirrorSourceProfile(['guest', uid], { activeId: 'x', accountId: uid })).toBe(uid);
+    expect(preferMirrorSourceProfile(['guest', 'default'], { activeId: 'x', accountId: uid })).toBe(
+      'default',
+    );
+  });
+
+  it('labels cloud source profiles for the import dialog', () => {
+    const uid = '11111111-1111-1111-1111-111111111111';
+    expect(labelMirrorSourceProfile('default')).toBe('Default');
+    expect(labelMirrorSourceProfile(uid, { accountId: uid })).toBe('This account');
+    expect(labelMirrorSourceProfile(uid)).toMatch(/11111111/);
   });
 });

--- a/tests/test_cloud_mirror.py
+++ b/tests/test_cloud_mirror.py
@@ -78,6 +78,10 @@ def test_schedule_too_large_records_status(profile_home: Path, monkeypatch: pyte
 
 def test_import_non_active_profile_raises(profile_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
+        "shared.supabase_auth.verify_bearer_user",
+        lambda *_a, **_k: {"id": "u", "email": "a@b.c"},
+    )
+    monkeypatch.setattr(
         cloud_mirror,
         "list_remote_mirror_artifacts",
         lambda **_: [{"path": "games_steam.json"}],
@@ -86,8 +90,61 @@ def test_import_non_active_profile_raises(profile_home: Path, monkeypatch: pytes
         import_remote_mirror_to_profile(
             authorization="Bearer x",
             profile_id="other",
+            source_profile_id="default",
             paths=["games_steam.json"],
         )
+
+
+def test_import_from_other_cloud_source(profile_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    catalog = profile_home / "games_steam.json"
+    catalog.write_text(
+        json.dumps({"games": [{"id": "1", "title": "Old"}], "store": "steam", "game_count": 1}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "shared.supabase_auth.verify_bearer_user",
+        lambda *_a, **_k: {"id": "u", "email": "a@b.c"},
+    )
+    seen: dict[str, str] = {}
+
+    def _list(**kwargs):
+        seen["list_profile"] = str(kwargs.get("profile_id") or "")
+        return [{"path": "games_steam.json"}]
+
+    def _download(*, authorization: str, artifact_path: str, profile_id: str | None = None) -> bytes:
+        seen["download_profile"] = str(profile_id or "")
+        return json.dumps(
+            {"games": [{"id": "9", "title": "From guest"}], "store": "steam", "game_count": 1}
+        ).encode()
+
+    monkeypatch.setattr(cloud_mirror, "list_remote_mirror_artifacts", _list)
+    monkeypatch.setattr(cloud_mirror, "download_remote_mirror_artifact", _download)
+    monkeypatch.setattr("shared.server_personal._rebind_after_save", lambda: None)
+
+    result = import_remote_mirror_to_profile(
+        authorization="Bearer x",
+        source_profile_id="guest",
+        include_personal=False,
+    )
+    assert seen["list_profile"] == "guest"
+    assert seen["download_profile"] == "guest"
+    assert result.get("sourceProfile") == "guest"
+    assert result.get("profile") == "default"
+    rewritten = json.loads(catalog.read_text(encoding="utf-8"))
+    assert rewritten["games"][0]["id"] == "9"
+
+
+def test_prefer_mirror_source_profile_order() -> None:
+    uid = "11111111-1111-1111-1111-111111111111"
+    assert cloud_mirror.prefer_mirror_source_profile(
+        ["guest", "default", uid], active_profile_id="default", user_id=uid
+    ) == "default"
+    assert cloud_mirror.prefer_mirror_source_profile(
+        ["guest", uid], active_profile_id="missing", user_id=uid
+    ) == uid
+    assert cloud_mirror.prefer_mirror_source_profile(
+        ["guest", "default"], active_profile_id="x", user_id=uid
+    ) == "default"
 
 
 def test_import_rollback_on_failure(profile_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -95,6 +152,10 @@ def test_import_rollback_on_failure(profile_home: Path, monkeypatch: pytest.Monk
     prior = {"games": [{"id": "1", "title": "Keep"}], "store": "steam", "game_count": 1}
     catalog.write_text(json.dumps(prior), encoding="utf-8")
 
+    monkeypatch.setattr(
+        "shared.supabase_auth.verify_bearer_user",
+        lambda *_a, **_k: {"id": "u", "email": "a@b.c"},
+    )
     monkeypatch.setattr(
         cloud_mirror,
         "list_remote_mirror_artifacts",
@@ -118,6 +179,7 @@ def test_import_rollback_on_failure(profile_home: Path, monkeypatch: pytest.Monk
     with pytest.raises(RuntimeError, match="personal save failed"):
         import_remote_mirror_to_profile(
             authorization="Bearer x",
+            source_profile_id="default",
             include_personal=True,
         )
 
@@ -146,6 +208,10 @@ def test_import_successful_overwrite(profile_home: Path, monkeypatch: pytest.Mon
     )
 
     monkeypatch.setattr(
+        "shared.supabase_auth.verify_bearer_user",
+        lambda *_a, **_k: {"id": "u", "email": "a@b.c"},
+    )
+    monkeypatch.setattr(
         cloud_mirror,
         "list_remote_mirror_artifacts",
         lambda **_: [{"path": "games_steam.json"}, {"path": "data/personal.json"}],
@@ -170,7 +236,11 @@ def test_import_successful_overwrite(profile_home: Path, monkeypatch: pytest.Mon
     # Avoid importing server during personal save in unit test.
     monkeypatch.setattr("shared.server_personal._rebind_after_save", lambda: None)
 
-    result = import_remote_mirror_to_profile(authorization="Bearer x", include_personal=True)
+    result = import_remote_mirror_to_profile(
+        authorization="Bearer x",
+        source_profile_id="default",
+        include_personal=True,
+    )
     assert "games_steam.json" in (result.get("imported") or [])
     assert result.get("personal") is True
     rewritten = json.loads(catalog.read_text(encoding="utf-8"))

--- a/tests/test_server_mirror.py
+++ b/tests/test_server_mirror.py
@@ -132,7 +132,7 @@ def test_get_mirror_unauthorized_on_permission_error(
     def _boom(**kwargs):
         raise PermissionError("invalid session")
 
-    monkeypatch.setattr("shared.server_mirror.list_remote_mirror_artifacts", _boom)
+    monkeypatch.setattr("shared.server_mirror.list_remote_mirror_profile_ids", _boom)
     status, data = _request(
         mirror_server,
         "/api/mirror",

--- a/tests/test_supabase_mirror.py
+++ b/tests/test_supabase_mirror.py
@@ -45,6 +45,22 @@ def test_list_mirror_artifacts_joins_data_subfolder(monkeypatch: pytest.MonkeyPa
     assert any(c.endswith("/data") or c.endswith("default/data") for c in calls)
 
 
+def test_list_mirror_profile_ids_filters_folders(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_list_prefix(*, prefix: str, bearer_token: str, limit: int = 200) -> list[dict[str, Any]]:
+        assert prefix == "user-1/"
+        return [
+            {"name": "default", "id": None},
+            {"name": "11111111-1111-1111-1111-111111111111", "id": None},
+            {"name": "games_steam.json", "id": "obj"},  # file at user root - skip
+            {"name": "nested/path", "id": None},  # invalid
+            {"name": "..", "id": None},
+        ]
+
+    monkeypatch.setattr(supabase_mirror, "_list_prefix", fake_list_prefix)
+    ids = supabase_mirror.list_mirror_profile_ids(user_id="user-1", bearer_token="tok")
+    assert ids == ["11111111-1111-1111-1111-111111111111", "default"]
+
+
 def test_mirror_object_key_rejects_traversal() -> None:
     with pytest.raises(ValueError):
         supabase_mirror.mirror_object_key("u", "p", "../secrets.bin")


### PR DESCRIPTION
## Summary
- Rewrite hosted `/mirror` About this view (read-only sync vs desktop Import).
- When the account has more than one cloud profile folder, show a quiet Merged from N hint (no picker).
- Desktop Import: `sourceProfile` selects the cloud folder; destination stays the active local profile. Dialog shows a Cloud profile select when N > 1.
- `GET /api/mirror` returns `profiles[]`; list helpers cover Storage profile folders.

## Test plan
- [x] `pytest tests/test_cloud_mirror.py tests/test_supabase_mirror.py tests/test_server_mirror.py`
- [x] `npx vitest run tests/mirror-artifact-sync.test.js`
- [ ] `/mirror` About copy reads correctly; multi-profile account shows merge hint
- [ ] Connections Import with two cloud folders: switch source, import into active local


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Cloud mirror imports can now be sourced from a selected cloud profile and imported into the active local profile.
  - Import dialogs show available profiles, selected source details, and replacement behavior.
  - The hosted library view explains sync and import behavior, including when data is merged from multiple cloud profiles.
- **Documentation**
  - Updated changelog and in-app guidance clarify read-only views, excluded data, and desktop restore behavior.
- **Bug Fixes**
  - Improved profile selection and labeling for cloud mirror browsing and imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->