### PR TITLE
Stop re-fetching dead /mirror covers on every scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Fixed
 
+- Hosted cloud library remembers dead cover CDN URLs for the page session so scrolling virtual rows does not re-request the same 403/404 art.
 - Hosted cloud library cover fallback no longer uses inline `onerror` (blocked by CSP); dead CDN art still shows the letter placeholder.
 - Hosted cloud library always keeps a letter placeholder under covers, so dead itch/Steam art never leaves an empty hole.
 - Hosted cloud library covers fall back to the Steam header art when the portrait library capsule is missing (for example Afterfall InSanity Extended Edition).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 ### Changed
 
 - Hosted cloud library rows show covers (store CDNs) plus playtime, HLTB, Steam %, Metacritic, deal price when synced, release, and last played - closer to the desktop library table without uploading image files.
-- Hosted cloud library About this view explains read-only sync vs desktop Import; when more than one cloud profile is uploaded it notes that the table is merged.
+- Hosted cloud library About this view explains read-only sync vs desktop Import, that store credentials stay on your PC, and when more than one cloud profile is uploaded it notes that the table is merged.
 - Import from cloud mirror can choose which cloud profile folder to pull into the current local profile.
 - Hosted cloud library (`/mirror`) is usable on phone and tablet: app breakpoint ladder, touch-sized controls, and card rows on narrow viewports.
 - Hosted cloud library (`/mirror`) header uses the same brand lockup as the desktop app (logo, wordmark, Cloud chip) at a denser size so it does not read oversized without the app nav beside it; Refresh and Sign out stay in the header.
