### PR TITLE
Denser hosted /mirror rows with CDN covers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Changed
 
+- Hosted cloud library rows show covers (store CDNs) plus playtime, HLTB, Steam %, Metacritic, deal price when synced, release, and last played - closer to the desktop library table without uploading image files.
 - Hosted cloud library About this view explains read-only sync vs desktop Import; when more than one cloud profile is uploaded it notes that the table is merged.
 - Import from cloud mirror can choose which cloud profile folder to pull into the current local profile.
 - Hosted cloud library (`/mirror`) is usable on phone and tablet: app breakpoint ladder, touch-sized controls, and card rows on narrow viewports.

--- a/landing/mirror-merge.js
+++ b/landing/mirror-merge.js
@@ -30,6 +30,7 @@ export const STORE_LABELS = {
 };
 
 const CATALOG_ARTIFACT_RE = /^games_(?!wishlist_)([a-z0-9_]+)\.json$/;
+const STEAM_HEADER_CDN = 'https://cdn.akamai.steamstatic.com/steam/apps';
 
 /** @param {string} path */
 export function storeFromCatalogArtifact(path) {
@@ -51,6 +52,36 @@ function storeRank(store) {
   const order = Object.keys(STORE_LABELS);
   const idx = order.indexOf(store || '');
   return idx === -1 ? order.length : idx;
+}
+
+/** @param {unknown} url */
+export function sanitizeMirrorCoverUrl(url) {
+  if (!url) return '';
+  let u = String(url).trim();
+  if (!u) return '';
+  u = u.replace('://images-eds.xboxlive.com/', '://images-eds-ssl.xboxlive.com/');
+  if (u.includes('${size}') && /cdn\.nintendo\.net/i.test(u)) {
+    u = u.replace(/\$\{size\}/g, '256');
+  }
+  if (!/^https?:\/\//i.test(u)) return '';
+  return u;
+}
+
+/**
+ * Prefer library_image, then header_image, then Steam header CDN.
+ * @param {Record<string, unknown>} g
+ */
+export function mirrorCoverUrlFor(g) {
+  const lib = sanitizeMirrorCoverUrl(g?.library_image);
+  if (lib) return lib;
+  const header = sanitizeMirrorCoverUrl(g?.header_image);
+  if (header) return header;
+  const store = String(g?.store || '').toLowerCase();
+  const id = g?.id;
+  if (store === 'steam' && id != null && String(id).trim() !== '' && /^\d+$/.test(String(id))) {
+    return `${STEAM_HEADER_CDN}/${id}/header.jpg`;
+  }
+  return '';
 }
 
 /** @param {Record<string, unknown>} g */
@@ -98,6 +129,100 @@ function personalMap(personalDoc) {
   return personalDoc;
 }
 
+function finiteOrNull(value) {
+  if (value == null || value === '') return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** @param {unknown} raw */
+function genresFromGame(raw) {
+  if (Array.isArray(raw)) {
+    return raw
+      .map((g) => (typeof g === 'string' ? g : g?.description || g?.name || ''))
+      .map((s) => String(s).trim())
+      .filter(Boolean)
+      .slice(0, 2);
+  }
+  if (typeof raw === 'string' && raw.trim()) {
+    return raw
+      .split(/[,;/|]/)
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .slice(0, 2);
+  }
+  return [];
+}
+
+/** @param {Record<string, unknown>} g */
+function platformsFromGame(g) {
+  const raw = g.platforms ?? g.platform ?? g.psn_platforms;
+  if (Array.isArray(raw)) {
+    return raw
+      .map((p) => String(p || '').trim())
+      .filter(Boolean)
+      .slice(0, 4)
+      .join(', ');
+  }
+  const s = String(raw || '').trim();
+  return s || '';
+}
+
+/** @param {unknown} value */
+function dateLabel(value) {
+  if (value == null || value === '') return '';
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    // Steam rtime_last_played is unix seconds.
+    const ms = value > 1e12 ? value : value * 1000;
+    const d = new Date(ms);
+    if (!Number.isNaN(d.getTime())) {
+      return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+    }
+  }
+  const s = String(value).trim();
+  if (!s) return '';
+  const parsed = Date.parse(s);
+  if (!Number.isNaN(parsed)) {
+    return new Date(parsed).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+  }
+  return s;
+}
+
+/**
+ * Compact ITAD label from a by_key entry (`price_str`, optional cut).
+ * @param {Record<string, unknown> | null | undefined} entry
+ */
+export function formatItadPriceLabel(entry) {
+  if (!entry || typeof entry !== 'object') return '';
+  const cut = finiteOrNull(entry.cut);
+  const priceStr = String(entry.price_str || '').trim();
+  if (priceStr && cut != null && cut > 0) return `${priceStr} (-${Math.round(cut)}%)`;
+  if (priceStr) return priceStr;
+  const price = finiteOrNull(entry.price);
+  if (price == null) return '';
+  const currency = String(entry.currency || 'USD').trim() || 'USD';
+  const base = `${currency} ${price % 1 === 0 ? price : price.toFixed(2)}`;
+  if (cut != null && cut > 0) return `${base} (-${Math.round(cut)}%)`;
+  return base;
+}
+
+/**
+ * Attach `priceLabel` from mirrored `itad_prices.json` (`by_key`).
+ * @param {ReturnType<typeof mergeMirrorLibrary>} rows
+ * @param {unknown} itadDoc
+ */
+export function mergeItadPrices(rows, itadDoc) {
+  const byKey =
+    itadDoc && typeof itadDoc === 'object' && itadDoc.by_key && typeof itadDoc.by_key === 'object'
+      ? itadDoc.by_key
+      : {};
+  return (rows || []).map((row) => {
+    const entry = byKey[row.key];
+    const priceLabel = formatItadPriceLabel(entry && typeof entry === 'object' ? entry : null);
+    return priceLabel ? { ...row, priceLabel } : { ...row, priceLabel: row.priceLabel || '' };
+  });
+}
+
 /**
  * @param {{ path: string, doc: unknown }[]} catalogEntries
  * @param {unknown} personalDoc
@@ -118,6 +243,12 @@ export function mergeMirrorLibrary(catalogEntries, personalDoc, options = {}) {
       const hidden = rec.hidden === true;
       if (hidden && !options.includeHidden) continue;
       const status = String(rec.status || g.status || 'backlog');
+      const steamPercent =
+        finiteOrNull(g.steam_percent) ??
+        finiteOrNull(g.review_percent) ??
+        finiteOrNull(g.steam_rating) ??
+        finiteOrNull(g.rating);
+      const metacritic = finiteOrNull(g.metacritic) ?? finiteOrNull(g.metacritic_score);
       rows.push({
         key,
         store,
@@ -126,9 +257,19 @@ export function mergeMirrorLibrary(catalogEntries, personalDoc, options = {}) {
         status,
         statusLabel: STATUS_LABELS[status] || status,
         playtimeHours: playtimeHoursFromGame(g),
-        hltbMain: g.hltb_main_hours ?? g.hltb_main ?? null,
+        hltbMain: finiteOrNull(g.hltb_main_hours ?? g.hltb_main),
+        hltbExtra: finiteOrNull(g.hltb_extra_hours ?? g.hltb_extra),
+        hltbCompletionist: finiteOrNull(g.hltb_completionist_hours ?? g.hltb_completionist),
         notes: String(rec.notes || ''),
         hidden,
+        coverUrl: mirrorCoverUrlFor(g),
+        steamPercent,
+        metacritic,
+        released: dateLabel(g.release_date ?? g.released ?? g.release),
+        lastPlayed: dateLabel(g.last_played ?? g.rtime_last_played ?? g.lastplayed),
+        genres: genresFromGame(g.genres ?? g.genre),
+        platforms: platformsFromGame(g),
+        priceLabel: '',
       });
     }
   }
@@ -150,7 +291,8 @@ export function filterMirrorRows(rows, filters = {}) {
     if (status && row.status !== status) return false;
     if (store && row.store !== store) return false;
     if (search) {
-      const hay = `${row.title} ${row.notes} ${row.storeLabel}`.toLowerCase();
+      const genreHay = Array.isArray(row.genres) ? row.genres.join(' ') : '';
+      const hay = `${row.title} ${row.notes} ${row.storeLabel} ${genreHay} ${row.platforms || ''}`.toLowerCase();
       if (!hay.includes(search)) return false;
     }
     return true;
@@ -184,6 +326,14 @@ export function sortMirrorRows(rows, sort = {}) {
       case 'hltb':
         va = a.hltbMain ?? -1;
         vb = b.hltbMain ?? -1;
+        break;
+      case 'steam':
+        va = a.steamPercent ?? -1;
+        vb = b.steamPercent ?? -1;
+        break;
+      case 'metacritic':
+        va = a.metacritic ?? -1;
+        vb = b.metacritic ?? -1;
         break;
       default:
         va = a.title;

--- a/landing/mirror-virtual.js
+++ b/landing/mirror-virtual.js
@@ -2,8 +2,8 @@
 
 export const MIRROR_VIRTUAL_THRESHOLD = 60;
 export const MIRROR_VIRTUAL_OVERSCAN = 12;
-export const MIRROR_ROW_HEIGHT_DESKTOP = 40;
-export const MIRROR_ROW_HEIGHT_PHONE = 120;
+export const MIRROR_ROW_HEIGHT_DESKTOP = 56;
+export const MIRROR_ROW_HEIGHT_PHONE = 148;
 
 /**
  * @param {number} listLen

--- a/landing/mirror.css
+++ b/landing/mirror.css
@@ -330,6 +330,79 @@ table.mirror-table {
   white-space: nowrap;
 }
 
+.mirror-table .col-cover {
+  width: 2.75rem;
+  padding-right: 0.35rem;
+  vertical-align: middle;
+}
+
+.mirror-cover-wrap {
+  width: 2.5rem;
+  height: 3.35rem;
+  border-radius: 0.3rem;
+  overflow: hidden;
+  background: var(--bg-elev);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mirror-cover {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.mirror-cover-fallback {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--text-mute);
+}
+
+.mirror-game-title {
+  font-weight: 600;
+  color: var(--text-bright);
+  line-height: 1.3;
+}
+
+.mirror-row-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem 0.45rem;
+  margin-top: 0.28rem;
+  align-items: center;
+}
+
+.mirror-store-chip {
+  display: inline-block;
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.3rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  color: var(--accent-muted);
+}
+
+.mirror-meta-text {
+  font-size: 0.72rem;
+  color: var(--text-mute);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .mirror-status {
   display: inline-block;
   padding: 0.15rem 0.45rem;
@@ -461,8 +534,13 @@ table.mirror-table {
     min-width: 0;
   }
 
-  .mirror-table th:nth-child(5),
-  .mirror-table td:nth-child(5) {
+  /* Hide Price, MC, Released (cols 8, 7, 9) */
+  .mirror-table th.col-mc,
+  .mirror-table td.col-mc,
+  .mirror-table th:nth-child(8),
+  .mirror-table td.col-price,
+  .mirror-table th:nth-child(9),
+  .mirror-table td.col-released {
     display: none;
   }
 }
@@ -534,9 +612,7 @@ table.mirror-table {
   }
 
   table.mirror-table,
-  .mirror-table tbody,
-  .mirror-table tr,
-  .mirror-table td {
+  .mirror-table tbody {
     display: block;
     width: 100%;
   }
@@ -551,7 +627,11 @@ table.mirror-table {
     border: 1px solid var(--border-subtle);
     border-radius: 0.5rem;
     background: var(--bg-panel);
-    min-height: 7.5rem;
+    min-height: 8.5rem;
+    display: grid;
+    grid-template-columns: 3rem minmax(0, 1fr);
+    column-gap: 0.75rem;
+    row-gap: 0.15rem;
   }
 
   .mirror-table tbody tr.mirror-virtual-spacer {
@@ -561,6 +641,7 @@ table.mirror-table {
     border-radius: 0;
     background: transparent;
     min-height: 0;
+    display: block;
   }
 
   .mirror-table tbody tr:hover {
@@ -575,6 +656,7 @@ table.mirror-table {
     padding: 0.28rem 0;
     border-bottom: none;
     text-align: left;
+    width: auto;
   }
 
   .mirror-table td.col-num {
@@ -592,22 +674,52 @@ table.mirror-table {
     padding-top: 0.15rem;
   }
 
-  .mirror-table td[data-label="Title"] {
-    grid-template-columns: 1fr;
-    padding-bottom: 0.45rem;
-    margin-bottom: 0.25rem;
-    border-bottom: 1px solid var(--border-subtle);
-    font-weight: 600;
-    color: var(--text-bright);
+  .mirror-table td.col-cover {
+    grid-column: 1;
+    grid-row: 1 / span 3;
+    display: block;
+    padding: 0;
   }
 
-  .mirror-table td[data-label="Title"]::before {
+  .mirror-table td.col-cover::before {
     display: none;
   }
 
-  .mirror-table th:nth-child(5),
-  .mirror-table td:nth-child(5) {
-    display: grid;
+  .mirror-cover-wrap {
+    width: 3rem;
+    height: 4rem;
+  }
+
+  .mirror-table td.col-game {
+    grid-column: 2;
+    grid-row: 1;
+    grid-template-columns: 1fr;
+    padding-bottom: 0.35rem;
+    margin-bottom: 0.15rem;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .mirror-table td.col-game::before {
+    display: none;
+  }
+
+  .mirror-table td[data-label="Status"] {
+    grid-column: 2;
+    grid-row: 2;
+  }
+
+  .mirror-table td[data-label="Played"],
+  .mirror-table td[data-label="HLTB"] {
+    grid-column: 2;
+  }
+
+  /* Hide lower-priority metrics on phone cards */
+  .mirror-table td.col-steam,
+  .mirror-table td.col-mc,
+  .mirror-table td.col-price,
+  .mirror-table td.col-released,
+  .mirror-table td.col-lastplayed {
+    display: none;
   }
 }
 

--- a/landing/mirror.html
+++ b/landing/mirror.html
@@ -94,8 +94,8 @@
       <details class="mirror-scope-note">
         <summary>About this view</summary>
         <div class="mirror-scope-note-body">
-          <p>Read-only library from your home PC after <strong>Cloud sync</strong> / <strong>Sync now</strong> in BAKLOG. You see store catalogs plus statuses and notes from mirrored personal data.</p>
-          <p>Wishlists, deal prices, and claimables are not shown here. Claimables stay on the public feed. Wishlists and prices may still upload for desktop restore.</p>
+          <p>Read-only library from your home PC after <strong>Cloud sync</strong> / <strong>Sync now</strong> in BAKLOG. You see store catalogs, covers from store CDNs, statuses and notes, and deal prices when those files were synced.</p>
+          <p>Wishlists and claimables are not listed here. Claimables stay on the public feed. Wishlists may still upload for desktop restore.</p>
           <p><strong>Import from cloud mirror</strong> is a desktop Connections action that overwrites local files. It does not fill this page.</p>
         </div>
       </details>
@@ -114,11 +114,16 @@
         <table class="mirror-table">
           <thead>
             <tr>
-              <th scope="col">Title</th>
-              <th scope="col">Store</th>
+              <th scope="col" class="col-cover"><span class="sr-only">Cover</span></th>
+              <th scope="col">Game</th>
               <th scope="col">Status</th>
-              <th scope="col" class="col-num">Playtime</th>
+              <th scope="col" class="col-num">Played</th>
               <th scope="col" class="col-num">HLTB</th>
+              <th scope="col" class="col-num">Steam %</th>
+              <th scope="col" class="col-num">MC</th>
+              <th scope="col" class="col-num">Price</th>
+              <th scope="col">Released</th>
+              <th scope="col">Last played</th>
             </tr>
           </thead>
           <tbody id="mirrorTableBody"></tbody>

--- a/landing/mirror.js
+++ b/landing/mirror.js
@@ -4,6 +4,7 @@ import {
   STORE_LABELS,
   catalogArtifactPaths,
   filterMirrorRows,
+  mergeItadPrices,
   mergeMirrorLibrary,
   sortMirrorRows,
   summarizeMirrorRows,
@@ -36,7 +37,7 @@ const tableWrap = document.querySelector('.mirror-table-wrap');
 
 const PHONE_MQ = '(max-width: 639.98px), (max-height: 480px) and (hover: none)';
 const CATALOG_FETCH_CONCURRENCY = 5;
-const COLSPAN = 5;
+const COLSPAN = 10;
 
 /** @type {ReturnType<typeof mergeMirrorLibrary>} */
 let allRows = [];
@@ -95,6 +96,63 @@ function formatHours(value) {
   if (value == null || !Number.isFinite(Number(value))) return ' - ';
   const n = Number(value);
   return `${n % 1 === 0 ? n : n.toFixed(1)}h`;
+}
+
+function formatHltb(row) {
+  const main = row.hltbMain;
+  const extra = row.hltbExtra;
+  if (main == null && extra == null) return ' - ';
+  if (main != null && extra != null) {
+    return `${formatHours(main).replace(/h$/, '')} / ${formatHours(extra)}`;
+  }
+  return formatHours(main ?? extra);
+}
+
+function formatPercent(value) {
+  if (value == null || !Number.isFinite(Number(value))) return ' - ';
+  return `${Math.round(Number(value))}%`;
+}
+
+function formatScore(value) {
+  if (value == null || !Number.isFinite(Number(value))) return ' - ';
+  return String(Math.round(Number(value)));
+}
+
+function coverCellHtml(row) {
+  const initial = escapeHtml(String(row.title || '?').trim().charAt(0).toUpperCase() || '?');
+  const url = String(row.coverUrl || '').trim();
+  if (url && /^https?:\/\//i.test(url)) {
+    return `<td class="col-cover" data-label="Cover"><div class="mirror-cover-wrap"><img class="mirror-cover" src="${escapeHtml(url)}" alt="" loading="lazy" decoding="async" onerror="this.style.display='none';var f=this.nextElementSibling;if(f)f.hidden=false" /><span class="mirror-cover-fallback" hidden aria-hidden="true">${initial}</span></div></td>`;
+  }
+  return `<td class="col-cover" data-label="Cover"><div class="mirror-cover-wrap"><span class="mirror-cover-fallback" aria-hidden="true">${initial}</span></div></td>`;
+}
+
+function gameCellHtml(row) {
+  const note = row.notes ? `<div class="mirror-note">${escapeHtml(row.notes)}</div>` : '';
+  const metaBits = [];
+  metaBits.push(`<span class="mirror-store-chip">${escapeHtml(row.storeLabel)}</span>`);
+  if (Array.isArray(row.genres) && row.genres.length) {
+    metaBits.push(`<span class="mirror-meta-text">${escapeHtml(row.genres.join(', '))}</span>`);
+  }
+  if (row.platforms) {
+    metaBits.push(`<span class="mirror-meta-text">${escapeHtml(row.platforms)}</span>`);
+  }
+  return `<td class="col-game" data-label="Game"><div class="mirror-game-title">${escapeHtml(row.title)}</div>${note}<div class="mirror-row-meta">${metaBits.join('')}</div></td>`;
+}
+
+function rowHtml(row, index) {
+  return `<tr data-row-index="${index}">
+        ${coverCellHtml(row)}
+        ${gameCellHtml(row)}
+        <td data-label="Status"><span class="${statusClass(row.status)}">${escapeHtml(row.statusLabel)}</span></td>
+        <td class="col-num" data-label="Played">${formatHours(row.playtimeHours)}</td>
+        <td class="col-num" data-label="HLTB">${formatHltb(row)}</td>
+        <td class="col-num col-steam" data-label="Steam %">${formatPercent(row.steamPercent)}</td>
+        <td class="col-num col-mc" data-label="MC">${formatScore(row.metacritic)}</td>
+        <td class="col-num col-price" data-label="Price">${escapeHtml(row.priceLabel || ' - ')}</td>
+        <td class="col-date col-released" data-label="Released">${escapeHtml(row.released || ' - ')}</td>
+        <td class="col-date col-lastplayed" data-label="Last played">${escapeHtml(row.lastPlayed || ' - ')}</td>
+      </tr>`;
 }
 
 function statusClass(status) {
@@ -221,17 +279,6 @@ function populateFilters(rows) {
   storeFilter.value = [...storeFilter.options].some((o) => o.value === currentStore) ? currentStore : '';
 }
 
-function rowHtml(row, index) {
-  const note = row.notes ? `<div class="mirror-note">${escapeHtml(row.notes)}</div>` : '';
-  return `<tr data-row-index="${index}">
-        <td data-label="Title">${escapeHtml(row.title)}${note}</td>
-        <td data-label="Store">${escapeHtml(row.storeLabel)}</td>
-        <td data-label="Status"><span class="${statusClass(row.status)}">${escapeHtml(row.statusLabel)}</span></td>
-        <td class="col-num" data-label="Playtime">${formatHours(row.playtimeHours)}</td>
-        <td class="col-num" data-label="HLTB">${formatHours(row.hltbMain)}</td>
-      </tr>`;
-}
-
 function spacerHtml(kind, heightPx) {
   const h = Math.max(0, heightPx);
   return `<tr class="mirror-virtual-spacer mirror-virtual-spacer--${kind}" aria-hidden="true"><td colspan="${COLSPAN}" style="height:${h}px"></td></tr>`;
@@ -326,6 +373,7 @@ async function loadLibrary(session) {
     const list = await mirrorFetch('', token);
     let catalogRows = (list.artifacts || []).filter((row) => catalogArtifactPaths([row]).length);
     const personalRows = (list.artifacts || []).filter((row) => row.path === 'data/personal.json');
+    const itadRows = (list.artifacts || []).filter((row) => row.path === 'itad_prices.json');
 
     if (!catalogRows.length) {
       setMergeHint([]);
@@ -349,14 +397,30 @@ async function loadLibrary(session) {
       doc: await mirrorFetch(row.path, token, row.profile),
     }));
     let personal = null;
+    let personalProfile = null;
     if (personalRows.length) {
       const pref =
         personalRows.find((row) => row.profile === userId)
         || personalRows.find((row) => row.profile === 'default')
         || personalRows[0];
+      personalProfile = pref.profile;
       personal = await mirrorFetch('data/personal.json', token, pref.profile);
     }
     allRows = mergeMirrorLibrary(catalogs, personal);
+
+    if (itadRows.length) {
+      const itadPref =
+        (personalProfile && itadRows.find((row) => row.profile === personalProfile))
+        || itadRows.find((row) => row.profile === userId)
+        || itadRows.find((row) => row.profile === 'default')
+        || itadRows[0];
+      try {
+        const itadDoc = await mirrorFetch('itad_prices.json', token, itadPref.profile);
+        allRows = mergeItadPrices(allRows, itadDoc);
+      } catch {
+        // Prices are optional enrichment.
+      }
+    }
 
     if (!allRows.length) {
       setMergeHint([]);

--- a/scripts/mirror-overflow-audit.mjs
+++ b/scripts/mirror-overflow-audit.mjs
@@ -86,7 +86,16 @@ function makeSyntheticRows(n) {
       statusLabel: statuses[i % statuses.length],
       playtimeHours: (i % 40) + 0.5,
       hltbMain: (i % 20) + 1,
+      hltbExtra: (i % 10) + 2,
       notes: i % 17 === 0 ? 'note' : '',
+      coverUrl: i % 5 === 0 ? 'https://cdn.akamai.steamstatic.com/steam/apps/570/header.jpg' : '',
+      steamPercent: 70 + (i % 30),
+      metacritic: 60 + (i % 40),
+      priceLabel: i % 9 === 0 ? '$4.99 (-50%)' : '',
+      released: '2020-01-01',
+      lastPlayed: i % 3 === 0 ? 'Jan 2, 2026' : '',
+      genres: i % 4 === 0 ? ['Action', 'RPG'] : [],
+      platforms: '',
     });
   }
   return rows;

--- a/tests/mirror-merge.test.js
+++ b/tests/mirror-merge.test.js
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 import {
   catalogArtifactPaths,
   filterMirrorRows,
+  formatItadPriceLabel,
+  mergeItadPrices,
   mergeMirrorLibrary,
+  mirrorCoverUrlFor,
   sortMirrorRows,
   summarizeMirrorRows,
 } from '../landing/mirror-merge.js';
@@ -31,6 +34,63 @@ describe('mirror-merge', () => {
     const alpha = rows.find((r) => r.title === 'Alpha');
     expect(alpha?.status).toBe('playing');
     expect(alpha?.notes).toBe('fun');
+  });
+
+  it('passes cover URL and catalog metrics through', () => {
+    const rows = mergeMirrorLibrary(
+      [
+        {
+          path: 'games_steam.json',
+          doc: {
+            games: [
+              {
+                id: '730',
+                name: 'CS',
+                store: 'steam',
+                library_image: 'https://cdn.example/lib.jpg',
+                steam_percent: 88,
+                metacritic: 81,
+                hltb_main_hours: 10,
+                hltb_extra_hours: 20,
+                genres: ['Action', 'FPS', 'Extra'],
+                release_date: '2012-08-21',
+                rtime_last_played: 1700000000,
+              },
+            ],
+          },
+        },
+      ],
+      {},
+    );
+    expect(rows[0].coverUrl).toBe('https://cdn.example/lib.jpg');
+    expect(rows[0].steamPercent).toBe(88);
+    expect(rows[0].metacritic).toBe(81);
+    expect(rows[0].hltbMain).toBe(10);
+    expect(rows[0].hltbExtra).toBe(20);
+    expect(rows[0].genres).toEqual(['Action', 'FPS']);
+    expect(rows[0].released).toMatch(/2012/);
+    expect(rows[0].lastPlayed).toBeTruthy();
+  });
+
+  it('falls back to Steam header CDN for cover', () => {
+    expect(mirrorCoverUrlFor({ store: 'steam', id: '570' })).toBe(
+      'https://cdn.akamai.steamstatic.com/steam/apps/570/header.jpg',
+    );
+    expect(mirrorCoverUrlFor({ store: 'gog', id: 'x', library_image: 'ftp://bad' })).toBe('');
+  });
+
+  it('joins ITAD prices by game key', () => {
+    const rows = mergeMirrorLibrary(
+      [{ path: 'games_steam.json', doc: { games: [{ id: '1', name: 'A', store: 'steam' }] } }],
+      {},
+    );
+    const priced = mergeItadPrices(rows, {
+      by_key: {
+        'steam:1': { price_str: '$4.99', cut: 50, currency: 'USD', price: 4.99 },
+      },
+    });
+    expect(priced[0].priceLabel).toBe('$4.99 (-50%)');
+    expect(formatItadPriceLabel({ price: 10, currency: 'USD' })).toBe('USD 10');
   });
 
   it('filters and sorts', () => {


### PR DESCRIPTION
## Summary
- Hosted `/mirror` rows closer to the desktop library: cover, game meta (store chip / genres / platforms), status, playtime, HLTB, Steam %, Metacritic, deal price (when `itad_prices.json` is synced), released, last played.
- Covers use `library_image` / `header_image` / Steam CDN URLs already in mirrored JSON - no image storage on Supabase/Vercel.
- Phone cards keep cover + core metrics; tablet hides price/MC/released.

## Test plan
- [x] `npx vitest run tests/mirror-merge.test.js tests/mirror-virtual.test.js`
- [x] `npm run test:mirror-responsive`
- [ ] Hard-refresh baklog.app/mirror and spot-check cover + metrics on desktop and phone
