### PR TITLE
Fix /mirror cover CSP fallbacks and credential About copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 ### Changed
 
 - Hosted cloud library rows show covers (store CDNs) plus playtime, HLTB, Steam %, Metacritic, deal price when synced, release, and last played - closer to the desktop library table without uploading image files.
-- Hosted cloud library About this view explains read-only sync vs desktop Import; when more than one cloud profile is uploaded it notes that the table is merged.
+- Hosted cloud library About this view explains read-only sync vs desktop Import, that store credentials stay on your PC, and when more than one cloud profile is uploaded it notes that the table is merged.
 - Import from cloud mirror can choose which cloud profile folder to pull into the current local profile.
 - Hosted cloud library (`/mirror`) is usable on phone and tablet: app breakpoint ladder, touch-sized controls, and card rows on narrow viewports.
 - Hosted cloud library (`/mirror`) header uses the same brand lockup as the desktop app (logo, wordmark, Cloud chip) at a denser size so it does not read oversized without the app nav beside it; Refresh and Sign out stay in the header.
@@ -51,6 +51,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Fixed
 
+- Hosted cloud library cover fallback no longer uses inline `onerror` (blocked by CSP); dead CDN art still shows the letter placeholder.
 - Hosted cloud library always keeps a letter placeholder under covers, so dead itch/Steam art never leaves an empty hole.
 - Hosted cloud library covers fall back to the Steam header art when the portrait library capsule is missing (for example Afterfall InSanity Extended Edition).
 - Hosted cloud library covers load again (CSP allows HTTPS store CDN images on `/mirror`).

--- a/landing/mirror.html
+++ b/landing/mirror.html
@@ -95,6 +95,7 @@
         <summary>About this view</summary>
         <div class="mirror-scope-note-body">
           <p>Read-only library from your home PC after <strong>Cloud sync</strong> / <strong>Sync now</strong> in BAKLOG. You see store catalogs, covers from store CDNs, statuses and notes, and deal prices when those files were synced.</p>
+          <p>Store credentials stay encrypted on your PC. This page only shows catalog JSON your desktop uploaded - sign-in never leaves your machine.</p>
           <p>Wishlists and claimables are not listed here. Claimables stay on the public feed. Wishlists may still upload for desktop restore.</p>
           <p><strong>Import from cloud mirror</strong> is a desktop Connections action that overwrites local files. It does not fill this page.</p>
         </div>

--- a/landing/mirror.js
+++ b/landing/mirror.js
@@ -40,8 +40,8 @@ const CATALOG_FETCH_CONCURRENCY = 5;
 const COLSPAN = 10;
 
 /** Retry header/Steam CDN once, then leave the letter placeholder visible. */
-window.__baklogMirrorCoverError = function mirrorCoverError(img) {
-  if (!img) return;
+function mirrorCoverError(img) {
+  if (!img || img.classList.contains('mirror-cover--failed')) return;
   const wrap = img.closest('.mirror-cover-wrap');
   const showPlaceholder = () => {
     img.classList.add('mirror-cover--failed');
@@ -61,7 +61,20 @@ window.__baklogMirrorCoverError = function mirrorCoverError(img) {
     return;
   }
   showPlaceholder();
-};
+}
+
+/** CSP on /mirror forbids inline onerror; bind after each virtual paint. */
+function bindMirrorCoverErrors(root = tableBody) {
+  if (!root) return;
+  root.querySelectorAll('img.mirror-cover:not([data-mirror-cover-bound])').forEach((img) => {
+    img.dataset.mirrorCoverBound = '1';
+    img.addEventListener('error', () => mirrorCoverError(img));
+    // Cached failures can complete before the listener attaches.
+    if (img.complete && img.naturalWidth === 0 && img.getAttribute('src')) {
+      mirrorCoverError(img);
+    }
+  });
+}
 
 /** @type {ReturnType<typeof mergeMirrorLibrary>} */
 let allRows = [];
@@ -153,7 +166,7 @@ function coverCellHtml(row) {
         ? ` data-fallback="${escapeHtml(fallback)}"`
         : '';
     // Letter sits under the image so any load failure still leaves a placeholder.
-    return `<td class="col-cover" data-label="Cover"><div class="mirror-cover-wrap">${letter}<img class="mirror-cover" src="${escapeHtml(url)}" alt="" loading="lazy" decoding="async"${fbAttr} onerror="window.__baklogMirrorCoverError&&window.__baklogMirrorCoverError(this)" /></div></td>`;
+    return `<td class="col-cover" data-label="Cover"><div class="mirror-cover-wrap">${letter}<img class="mirror-cover" src="${escapeHtml(url)}" alt="" loading="lazy" decoding="async"${fbAttr} /></div></td>`;
   }
   return `<td class="col-cover" data-label="Cover"><div class="mirror-cover-wrap">${letter}</div></td>`;
 }
@@ -342,6 +355,7 @@ function paintMirrorSlice() {
   if (!usesMirrorVirtualScroll(len)) {
     tableBody.innerHTML = list.map((row, i) => rowHtml(row, i)).join('');
     _virtualWindow = { start: 0, end: len };
+    bindMirrorCoverErrors();
     refreshMeasuredRowHeight();
     return;
   }
@@ -366,6 +380,7 @@ function paintMirrorSlice() {
   }
   parts.push(spacerHtml('bottom', (len - end) * _rowHeightPx));
   tableBody.innerHTML = parts.join('');
+  bindMirrorCoverErrors();
   refreshMeasuredRowHeight();
 }
 

--- a/scripts/mirror-overflow-audit.mjs
+++ b/scripts/mirror-overflow-audit.mjs
@@ -61,8 +61,9 @@ function startStaticServer() {
       res.writeHead(200, { 'Content-Type': MIME[ext] || 'application/octet-stream' });
       fs.createReadStream(filePath).pipe(res);
     } catch (err) {
+      console.error(err);
       res.writeHead(500);
-      res.end(String(err));
+      res.end('internal error');
     }
   });
   return new Promise((resolve) => {


### PR DESCRIPTION
## Summary
- Bind hosted `/mirror` cover load failures with `addEventListener` instead of inline `onerror`, so CSP no longer blocks header retry and the letter placeholder (including already-cached dead CDN art).
- About this view notes that store credentials stay on the home PC and only synced catalog JSON appears on the page.
- Local mirror overflow audit static server returns a generic 500 body instead of `String(err)` (CodeQL `js/stack-trace-exposure` #193).

## Test plan
- [ ] Open `/mirror`, force a dead itch/Steam cover, confirm no CSP inline-handler console error and the letter placeholder still appears.
- [ ] Confirm Steam library→header fallback still runs once for missing portrait capsules.
- [ ] Expand About this view and confirm the credentials/local privacy sentence.
- [ ] After merge, confirm CodeQL alert #193 closes or is marked fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that store credentials remain encrypted on the user’s PC and are not transmitted during mirror sign-in.
  - Explained that the hosted mirror displays uploaded catalog data only.

- **Bug Fixes**
  - Fixed cover-image fallback behavior when CDN artwork fails, including cached failures, with reliable letter placeholders.
  - Improved error responses from the static server by showing a generic message instead of exposing internal error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->