### PR TITLE
Fix broken /mirror covers (CSP img-src)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Fixed
 
+- Hosted cloud library covers load again (CSP allows HTTPS store CDN images on `/mirror`).
 - Hosted cloud library scrolls large catalogs with virtual rows so the page does not freeze when thousands of games load.
 - Cloud mirror page no longer hits "Too many requests" when loading a full library (higher limits for `/api/mirror` and `/api/auth-config`).
 - Ubisoft wishlist Connect retries once on a transient browser navigation error before failing.

--- a/landing/vercel.json
+++ b/landing/vercel.json
@@ -25,7 +25,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'sha256-MUTZmPoMWlbCHgWnl6ZOqieYIw16NdlicHoRzqNWRKY=' https://www.googletagmanager.com https://*.googletagmanager.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https://www.googletagmanager.com https://*.google-analytics.com; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; form-action 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none'"
+          "value": "default-src 'self'; script-src 'self' 'sha256-MUTZmPoMWlbCHgWnl6ZOqieYIw16NdlicHoRzqNWRKY=' https://www.googletagmanager.com https://*.googletagmanager.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https: https://www.googletagmanager.com https://*.google-analytics.com; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; form-action 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none'"
         }
       ]
     },
@@ -139,7 +139,7 @@
         { "key": "X-Robots-Tag", "value": "noindex, nofollow" },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://*.supabase.co wss://*.supabase.co; form-action 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none'"
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co; form-action 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none'"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- Root cause: Vercel CSP on `/mirror` (and the site-wide rule) only allowed `img-src 'self' data:`, so Steam/GOG/Xbox CDN covers were blocked.
- Multiple CSP headers are combined with AND, so both policies now include `https:` for images.

## Test plan
- [ ] After Vercel deploy, hard-refresh baklog.app/mirror and confirm covers render
- [ ] DevTools console has no CSP img-src violations for steamstatic/cdn URLs
