### PR TITLE
Unlock Pro features under local admin while keeping ads visible

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ Refresh bundle budget after intentional growth: `npm run build && node scripts/c
 
 - **CSRF** — mutating requests require `X-BAKLOG-Local: 1` (the app and admin console send it). When Supabase auth is on, a valid bearer may also authorize mutations; Origin/Referer alone is not enough.
 - **Supabase JWT** — when `BAKLOG_SUPABASE_URL` + anon key set; all `/api/*` except `/api/config` require bearer token.
-- **BAKLOG_ADMIN** — exposes `/admin/` and `/api/internal/*` without Supabase.
+- **BAKLOG_ADMIN** — exposes `/admin/` and `/api/internal/*` without Supabase. Also unlocks **Pro feature sim** for local testing (Cloud sync, bulk refresh, etc.) while **keeping ads visible** (unlike real Pro). Restart the server after pulling capability/admin changes. Does not grant hosted Storage RLS / baklog.app/mirror without a real JWT `plan=pro`.
 
 ## Tests & dev
 

--- a/guide/troubleshooting.md
+++ b/guide/troubleshooting.md
@@ -154,7 +154,7 @@ If you still have `BAKLOG-Data`, reinstall BAKLOG and launch normally - first bo
 
 **Split dev from frozen (recommended on one PC):** Set `BAKLOG_DATA_DIR=%LOCALAPPDATA%\BAKLOG-Dev` and `PORT=8766` in `.env` before running `python server.py`. Dev library files stay in `BAKLOG-Dev`; the installed app keeps using `BAKLOG-Data` on port 8765. The header shows a **Dev server** chip when `python server.py` is active.
 
-**Admin console vs installed library:** `BAKLOG_ADMIN=1` will not attach to the default installed data folder (`BAKLOG-Data`). Run admin against the repo (or `BAKLOG-Dev`). Only set `BAKLOG_ADMIN_ALLOW_INSTALLED=1` if you intentionally need admin on the installed library.
+**Admin console vs installed library:** `BAKLOG_ADMIN=1` will not attach to the default installed data folder (`BAKLOG-Data`). Run admin against the repo (or `BAKLOG-Dev`). Only set `BAKLOG_ADMIN_ALLOW_INSTALLED=1` if you intentionally need admin on the installed library. Local admin also unlocks Pro feature capabilities for testing (Cloud sync, bulk refresh, bonus claims) while **still showing ads**; restart the server after code pulls so `/api/config` picks up the change. Hosted baklog.app/mirror still needs a real Pro JWT.
 
 **Full clean of the installed library (maintainer / clean SoT):** Quit the tray, `BAKLOG.exe`, and any `server.py` on port 8765. Delete the entire `%LOCALAPPDATA%\BAKLOG-Data` folder. In Edge or Chrome, clear site data for `127.0.0.1` (and `:8766` if you used it). Launch the installed app once, create a new profile, and reconnect only the stores you want as the real library. Keep testing data under `BAKLOG-Dev` or the git checkout - do not copy testing dumps back into `BAKLOG-Data` unless intentional.
 

--- a/js/auth-gate.js
+++ b/js/auth-gate.js
@@ -126,6 +126,22 @@ export function isAdminMode() {
   return _adminMode;
 }
 
+/**
+ * Pro feature gates for local testing: real Pro OR BAKLOG_ADMIN.
+ * Does not suppress ads (see suppressSponsoredAds). Local-only; not a hosted entitlement.
+ */
+export function proFeaturesUnlocked() {
+  return isPro() || isAdminMode();
+}
+
+/**
+ * True when sponsored/house creatives should be removed (real Pro, not admin Pro-sim).
+ * Admin keeps ads visible so maintainers can test slots before frozen builds.
+ */
+export function suppressSponsoredAds() {
+  return isPro() && !isAdminMode();
+}
+
 export function getAccessToken() {
   return _accessToken;
 }
@@ -299,6 +315,11 @@ function applyConfigEntitlement(config) {
   };
   setCapabilitiesFromConfig(config.capabilities);
   setProSettingsFromConfig(config.proSettings);
