### PR TITLE
Fix /mirror covers that 404 on Steam library capsules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Fixed
 
+- Hosted cloud library covers fall back to the Steam header art when the portrait library capsule is missing (for example Afterfall InSanity Extended Edition).
 - Hosted cloud library covers load again (CSP allows HTTPS store CDN images on `/mirror`).
 - Hosted cloud library scrolls large catalogs with virtual rows so the page does not freeze when thousands of games load.
 - Cloud mirror page no longer hits "Too many requests" when loading a full library (higher limits for `/api/mirror` and `/api/auth-config`).

--- a/landing/mirror-merge.js
+++ b/landing/mirror-merge.js
@@ -54,19 +54,6 @@ function storeRank(store) {
   return idx === -1 ? order.length : idx;
 }
 
-/** @param {unknown} url */
-export function sanitizeMirrorCoverUrl(url) {
-  if (!url) return '';
-  let u = String(url).trim();
-  if (!u) return '';
-  u = u.replace('://images-eds.xboxlive.com/', '://images-eds-ssl.xboxlive.com/');
-  if (u.includes('${size}') && /cdn\.nintendo\.net/i.test(u)) {
-    u = u.replace(/\$\{size\}/g, '256');
-  }
-  if (!/^https?:\/\//i.test(u)) return '';
-  return u;
-}
-
 /**
  * Prefer library_image, then header_image, then Steam header CDN.
  * @param {Record<string, unknown>} g
@@ -82,6 +69,43 @@ export function mirrorCoverUrlFor(g) {
     return `${STEAM_HEADER_CDN}/${id}/header.jpg`;
   }
   return '';
+}
+
+/**
+ * Secondary cover when primary 404s (common for older Steam titles without
+ * library_600x900 capsules). Distinct from primary only.
+ * @param {Record<string, unknown>} g
+ * @param {string} [primary]
+ */
+export function mirrorCoverFallbackUrlFor(g, primary = '') {
+  const primaryUrl = primary || mirrorCoverUrlFor(g);
+  const candidates = [];
+  const header = sanitizeMirrorCoverUrl(g?.header_image);
+  if (header) candidates.push(header);
+  const store = String(g?.store || '').toLowerCase();
+  const id = g?.id;
+  if (store === 'steam' && id != null && String(id).trim() !== '' && /^\d+$/.test(String(id))) {
+    candidates.push(`${STEAM_HEADER_CDN}/${id}/header.jpg`);
+  }
+  for (const url of candidates) {
+    if (url && url !== primaryUrl) return url;
+  }
+  return '';
+}
+
+/** @param {unknown} url */
+export function sanitizeMirrorCoverUrl(url) {
+  if (!url) return '';
+  let u = String(url).trim();
+  if (!u) return '';
+  u = u.replace('://images-eds.xboxlive.com/', '://images-eds-ssl.xboxlive.com/');
+  // itch occasionally ships a broken "originalb" size token; original works when the asset exists.
+  u = u.replace(/\/originalb\//g, '/original/');
+  if (u.includes('${size}') && /cdn\.nintendo\.net/i.test(u)) {
+    u = u.replace(/\$\{size\}/g, '256');
+  }
+  if (!/^https?:\/\//i.test(u)) return '';
+  return u;
 }
 
 /** @param {Record<string, unknown>} g */
@@ -249,6 +273,7 @@ export function mergeMirrorLibrary(catalogEntries, personalDoc, options = {}) {
         finiteOrNull(g.steam_rating) ??
         finiteOrNull(g.rating);
       const metacritic = finiteOrNull(g.metacritic) ?? finiteOrNull(g.metacritic_score);
+      const coverUrl = mirrorCoverUrlFor(g);
       rows.push({
         key,
         store,
@@ -262,7 +287,8 @@ export function mergeMirrorLibrary(catalogEntries, personalDoc, options = {}) {
         hltbCompletionist: finiteOrNull(g.hltb_completionist_hours ?? g.hltb_completionist),
         notes: String(rec.notes || ''),
         hidden,
-        coverUrl: mirrorCoverUrlFor(g),
+        coverUrl,
+        coverFallbackUrl: mirrorCoverFallbackUrlFor(g, coverUrl),
         steamPercent,
         metacritic,
         released: dateLabel(g.release_date ?? g.released ?? g.release),

--- a/landing/mirror.js
+++ b/landing/mirror.js
@@ -39,6 +39,25 @@ const PHONE_MQ = '(max-width: 639.98px), (max-height: 480px) and (hover: none)';
 const CATALOG_FETCH_CONCURRENCY = 5;
 const COLSPAN = 10;
 
+/** Retry header/Steam CDN once, then show letter placeholder. */
+window.__baklogMirrorCoverError = function mirrorCoverError(img) {
+  if (!img || img.dataset.mirrorCoverTried === '1') {
+    img.style.display = 'none';
+    const fallback = img.nextElementSibling;
+    if (fallback) fallback.hidden = false;
+    return;
+  }
+  const next = String(img.dataset.fallback || '').trim();
+  if (next && /^https?:\/\//i.test(next) && next !== img.getAttribute('src')) {
+    img.dataset.mirrorCoverTried = '1';
+    img.src = next;
+    return;
+  }
+  img.style.display = 'none';
+  const fallback = img.nextElementSibling;
+  if (fallback) fallback.hidden = false;
+};
+
 /** @type {ReturnType<typeof mergeMirrorLibrary>} */
 let allRows = [];
 /** @type {ReturnType<typeof mergeMirrorLibrary>} */
@@ -121,8 +140,13 @@ function formatScore(value) {
 function coverCellHtml(row) {
   const initial = escapeHtml(String(row.title || '?').trim().charAt(0).toUpperCase() || '?');
   const url = String(row.coverUrl || '').trim();
+  const fallback = String(row.coverFallbackUrl || '').trim();
   if (url && /^https?:\/\//i.test(url)) {
-    return `<td class="col-cover" data-label="Cover"><div class="mirror-cover-wrap"><img class="mirror-cover" src="${escapeHtml(url)}" alt="" loading="lazy" decoding="async" onerror="this.style.display='none';var f=this.nextElementSibling;if(f)f.hidden=false" /><span class="mirror-cover-fallback" hidden aria-hidden="true">${initial}</span></div></td>`;
+    const fbAttr =
+      fallback && /^https?:\/\//i.test(fallback) && fallback !== url
+        ? ` data-fallback="${escapeHtml(fallback)}"`
+        : '';
+    return `<td class="col-cover" data-label="Cover"><div class="mirror-cover-wrap"><img class="mirror-cover" src="${escapeHtml(url)}" alt="" loading="lazy" decoding="async"${fbAttr} onerror="window.__baklogMirrorCoverError&&window.__baklogMirrorCoverError(this)" /><span class="mirror-cover-fallback" hidden aria-hidden="true">${initial}</span></div></td>`;
   }
   return `<td class="col-cover" data-label="Cover"><div class="mirror-cover-wrap"><span class="mirror-cover-fallback" aria-hidden="true">${initial}</span></div></td>`;
 }

--- a/tests/mirror-merge.test.js
+++ b/tests/mirror-merge.test.js
@@ -5,7 +5,9 @@ import {
   formatItadPriceLabel,
   mergeItadPrices,
   mergeMirrorLibrary,
+  mirrorCoverFallbackUrlFor,
   mirrorCoverUrlFor,
+  sanitizeMirrorCoverUrl,
   sortMirrorRows,
   summarizeMirrorRows,
 } from '../landing/mirror-merge.js';
@@ -77,6 +79,24 @@ describe('mirror-merge', () => {
       'https://cdn.akamai.steamstatic.com/steam/apps/570/header.jpg',
     );
     expect(mirrorCoverUrlFor({ store: 'gog', id: 'x', library_image: 'ftp://bad' })).toBe('');
+  });
+
+  it('keeps a distinct header fallback when library capsule is primary', () => {
+    const g = {
+      store: 'steam',
+      id: '224420',
+      library_image: 'https://cdn.akamai.steamstatic.com/steam/apps/224420/library_600x900.jpg',
+      header_image: 'https://cdn.akamai.steamstatic.com/steam/apps/224420/header.jpg',
+    };
+    const primary = mirrorCoverUrlFor(g);
+    expect(primary).toContain('library_600x900');
+    expect(mirrorCoverFallbackUrlFor(g, primary)).toContain('header.jpg');
+  });
+
+  it('rewrites itch originalb size token', () => {
+    expect(
+      sanitizeMirrorCoverUrl('https://img.itch.zone/aW1nLzE=/originalb/x.gif'),
+    ).toBe('https://img.itch.zone/aW1nLzE=/original/x.gif');
   });
 
   it('joins ITAD prices by game key', () => {


### PR DESCRIPTION
## Summary
- **Afterfall InSanity Extended Edition**: `library_600x900.jpg` is 404 on Steam CDN; `header.jpg` is fine. Mirror preferred library and jumped straight to a letter placeholder.
- Now rows carry `coverFallbackUrl` (header / Steam header CDN when distinct) and the img `onerror` retries once before the letter.
- Bonus: rewrite itch `originalb` → `original` size token (helps some GIF 500s when the asset still exists).

## Note on itch
- Dead itch CDN URLs (403/404 after publishers replace covers) still show the letter until a desktop itch refresh updates `library_image` in the mirror. Same URL is usually stored as both library and header, so fallback cannot invent a new asset.

## Test plan
- [x] `npx vitest run tests/mirror-merge.test.js`
- [ ] After deploy: Afterfall shows header art on baklog.app/mirror
- [ ] Spot-check a normal Steam portrait library cover still loads


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic fallback artwork when hosted library covers or portrait capsule images are unavailable.
  * Steam library entries can now fall back to header artwork from Steam’s CDN.
  * Improved handling of itch.io cover image URLs to use the correct image size.
  * If both primary and fallback artwork fail, the cover is hidden and its placeholder is shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->