@@ -51,6 +51,7 @@ version is `pyproject.toml` (mirrored into `package.json` and the
 
 ### Fixed
 
+- Hosted cloud library cover fallback no longer uses inline `onerror` (blocked by CSP); dead CDN art still shows the letter placeholder.
 - Hosted cloud library always keeps a letter placeholder under covers, so dead itch/Steam art never leaves an empty hole.
 - Hosted cloud library covers fall back to the Steam header art when the portrait library capsule is missing (for example Afterfall InSanity Extended Edition).
 - Hosted cloud library covers load again (CSP allows HTTPS store CDN images on `/mirror`).

--- a/landing/mirror.html
+++ b/landing/mirror.html
@@ -95,6 +95,7 @@
         <summary>About this view</summary>
         <div class="mirror-scope-note-body">
           <p>Read-only library from your home PC after <strong>Cloud sync</strong> / <strong>Sync now</strong> in BAKLOG. You see store catalogs, covers from store CDNs, statuses and notes, and deal prices when those files were synced.</p>
+          <p>Store credentials stay encrypted on your PC. This page only shows catalog JSON your desktop uploaded - sign-in never leaves your machine.</p>
           <p>Wishlists and claimables are not listed here. Claimables stay on the public feed. Wishlists may still upload for desktop restore.</p>
           <p><strong>Import from cloud mirror</strong> is a desktop Connections action that overwrites local files. It does not fill this page.</p>
         </div>

--- a/landing/mirror.js
+++ b/landing/mirror.js
@@ -39,23 +39,39 @@ const PHONE_MQ = '(max-width: 639.98px), (max-height: 480px) and (hover: none)';
 const CATALOG_FETCH_CONCURRENCY = 5;
 const COLSPAN = 10;
 
+/** Dead CDN URLs (403/404) remembered for this page session so virtual scroll does not re-request them. */
+const failedCoverUrls = new Set();
+
+function markCoverUrlFailed(url) {
+  const u = String(url || '').trim();
+  if (u) failedCoverUrls.add(u);
+}
+
 /** Retry header/Steam CDN once, then leave the letter placeholder visible. */
 function mirrorCoverError(img) {
   if (!img || img.classList.contains('mirror-cover--failed')) return;
   const wrap = img.closest('.mirror-cover-wrap');
   const showPlaceholder = () => {
+    markCoverUrlFailed(img.getAttribute('src'));
     img.classList.add('mirror-cover--failed');
     img.removeAttribute('src');
     img.alt = '';
     const letter = wrap?.querySelector('.mirror-cover-fallback');
     if (letter) letter.hidden = false;
   };
+  const current = String(img.getAttribute('src') || '').trim();
+  markCoverUrlFailed(current);
   if (img.dataset.mirrorCoverTried === '1') {
     showPlaceholder();
     return;
   }
   const next = String(img.dataset.fallback || '').trim();
-  if (next && /^https?:\/\//i.test(next) && next !== img.getAttribute('src')) {
+  if (
+    next
+    && /^https?:\/\//i.test(next)
+    && next !== current
+    && !failedCoverUrls.has(next)
+  ) {
     img.dataset.mirrorCoverTried = '1';
     img.src = next;
     return;
@@ -157,12 +173,20 @@ function formatScore(value) {
 
 function coverCellHtml(row) {
   const initial = escapeHtml(String(row.title || '?').trim().charAt(0).toUpperCase() || '?');
-  const url = String(row.coverUrl || '').trim();
-  const fallback = String(row.coverFallbackUrl || '').trim();
+  let url = String(row.coverUrl || '').trim();
+  let fallback = String(row.coverFallbackUrl || '').trim();
   const letter = `<span class="mirror-cover-fallback" aria-hidden="true">${initial}</span>`;
+  if (url && failedCoverUrls.has(url)) {
+    if (fallback && fallback !== url && !failedCoverUrls.has(fallback) && /^https?:\/\//i.test(fallback)) {
+      url = fallback;
+      fallback = '';
+    } else {
+      return `<td class="col-cover" data-label="Cover"><div class="mirror-cover-wrap">${letter}</div></td>`;
+    }
+  }
   if (url && /^https?:\/\//i.test(url)) {
     const fbAttr =
-      fallback && /^https?:\/\//i.test(fallback) && fallback !== url
+      fallback && /^https?:\/\//i.test(fallback) && fallback !== url && !failedCoverUrls.has(fallback)
         ? ` data-fallback="${escapeHtml(fallback)}"`
         : '';
     // Letter sits under the image so any load failure still leaves a placeholder.
@@ -413,6 +437,7 @@ async function loadLibrary(session) {
   if (!token) return;
   const userId = String(session?.user?.id || '').trim();
   showAlert('');
+  failedCoverUrls.clear();
   signInBtn.disabled = true;
   refreshBtn.disabled = true;
   try {

--- a/landing/mirror.js
+++ b/landing/mirror.js
@@ -40,8 +40,8 @@ const CATALOG_FETCH_CONCURRENCY = 5;
 const COLSPAN = 10;
 
 /** Retry header/Steam CDN once, then leave the letter placeholder visible. */
-window.__baklogMirrorCoverError = function mirrorCoverError(img) {
-  if (!img) return;
+function mirrorCoverError(img) {
+  if (!img || img.classList.contains('mirror-cover--failed')) return;
   const wrap = img.closest('.mirror-cover-wrap');
   const showPlaceholder = () => {
     img.classList.add('mirror-cover--failed');
@@ -61,7 +61,20 @@ window.__baklogMirrorCoverError = function mirrorCoverError(img) {
     return;
   }
   showPlaceholder();
-};
+}
+
+/** CSP on /mirror forbids inline onerror; bind after each virtual paint. */
+function bindMirrorCoverErrors(root = tableBody) {
+  if (!root) return;
+  root.querySelectorAll('img.mirror-cover:not([data-mirror-cover-bound])').forEach((img) => {
+    img.dataset.mirrorCoverBound = '1';
+    img.addEventListener('error', () => mirrorCoverError(img));
+    // Cached failures can complete before the listener attaches.
+    if (img.complete && img.naturalWidth === 0 && img.getAttribute('src')) {
+      mirrorCoverError(img);
+    }
+  });
+}
 
 /** @type {ReturnType<typeof mergeMirrorLibrary>} */
 let allRows = [];
@@ -153,7 +166,7 @@ function coverCellHtml(row) {
         ? ` data-fallback="${escapeHtml(fallback)}"`
         : '';
     // Letter sits under the image so any load failure still leaves a placeholder.
-    return `<td class="col-cover" data-label="Cover"><div class="mirror-cover-wrap">${letter}<img class="mirror-cover" src="${escapeHtml(url)}" alt="" loading="lazy" decoding="async"${fbAttr} onerror="window.__baklogMirrorCoverError&&window.__baklogMirrorCoverError(this)" /></div></td>`;
+    return `<td class="col-cover" data-label="Cover"><div class="mirror-cover-wrap">${letter}<img class="mirror-cover" src="${escapeHtml(url)}" alt="" loading="lazy" decoding="async"${fbAttr} /></div></td>`;
   }
   return `<td class="col-cover" data-label="Cover"><div class="mirror-cover-wrap">${letter}</div></td>`;
 }
@@ -342,6 +355,7 @@ function paintMirrorSlice() {
   if (!usesMirrorVirtualScroll(len)) {
     tableBody.innerHTML = list.map((row, i) => rowHtml(row, i)).join('');
     _virtualWindow = { start: 0, end: len };
+    bindMirrorCoverErrors();
     refreshMeasuredRowHeight();
     return;
   }
@@ -366,6 +380,7 @@ function paintMirrorSlice() {
   }
   parts.push(spacerHtml('bottom', (len - end) * _rowHeightPx));
   tableBody.innerHTML = parts.join('');
+  bindMirrorCoverErrors();
   refreshMeasuredRowHeight();
 }
 

--- a/scripts/mirror-overflow-audit.mjs
+++ b/scripts/mirror-overflow-audit.mjs
@@ -61,8 +61,9 @@ function startStaticServer() {
       res.writeHead(200, { 'Content-Type': MIME[ext] || 'application/octet-stream' });
       fs.createReadStream(filePath).pipe(res);
     } catch (err) {
+      console.error(err);
       res.writeHead(500);
-      res.end(String(err));
+      res.end('internal error');
     }
   });
   return new Promise((resolve) => {


### PR DESCRIPTION
## Summary
- Remember failed cover CDN URLs for the `/mirror` page session so virtual scroll does not recreate `<img>` tags that re-hit the same itch/Steam 403/404.
- Skip straight to the letter placeholder (or unused header fallback) for known-dead URLs; clear the set on Refresh / library reload.

## Test plan
- [ ] Open `/mirror` with a dead itch cover, confirm one 403 then letter placeholder.
- [ ] Scroll that row out and back; confirm no new 403s for that URL.
- [ ] Click Refresh once; confirm a single retry burst is allowed again.
- [ ] Confirm Edge lazy-load Intervention message alone is harmless.