+}
+
+/** Test helper: apply the same entitlement fields GET /api/config would. */
+export function __applyConfigEntitlementForTest(config) {
+  applyConfigEntitlement(config);
 }
 
 export function licenseActivationEnabled() {

--- a/js/claimable.js
+++ b/js/claimable.js
@@ -8,7 +8,7 @@ import { claimsSnapshotStorageKey } from './profiles.js';
 import { dataFetch } from './api-client.js';
 import { syncCoverFits } from './covers.js';
 import { getAdsForLocation, sponsoredClaimCardHtml } from './sponsored-deals.js';
-import { isPro } from './auth-gate.js';
+import { proFeaturesUnlocked } from './auth-gate.js';
 import { affiliateUrl } from './affiliate.js';
 import { hasValidClaimLinks, normalizeClaimUrls } from './claim-links.js';
 import { isDebugEnabled } from './debug-overlay.js';
@@ -227,7 +227,7 @@ export function isClaimOwned(claim) {
 }
 
 /** Debug-only: why a feed row is visible, hidden, or filtered out. */
-export function claimDispositionReason(c, now = Date.now(), pro = isPro()) {
+export function claimDispositionReason(c, now = Date.now(), pro = proFeaturesUnlocked()) {
   if (!isClaimFeedItemValid(c)) return 'invalid';
   if (isClaimExpired(c, now)) return 'expired';
   const owned = claimOwnedReason(c);
@@ -254,7 +254,7 @@ function logClaimsFeedDebug(doc, source) {
 function logClaimsDispositionDebug(items) {
   if (!isDebugEnabled()) return;
   const now = Date.now();
-  const pro = isPro();
+  const pro = proFeaturesUnlocked();
   console.debug('[baklog-claims] dispositions', (items || []).map((c) => ({
     id: c.id,
     store: c.store,
@@ -300,7 +300,7 @@ function isClaimEligible(c, now = Date.now()) {
 
 export function getVisibleClaims(items) {
   const now = Date.now();
-  const pro = isPro();
+  const pro = proFeaturesUnlocked();
   const filtered = (items || []).filter((c) => {
     if (!isClaimEligible(c, now)) return false;
     if (isClaimPurged(c)) return false;
@@ -313,7 +313,7 @@ export function getVisibleClaims(items) {
 
 export function getHiddenClaims(items) {
   const now = Date.now();
-  const pro = isPro();
+  const pro = proFeaturesUnlocked();
   const filtered = (items || []).filter((c) => {
     if (!isClaimEligible(c, now)) return false;
     if (isClaimPurged(c)) return false;

--- a/js/connections.js
+++ b/js/connections.js
@@ -3,7 +3,7 @@ import {
   getAccessToken,
   getAccountProfileId,
   isAccountAuthMode,
-  isPro,
+  proFeaturesUnlocked,
   refreshAccountPlan,
 } from "./auth-gate.js";
 import {
@@ -530,7 +530,7 @@ function renderConnPrefs() {
   const syncBtn = document.getElementById("cloudMirrorSyncBtn");
   const importBtn = document.getElementById("cloudMirrorImportBtn");
   const showCloudMirror =
-    isPro() &&
+    proFeaturesUnlocked() &&
     isAccountAuthMode() &&
     !!getAccessToken() &&
     capabilityStatus("cloud_sync_mirror") === "live";
@@ -551,7 +551,7 @@ function renderConnPrefs() {
 
   const note = document.getElementById("bgRefreshPlanNote");
   if (note) {
-    if (isPro()) {
+    if (proFeaturesUnlocked()) {
       note.textContent =
         "Pro: background refresh keeps stale stores fresh even when BAKLOG is closed to the tray.";
       note.classList.add("conn-prefs-note--pro");
@@ -571,7 +571,7 @@ async function refreshCloudMirrorUploadStatus() {
   const el = document.getElementById("cloudMirrorUploadStatus");
   if (!el) return;
   const showCloudMirror =
-    isPro() &&
+    proFeaturesUnlocked() &&
     isAccountAuthMode() &&
     !!getAccessToken() &&
     capabilityStatus("cloud_sync_mirror") === "live";

--- a/js/fetcher/render/dashboard.js
+++ b/js/fetcher/render/dashboard.js
@@ -1,5 +1,5 @@
 /** Fetcher health dashboard renderer. */
-import { isAccountAuthMode, isPro } from '../../auth-gate.js';
+import { isAccountAuthMode, proFeaturesUnlocked } from '../../auth-gate.js';
 import { state } from '../../state.js';
 import { escapeAttr, escapeHtml, formatNum } from '../../dom-util.js';
 import { formatPlatformList } from '../../platform-labels.js';
@@ -342,7 +342,7 @@ export function renderDashboardFetcherHealth() {
   const failedBtnDisabled = !apiReady || !runnableFailed.length || Date.now() < batchRunCooldowns.failedUntil;
   const failedBtnLabel = `Retry failed (${runnableFailed.length})`;
 
-  const staleButtonHtml = isPro()
+  const staleButtonHtml = proFeaturesUnlocked()
     ? `<button type="button" class="fh-run-stale" ${staleBtnDisabled ? 'disabled' : ''} title="Queue every stale store back-to-back (Pro)">${escapeHtml(staleBtnLabel)}</button>`
     : '';
   const failedButtonHtml = runnableFailed.length

--- a/js/sponsored-deals.js
+++ b/js/sponsored-deals.js
@@ -3,8 +3,8 @@
  *
  * Honest by design: every sponsored slot carries a visible "Sponsored" (or
  * "House") disclosure, is ownership-aware (a slot whose `match_title` you
- * already own is skipped). The paid (pro) tier removes every slot via the
- * server-resolved entitlement (`isPro()`).
+ * already own is skipped). The paid (pro) tier removes every slot via
+ * suppressSponsoredAds() (real Pro only; local admin Pro-sim keeps ads visible).
  *
  * Closeable vs permanent: paid sponsor cards always carry a dismiss (X), and
  * house promos opt in with `dismissible: true`. Permanent house promos (the
@@ -44,7 +44,7 @@ import { escapeHtml, escapeAttr, isSafeHttpUrl, formatNum } from './dom-util.js'
 import { normalizeNameForDedup, combinedPlaytime } from './game-core.js';
 import { isOwnedByTitle } from './deals.js';
 import { dataFetch } from './api-client.js';
-import { isPro } from './auth-gate.js';
+import { isAdminMode, suppressSponsoredAds } from './auth-gate.js';
 import { noteSponsoredImpression } from './anon-metrics.js';
 import { PRO_CHECKOUT_MONTHLY } from './pro-checkout.js';
 import { affiliateUrl } from './affiliate.js';
@@ -68,6 +68,8 @@ export function __resetHouseProBannersForTest() {
 }
 function houseProBannersLive() {
   if (_houseProBannersForceForTest != null) return _houseProBannersForceForTest;
+  // Local admin Pro-sim: exercise house slots even while the shipping flag is off.
+  if (isAdminMode()) return true;
   return HOUSE_PRO_BANNERS_ENABLED;
 }
 
@@ -403,14 +405,14 @@ export function __resetSpotlightHouseAdsForTest() {
   _spotlightHouseAdsForceForTest = null;
 }
 function spotlightHouseAdsLive() {
-  if (isPro()) return false;
+  if (suppressSponsoredAds()) return false;
   if (_spotlightHouseAdsForceForTest != null) return _spotlightHouseAdsForceForTest;
   return !IN_VITEST;
 }
 
 // The permanent Pro spotlight slides, in display order. The large-logo slide is
 // first so the dashboard opens on the brand/Pro pitch. Always present in the
-// spotlight rotation for free users; removed entirely for Pro (isPro()).
+// spotlight rotation for free users; removed entirely for Pro (suppressSponsoredAds).
 const SPOTLIGHT_PRO_AD_IDS = [
   'house-spotlight-pro-logo',
   'house-spotlight-pro-sync',
@@ -648,7 +650,7 @@ function sponsorBadgeHtml(item, extraClass = '') {
  * @param {{ count?: number }} [opts]
  */
 export function getAdsForLocation(locationKey, { count = 1 } = {}) {
-  if (isPro()) return [];
+  if (suppressSponsoredAds()) return [];
   const key = String(locationKey || '').toLowerCase();
   if (!AD_LOCATION_SET.has(key)) return [];
   const ids = state.adLocations?.[key] || [];
@@ -717,7 +719,7 @@ export function getEligibleSponsoredDeal() {
  */
 export function getVersusColumnAds() {
   const empty = { rated: null, fast: null, ratedReserved: false, fastReserved: false };
-  if (isPro()) return empty;
+  if (suppressSponsoredAds()) return empty;
   const ratedIds = state.adLocations?.['dash-versus-rated'] || [];
   const fastIds = state.adLocations?.['dash-versus-fast'] || [];
   return {
@@ -966,7 +968,7 @@ export function houseDealBannerHtml(item, { accent = 'blue' } = {}) {
  * @param {object | null | undefined} item — dash-deal-rail feed row; title/tagline/cta/url override PRO_PROMO defaults.
  */
 export function proPromoBannerHtml(item) {
-  if (isPro()) return '';
+  if (suppressSponsoredAds()) return '';
   if (!item) return '';
   const discTitle = 'House promotion from BAKLOG - optional paid tier';
   const title = item.title || PRO_PROMO.title;
@@ -1012,7 +1014,7 @@ export function proPromoBannerHtml(item) {
 /** Markup for the dashboard house slot (dash-house — Pro upsell). */
 export function proPromoSlotHtml() {
   if (!houseProBannersLive()) return '';
-  if (isPro()) return '';
+  if (suppressSponsoredAds()) return '';
   const item = getAdsForLocation('dash-house')[0] || PRO_PROMO_ITEM;
   return proPromoBannerHtml(item);
 }

--- a/js/trophy-popover.js
+++ b/js/trophy-popover.js
@@ -1,5 +1,5 @@
 import { escapeHtml } from "./dom-util.js";
-import { isPro } from "./auth-gate.js";
+import { proFeaturesUnlocked } from "./auth-gate.js";
 
 const POP_ID = "trophyPop";
 const DEEP_SYNC_STORES = new Set(["psn", "xbox"]);
@@ -82,7 +82,7 @@ function buildPopHtml(pill) {
 /** Pro-only deep-sync footer for PSN/Xbox pills: cached % is free; a full
  *  achievement/trophy re-pull is a paid-tier action. */
 function buildMeterHtml(pill) {
-  if (!isPro()) return "";
+  if (!proFeaturesUnlocked()) return "";
   const store = (pill.dataset.store || "").toLowerCase();
   if (!DEEP_SYNC_STORES.has(store)) return "";
   const key = pill.dataset.key || "";

--- a/server.py
+++ b/server.py
@@ -1632,10 +1632,16 @@ class Handler(SimpleHTTPRequestHandler):
         config = dict(public_auth_config())
         # Entitlement: signed JWT claim (when a bearer is sent) wins, else the
         # local license file / BAKLOG_PLAN override. Defaults to "free".
+        # Admin Pro-sim unlocks capability enabled flags without rewriting plan.
+        from shared.entitlement import plan_for_capabilities
+
         plan = current_plan(self.headers.get("Authorization"))
         pro_settings = read_pro_settings()
         config["plan"] = plan
-        config["capabilities"] = resolve_capabilities(plan=plan, pro_settings=pro_settings)
+        config["capabilities"] = resolve_capabilities(
+            plan=plan_for_capabilities(self.headers.get("Authorization")),
+            pro_settings=pro_settings,
+        )
         config["proSettings"] = pro_settings
         config["licenseActivation"] = polar_configured() and not auth_enabled()
         config["proCheckoutEnabled"] = pro_checkout_enabled()

--- a/shared/cloud_mirror.py
+++ b/shared/cloud_mirror.py
@@ -86,12 +86,12 @@ def mirror_upload_allowed(*, profile_id: str | None = None) -> bool:
 
 
 def mirror_read_allowed(*, authorization: str | None) -> bool:
-    from shared.entitlement import is_pro
+    from shared.entitlement import pro_features_unlocked
     from shared.supabase_auth import auth_enabled
 
     if not auth_enabled():
         return False
-    return is_pro(authorization)
+    return pro_features_unlocked(authorization)
 
 
 def schedule_mirror_upload(path: Path, *, profile_id: str | None = None) -> None:

--- a/shared/entitlement.py
+++ b/shared/entitlement.py
@@ -258,13 +258,37 @@ def is_pro(authorization: str | None = None) -> bool:
     return current_plan(authorization) == PLAN_PRO
 
 
+def _admin_enabled() -> bool:
+    """True when BAKLOG_ADMIN is allowed for the active data root (local Pro-sim)."""
+    try:
+        from shared.admin_gate import resolve_admin_enabled
+        from shared.install_paths import data_root
+
+        ok, _warn = resolve_admin_enabled(data_root())
+        return bool(ok)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def pro_features_unlocked(authorization: str | None = None) -> bool:
+    """Pro feature gates: real plan OR local admin Pro-sim.
+
+    Admin unlocks desktop Pro capabilities for maintainer testing; it does not
+    change hosted Storage RLS / baklog.app/mirror JWT requirements.
+    """
+    return is_pro(authorization) or _admin_enabled()
+
+
 def is_pro_background() -> bool:
     """Best-effort pro check for server-side background work (no request context).
 
     Under hosted auth uses the last JWT-verified plan seen this process (within
     a TTL); in pure-local mode honors ``BAKLOG_PLAN`` then ``license.json``.
     Local overrides are ignored under hosted auth (same as ``current_plan``).
+    Local ``BAKLOG_ADMIN`` Pro-sim also unlocks background Pro work.
     """
+    if _admin_enabled():
+        return True
     if _auth_enabled():
         if _LAST_AUTH_PLAN is not None:
             ts, plan = _LAST_AUTH_PLAN
@@ -277,3 +301,10 @@ def is_pro_background() -> bool:
         return env == PLAN_PRO
 
     return _local_license_plan() == PLAN_PRO
+
+
+def plan_for_capabilities(authorization: str | None = None) -> str:
+    """Plan used to resolve capability enabled flags (admin sims as pro)."""
+    if _admin_enabled():
+        return PLAN_PRO
+    return current_plan(authorization)

--- a/shared/server_pro_settings.py
+++ b/shared/server_pro_settings.py
@@ -1,7 +1,7 @@
 import json
 from http import HTTPStatus
 
-from shared.entitlement import is_pro
+from shared.entitlement import pro_features_unlocked
 from shared.pro_settings import write_pro_settings
 from shared.supabase_auth import auth_enabled
 
@@ -22,7 +22,7 @@ def handle_pro_settings_put(handler):
     if auth_enabled() and (not authorization):
         srv._send_json(handler, HTTPStatus.UNAUTHORIZED, {"error": "Sign in required"})
         return
-    if not is_pro(authorization):
+    if not pro_features_unlocked(authorization):
         srv._send_json(handler, HTTPStatus.FORBIDDEN, {"error": "Pro plan required"})
         return
     try:

--- a/tests/auth-gate.test.js
+++ b/tests/auth-gate.test.js
@@ -272,6 +272,29 @@ describe('auth-gate', () => {
     localStorage.removeItem('baklog-debug-pro');
   });
 
+  it('proFeaturesUnlocked and suppressSponsoredAds honor admin Pro-sim', async () => {
+    const {
+      __applyConfigEntitlementForTest,
+      isAdminMode,
+      isPro,
+      proFeaturesUnlocked,
+      suppressSponsoredAds,
+    } = await import('../js/auth-gate.js');
+    __applyConfigEntitlementForTest({ plan: 'free', admin: true, capabilities: {}, proSettings: {} });
+    expect(isAdminMode()).toBe(true);
+    expect(isPro()).toBe(false);
+    expect(proFeaturesUnlocked()).toBe(true);
+    expect(suppressSponsoredAds()).toBe(false);
+
+    __applyConfigEntitlementForTest({ plan: 'pro', admin: true, capabilities: {}, proSettings: {} });
+    expect(isPro()).toBe(true);
+    expect(proFeaturesUnlocked()).toBe(true);
+    expect(suppressSponsoredAds()).toBe(false);
+
+    __applyConfigEntitlementForTest({ plan: 'pro', admin: false, capabilities: {}, proSettings: {} });
+    expect(suppressSponsoredAds()).toBe(true);
+  });
+
   it('showAuthGatePanel toggles signup form', async () => {
     const { showAuthGatePanel } = await import('../js/auth-gate.js');
     showAuthGatePanel('signup');

--- a/tests/claimable.test.js
+++ b/tests/claimable.test.js
@@ -13,6 +13,7 @@ vi.mock('../js/auth-gate.js', async (importOriginal) => {
   return {
     ...actual,
     isPro: () => isProMock(),
+    proFeaturesUnlocked: () => isProMock(),
   };
 });
 

--- a/tests/connections-rail-render.test.js
+++ b/tests/connections-rail-render.test.js
@@ -42,7 +42,10 @@ vi.mock('../js/api-client.js', () => ({
 vi.mock('../js/auth-gate.js', () => ({
   isAccountAuthMode: vi.fn(() => false),
   isPro: vi.fn(() => false),
+  isAdminMode: vi.fn(() => false),
+  proFeaturesUnlocked: vi.fn(() => false),
   getAccessToken: vi.fn(() => null),
+  getAccountProfileId: vi.fn(() => null),
   getProSettings: vi.fn(() => ({ cloudMirrorEnabled: false })),
   refreshAccountPlan: vi.fn(async () => 'free'),
 }));
@@ -317,7 +320,7 @@ describe('cloud mirror prefs visibility', () => {
     mountCloudPrefsDom();
     const auth = await import('../js/auth-gate.js');
     const caps = await import('../js/pro-capabilities.js');
-    vi.mocked(auth.isPro).mockReturnValue(true);
+    vi.mocked(auth.proFeaturesUnlocked).mockReturnValue(true);
     vi.mocked(auth.isAccountAuthMode).mockReturnValue(true);
     vi.mocked(auth.getAccessToken).mockReturnValue('tok');
     vi.mocked(caps.capabilityStatus).mockReturnValue('soon');
@@ -335,7 +338,7 @@ describe('cloud mirror prefs visibility', () => {
     mountCloudPrefsDom();
     const auth = await import('../js/auth-gate.js');
     const caps = await import('../js/pro-capabilities.js');
-    vi.mocked(auth.isPro).mockReturnValue(true);
+    vi.mocked(auth.proFeaturesUnlocked).mockReturnValue(true);
     vi.mocked(auth.isAccountAuthMode).mockReturnValue(true);
     vi.mocked(auth.getAccessToken).mockReturnValue('tok');
     vi.mocked(caps.capabilityStatus).mockReturnValue('live');
@@ -349,5 +352,23 @@ describe('cloud mirror prefs visibility', () => {
     expect(document.getElementById('cloudMirrorImportBtn')?.hidden).toBe(false);
     expect(document.getElementById('cloudMirrorSyncBtn')?.hidden).toBe(false);
     expect(document.getElementById('cloudMirrorSyncBtn')?.disabled).toBe(true);
+  });
+
+  it('shows cloud sync for admin Pro-sim without real Pro plan', async () => {
+    mountCloudPrefsDom();
+    const auth = await import('../js/auth-gate.js');
+    const caps = await import('../js/pro-capabilities.js');
+    vi.mocked(auth.isPro).mockReturnValue(false);
+    vi.mocked(auth.proFeaturesUnlocked).mockReturnValue(true);
+    vi.mocked(auth.isAccountAuthMode).mockReturnValue(true);
+    vi.mocked(auth.getAccessToken).mockReturnValue('tok');
+    vi.mocked(caps.capabilityStatus).mockReturnValue('live');
+    vi.mocked(caps.getProSettings).mockReturnValue({ cloudMirrorEnabled: false });
+
+    const { refreshConnections } = await import('../js/connections.js');
+    await refreshConnections();
+
+    expect(document.getElementById('connCloudPrefs')?.hidden).toBe(false);
+    expect(document.getElementById('cloudMirrorToggleWrap')?.hidden).toBe(false);
   });
 });

--- a/tests/fetcher-stale-button.test.js
+++ b/tests/fetcher-stale-button.test.js
@@ -48,14 +48,14 @@ describe('Pro run stale button', () => {
   });
 
   it('omits Run stale for free tier', async () => {
-    vi.spyOn(authGate, 'isPro').mockReturnValue(false);
+    vi.spyOn(authGate, 'proFeaturesUnlocked').mockReturnValue(false);
     await fetcherRunner.probeApi(true);
     renderDashboardFetcherHealth();
     expect(document.querySelector('.fh-run-stale')).toBeNull();
   });
 
   it('renders Run stale for Pro when stale fetchers exist', async () => {
-    vi.spyOn(authGate, 'isPro').mockReturnValue(true);
+    vi.spyOn(authGate, 'proFeaturesUnlocked').mockReturnValue(true);
     await fetcherRunner.probeApi(true);
     renderDashboardFetcherHealth();
     const btn = document.querySelector('.fh-run-stale');
@@ -66,7 +66,7 @@ describe('Pro run stale button', () => {
 
   it('disables Run stale for Pro when all fetchers are fresh', async () => {
     state.libraryMeta.steam.fetched_at = new Date().toISOString();
-    vi.spyOn(authGate, 'isPro').mockReturnValue(true);
+    vi.spyOn(authGate, 'proFeaturesUnlocked').mockReturnValue(true);
     await fetcherRunner.probeApi(true);
     renderDashboardFetcherHealth();
     const btn = document.querySelector('.fh-run-stale');
@@ -77,7 +77,7 @@ describe('Pro run stale button', () => {
 
   it('disables Run stale when API probe fails (readonly)', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false })));
-    vi.spyOn(authGate, 'isPro').mockReturnValue(true);
+    vi.spyOn(authGate, 'proFeaturesUnlocked').mockReturnValue(true);
     await fetcherRunner.probeApi(true);
     renderDashboardFetcherHealth();
     const btn = document.querySelector('.fh-run-stale');

--- a/tests/pro-view.test.js
+++ b/tests/pro-view.test.js
@@ -4,6 +4,8 @@ import { isProPromoSponsorId, proPromoBannerHtml, PRO_PROMO, PRO_PROMO_ITEM } fr
 vi.mock('../js/auth-gate.js', () => ({
   isPro: vi.fn(() => false),
   isAdminMode: vi.fn(() => false),
+  proFeaturesUnlocked: vi.fn(() => false),
+  suppressSponsoredAds: vi.fn(() => false),
   isAccountAuthMode: vi.fn(() => false),
   isLocalProfilesEnabled: vi.fn(() => false),
   licenseActivationEnabled: vi.fn(() => true),

--- a/tests/sponsored-deals.test.js
+++ b/tests/sponsored-deals.test.js
@@ -136,7 +136,7 @@ describe('getEligibleSponsoredDeal', () => {
   });
 
   it('returns null for the paid (pro) entitlement', () => {
-    const spy = vi.spyOn(authGate, 'isPro').mockReturnValue(true);
+    const spy = vi.spyOn(authGate, 'suppressSponsoredAds').mockReturnValue(true);
     __setSponsorsForTest(v2Doc({ sp1: sponsor() }, { 'wish-deal-hero': ['sp1'] }));
     expect(getEligibleSponsoredDeal()).toBeNull();
     spy.mockRestore();
@@ -259,15 +259,25 @@ describe('getAdsForLocation round-robin', () => {
     expect(getAdsForLocation('claim-cards', { count: 3 }).map(x => x.id)).toEqual(['a', 'b', 'c']);
   });
 
-  it('returns no ads when isPro()', () => {
+  it('returns no ads when suppressSponsoredAds (real Pro)', () => {
     __setSponsorsForTest(v2Doc(
       { a: sponsor({ id: 'a', title: 'A' }) },
       { 'claim-cards': ['a'], 'lib-pick': ['a'] },
     ));
-    const spy = vi.spyOn(authGate, 'isPro').mockReturnValue(true);
+    const spy = vi.spyOn(authGate, 'suppressSponsoredAds').mockReturnValue(true);
     expect(getAdsForLocation('claim-cards')).toEqual([]);
     expect(getAdsForLocation('lib-pick')).toEqual([]);
     spy.mockRestore();
+  });
+
+  it('keeps ads for admin Pro-sim (Pro plan but admin mode)', () => {
+    __setSponsorsForTest(v2Doc(
+      { a: sponsor({ id: 'a', title: 'A' }) },
+      { 'lib-pick': ['a'] },
+    ));
+    const suppressSpy = vi.spyOn(authGate, 'suppressSponsoredAds').mockReturnValue(false);
+    expect(getAdsForLocation('lib-pick').map((x) => x.id)).toEqual(['a']);
+    suppressSpy.mockRestore();
   });
 });
 
@@ -680,7 +690,7 @@ describe('getSpotlightHouseAds', () => {
   });
 
   it('returns nothing for Pro subscribers', () => {
-    const spy = vi.spyOn(authGate, 'isPro').mockReturnValue(true);
+    const spy = vi.spyOn(authGate, 'suppressSponsoredAds').mockReturnValue(true);
     expect(getSpotlightHouseAds()).toEqual([]);
     spy.mockRestore();
   });
@@ -842,7 +852,7 @@ describe('sponsoredDealSlotHtml', () => {
 
   it('returns empty string for Pro subscribers', () => {
     wireWishHouse();
-    const spy = vi.spyOn(authGate, 'isPro').mockReturnValue(true);
+    const spy = vi.spyOn(authGate, 'suppressSponsoredAds').mockReturnValue(true);
     expect(sponsoredDealSlotHtml()).toBe('');
     spy.mockRestore();
   });
@@ -866,7 +876,7 @@ describe('proPromoBannerHtml', () => {
   });
 
   it('returns empty string for Pro subscribers', () => {
-    const spy = vi.spyOn(authGate, 'isPro').mockReturnValue(true);
+    const spy = vi.spyOn(authGate, 'suppressSponsoredAds').mockReturnValue(true);
     expect(proPromoBannerHtml(proPromoItem())).toBe('');
     spy.mockRestore();
   });
@@ -881,7 +891,7 @@ describe('proPromoSlotHtml', () => {
   });
 
   it('returns empty string for Pro subscribers', () => {
-    const spy = vi.spyOn(authGate, 'isPro').mockReturnValue(true);
+    const spy = vi.spyOn(authGate, 'suppressSponsoredAds').mockReturnValue(true);
     expect(proPromoSlotHtml()).toBe('');
     spy.mockRestore();
   });

--- a/tests/test_entitlement.py
+++ b/tests/test_entitlement.py
@@ -117,3 +117,18 @@ def test_background_plan_free_when_auth_enabled_uncached(monkeypatch):
     ent.license_path().write_text(json.dumps({"plan": "pro"}), encoding="utf-8")
     _enable_auth(monkeypatch)
     assert ent.is_pro_background() is False
+
+
+def test_admin_pro_sim_unlocks_features_without_rewriting_plan(monkeypatch):
+    monkeypatch.setattr(ent, "_admin_enabled", lambda: True)
+    assert ent.current_plan() == "free"
+    assert ent.is_pro() is False
+    assert ent.pro_features_unlocked() is True
+    assert ent.plan_for_capabilities() == "pro"
+    assert ent.is_pro_background() is True
+
+
+def test_admin_pro_sim_off_stays_free(monkeypatch):
+    monkeypatch.setattr(ent, "_admin_enabled", lambda: False)
+    assert ent.pro_features_unlocked() is False
+    assert ent.plan_for_capabilities() == "free"

--- a/tests/test_pro_capabilities_mirror.py
+++ b/tests/test_pro_capabilities_mirror.py
@@ -32,7 +32,7 @@ def pro_settings_server(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     server._refresh_personal_paths()
     monkeypatch.setattr("shared.supabase_auth.auth_enabled", lambda: True)
     monkeypatch.setattr(server, "_bind_request_user", lambda _h: {"id": "u", "email": "a@b.c"})
-    monkeypatch.setattr("shared.server_pro_settings.is_pro", lambda *_a, **_k: True)
+    monkeypatch.setattr("shared.server_pro_settings.pro_features_unlocked", lambda *_a, **_k: True)
     monkeypatch.setattr(
         "shared.supabase_auth.verify_bearer_user",
         lambda *_a, **_k: {"id": "u", "email": "a@b.c"},
@@ -120,7 +120,7 @@ def test_pro_settings_enable_ok_when_live(pro_settings_server: str) -> None:
 def test_pro_settings_sign_in_required_before_pro_check(
     pro_settings_server: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr("shared.server_pro_settings.is_pro", lambda *_a, **_k: False)
+    monkeypatch.setattr("shared.server_pro_settings.pro_features_unlocked", lambda *_a, **_k: False)
     status, data = _request(
         pro_settings_server,
         "/api/pro/settings",

--- a/tests/trophy-popover.test.js
+++ b/tests/trophy-popover.test.js
@@ -4,6 +4,7 @@ const isProMock = vi.fn(() => false);
 
 vi.mock('../js/auth-gate.js', () => ({
   isPro: () => isProMock(),
+  proFeaturesUnlocked: () => isProMock(),
 }));
 
 import { initTrophyPopover } from '../js/trophy-popover.js';


### PR DESCRIPTION
## Summary
- Local `BAKLOG_ADMIN=1` unlocks Pro feature capabilities (Cloud sync UI/APIs, bulk refresh, bonus claims, trophies, scheduler) via `proFeaturesUnlocked` / `pro_features_unlocked`.
- Real Pro still suppresses ads; admin Pro-sim keeps ads and forces house banners live for slot testing.
- `GET /api/config` keeps reporting the real `plan`; capability `enabled` flags resolve as Pro when admin is on.
- Docs: AGENTS + troubleshooting one-liners. Hosted `/mirror` Storage RLS still needs JWT `plan=pro`.

## Test plan
- [ ] `pytest tests/test_entitlement.py tests/test_pro_capabilities_mirror.py`
- [ ] `npm test -- --run tests/auth-gate.test.js tests/sponsored-deals.test.js tests/connections-rail-render.test.js`
- [ ] Restart `BAKLOG_ADMIN=1` server → free JWT still sees Cloud sync + ads
- [ ] Real Pro (no admin) still hides ads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Local admin mode can now simulate Pro capabilities, including cloud sync, bulk refresh, bonus claims, and other Pro-only features.
  - Sponsored ads remain visible during local Pro simulations; ad removal is limited to real Pro access.
  - Cloud mirror and Pro settings now recognize simulated Pro capabilities.

- **Documentation**
  - Clarified admin-mode limitations, server restart requirements, and hosted access requirements.

- **Tests**
  - Added coverage for simulated Pro access, feature visibility, cloud controls, and advertising behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->