### PR TITLE
Always show /mirror cover letter placeholder on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Fixed
 
+- Hosted cloud library always keeps a letter placeholder under covers, so dead itch/Steam art never leaves an empty hole.
 - Hosted cloud library covers fall back to the Steam header art when the portrait library capsule is missing (for example Afterfall InSanity Extended Edition).
 - Hosted cloud library covers load again (CSP allows HTTPS store CDN images on `/mirror`).
 - Hosted cloud library scrolls large catalogs with virtual rows so the page does not freeze when thousands of games load.

--- a/landing/mirror.css
+++ b/landing/mirror.css
@@ -337,6 +337,7 @@ table.mirror-table {
 }
 
 .mirror-cover-wrap {
+  position: relative;
   width: 2.5rem;
   height: 3.35rem;
   border-radius: 0.3rem;
@@ -348,16 +349,28 @@ table.mirror-table {
 }
 
 .mirror-cover {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
   object-fit: cover;
   display: block;
+  z-index: 1;
+  background: var(--bg-elev);
+}
+
+.mirror-cover.mirror-cover--failed {
+  display: none;
 }
 
 .mirror-cover-fallback {
+  position: relative;
+  z-index: 0;
   font-size: 0.95rem;
   font-weight: 700;
   color: var(--text-mute);
+  line-height: 1;
+  user-select: none;
 }
 
 .mirror-game-title {

--- a/landing/mirror.js
+++ b/landing/mirror.js
@@ -39,12 +39,19 @@ const PHONE_MQ = '(max-width: 639.98px), (max-height: 480px) and (hover: none)';
 const CATALOG_FETCH_CONCURRENCY = 5;
 const COLSPAN = 10;
 
-/** Retry header/Steam CDN once, then show letter placeholder. */
+/** Retry header/Steam CDN once, then leave the letter placeholder visible. */
 window.__baklogMirrorCoverError = function mirrorCoverError(img) {
-  if (!img || img.dataset.mirrorCoverTried === '1') {
-    img.style.display = 'none';
-    const fallback = img.nextElementSibling;
-    if (fallback) fallback.hidden = false;
+  if (!img) return;
+  const wrap = img.closest('.mirror-cover-wrap');
+  const showPlaceholder = () => {
+    img.classList.add('mirror-cover--failed');
+    img.removeAttribute('src');
+    img.alt = '';
+    const letter = wrap?.querySelector('.mirror-cover-fallback');
+    if (letter) letter.hidden = false;
+  };
+  if (img.dataset.mirrorCoverTried === '1') {
+    showPlaceholder();
     return;
   }
   const next = String(img.dataset.fallback || '').trim();
@@ -53,9 +60,7 @@ window.__baklogMirrorCoverError = function mirrorCoverError(img) {
     img.src = next;
     return;
   }
-  img.style.display = 'none';
-  const fallback = img.nextElementSibling;
-  if (fallback) fallback.hidden = false;
+  showPlaceholder();
 };
 
 /** @type {ReturnType<typeof mergeMirrorLibrary>} */
@@ -141,14 +146,16 @@ function coverCellHtml(row) {
   const initial = escapeHtml(String(row.title || '?').trim().charAt(0).toUpperCase() || '?');
   const url = String(row.coverUrl || '').trim();
   const fallback = String(row.coverFallbackUrl || '').trim();
+  const letter = `<span class="mirror-cover-fallback" aria-hidden="true">${initial}</span>`;
   if (url && /^https?:\/\//i.test(url)) {
     const fbAttr =
       fallback && /^https?:\/\//i.test(fallback) && fallback !== url
         ? ` data-fallback="${escapeHtml(fallback)}"`
         : '';
-    return `<td class="col-cover" data-label="Cover"><div class="mirror-cover-wrap"><img class="mirror-cover" src="${escapeHtml(url)}" alt="" loading="lazy" decoding="async"${fbAttr} onerror="window.__baklogMirrorCoverError&&window.__baklogMirrorCoverError(this)" /><span class="mirror-cover-fallback" hidden aria-hidden="true">${initial}</span></div></td>`;
+    // Letter sits under the image so any load failure still leaves a placeholder.
+    return `<td class="col-cover" data-label="Cover"><div class="mirror-cover-wrap">${letter}<img class="mirror-cover" src="${escapeHtml(url)}" alt="" loading="lazy" decoding="async"${fbAttr} onerror="window.__baklogMirrorCoverError&&window.__baklogMirrorCoverError(this)" /></div></td>`;
   }
-  return `<td class="col-cover" data-label="Cover"><div class="mirror-cover-wrap"><span class="mirror-cover-fallback" aria-hidden="true">${initial}</span></div></td>`;
+  return `<td class="col-cover" data-label="Cover"><div class="mirror-cover-wrap">${letter}</div></td>`;
 }
 
 function gameCellHtml(row) {


### PR DESCRIPTION
## Summary
- Cover cell always includes a title-initial placeholder under the `<img>`.
- On load failure (after optional header retry), the image is marked failed/hidden; the letter stays visible.
- No more empty cover holes when itch/Steam CDN assets 403/404.

## Test plan
- [ ] Hard-refresh baklog.app/mirror after deploy
- [ ] Broken itch cover (e.g. 21G) shows a letter, not a blank box
- [ ] Afterfall still shows header art when library capsule 404s
- [ ] Healthy covers still paint over the letter


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cover images that fail to load now display a letter placeholder instead of leaving an empty space.
  - Placeholder letters remain available beneath cover art and are revealed automatically when artwork is unavailable.
  - Improved handling ensures covers without an image URL also display a consistent placeholder.
- **Documentation**
  - Updated the unreleased changes log to document the improved cover fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->