### PR TITLE
Fix Back BAKLOG hero layout when checkout is closed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ scripts/perf-last-run.json
 scripts/drill-geometry-last-run.json
 scripts/modal-geometry-last-run.json
 scripts/library-count-geometry-last-run.json
+scripts/pro-view-hero-geometry-last-run.json
 scripts/responsive-overflow-last-run.json
 scripts/mirror-overflow-last-run.json
 

--- a/app.css
+++ b/app.css
@@ -11298,16 +11298,29 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
   align-items: center;
   gap: 1.25rem 2rem;
 }
+.pro-view-hero-main--beta {
+  align-items: flex-start;
+}
 .pro-view-hero-copy {
   flex: 1 1 22rem;
   min-width: 0;
 }
+.pro-view-founder--hero-beta {
+  margin-top: 0.85rem;
+  max-width: 42rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid
+    color-mix(in srgb, var(--accent, #38bdf8) 22%, var(--border));
+  font-size: 0.88rem;
+  text-align: left;
+}
 .pro-view-hero .pro-view-pricing {
-  flex: 0 0 auto;
+  flex: 0 1 16rem;
+  max-width: min(18rem, 100%);
   align-items: flex-end;
   text-align: right;
   margin-top: 0;
-  padding: 0 0 0 2rem;
+  padding: 0 0 0 1.5rem;
   border: none;
   border-left: 1px solid
     color-mix(in srgb, var(--accent, #38bdf8) 22%, var(--border));
@@ -11316,10 +11329,12 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
 }
 .pro-view-hero .pro-view-pricing .pro-view-founder {
   text-align: right;
+  max-width: 16rem;
 }
 @media (max-width: 639.98px) {
   .pro-view-hero .pro-view-pricing {
     flex-basis: 100%;
+    max-width: none;
     align-items: flex-start;
     text-align: left;
     margin-top: 0.15rem;
@@ -11330,6 +11345,7 @@ html[data-init-view="wishlist"] .steal-list-footer-passive {
   }
   .pro-view-hero .pro-view-pricing .pro-view-founder {
     text-align: left;
+    max-width: none;
   }
 }
 .pro-view-toggle {

--- a/js/pro-view.js
+++ b/js/pro-view.js
@@ -148,12 +148,12 @@ function proTrustHtml() {
   </div>`;
 }
 
+function proBetaClosedNoteHtml() {
+  // Keep under the pitch copy - not a side "pricing" column (that layout is for live checkout).
+  return `<p class="pro-view-founder pro-view-founder--hero-beta">Checkout is closed during beta. Pro perks will roll out to beta testers before public launch.</p>`;
+}
+
 function proPricingHtml() {
-  if (!proCheckoutEnabled()) {
-    return `<div class="pro-view-pricing pro-view-pricing--beta">
-    <p class="pro-view-founder">Checkout is closed during beta. Pro perks will roll out to beta testers before public launch.</p>
-  </div>`;
-  }
   const monthly = escapeAttr(proCheckoutLink('monthly'));
   const yearly = escapeAttr(proCheckoutLink('yearly'));
   const monthlyPressed = selectedProPlan === 'monthly' ? 'true' : 'false';
@@ -227,16 +227,18 @@ function proActiveHtml() {
 
 function proPitchHtml({ showPending = false } = {}) {
   const planClass = selectedProPlan === 'yearly' ? 'pro-view-funnel--yearly' : 'pro-view-funnel--monthly';
+  const checkoutOpen = proCheckoutEnabled();
   return `${showPending ? waitingActivationBannerHtml() : ''}
     <div class="pro-view-funnel ${planClass}" role="region" aria-label="BAKLOG Pro">
       <header class="pro-view-hero">
         ${proHeroBannerHtml(selectedProPlan)}
-        <div class="pro-view-hero-main">
+        <div class="pro-view-hero-main${checkoutOpen ? '' : ' pro-view-hero-main--beta'}">
           <div class="pro-view-hero-copy">
             <h1 class="pro-view-headline">${escapeHtml(PRO_PROMO.title)}</h1>
             <p class="pro-view-subhead">${escapeHtml(PRO_PROMO.tagline)}</p>
+            ${checkoutOpen ? '' : proBetaClosedNoteHtml()}
           </div>
-          ${proPricingHtml()}
+          ${checkoutOpen ? proPricingHtml() : ''}
         </div>
       </header>
       <section class="pro-view-perks" aria-label="Pro features">

--- a/scripts/pro-view-hero-geometry-audit.mjs
+++ b/scripts/pro-view-hero-geometry-audit.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * Back BAKLOG hero geometry — viewport matrix for beta (checkout closed) layout.
+ * Usage: node scripts/pro-view-hero-geometry-audit.mjs [baseUrl]
+ * Prefer: BAKLOG_AUTH_DISABLED=1 BAKLOG_PROFILE=perf
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+import { clickViewTab, waitViewSettled } from './audit-view-click.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const BASE = process.argv[2] || 'http://127.0.0.1:8765';
+const OUT = path.join(root, 'scripts', 'pro-view-hero-geometry-last-run.json');
+
+const VIEWPORTS = [
+  { width: 1280, height: 800, label: '1280' },
+  { width: 1024, height: 768, label: '1024' },
+  { width: 768, height: 1024, label: '768' },
+  { width: 390, height: 844, label: '390' },
+  { width: 360, height: 740, label: '360' },
+  { width: 844, height: 390, label: '844x390' },
+];
+
+async function measureHero(page) {
+  return page.evaluate(() => {
+    const main = document.querySelector('.pro-view-hero-main');
+    const copy = document.querySelector('.pro-view-hero-copy');
+    const beta = document.querySelector('.pro-view-founder--hero-beta');
+    const pricing = document.querySelector('.pro-view-hero .pro-view-pricing');
+    const sub = document.querySelector('.pro-view-subhead');
+    if (!main || !copy) {
+      return { ok: false, error: 'missing hero nodes' };
+    }
+    const mr = main.getBoundingClientRect();
+    const cr = copy.getBoundingClientRect();
+    const br = beta?.getBoundingClientRect() || null;
+    const pr = pricing?.getBoundingClientRect() || null;
+    const sr = sub?.getBoundingClientRect() || null;
+    const issues = [];
+    if (pricing && !beta) {
+      // Live checkout: pricing should not leave a huge empty mid gap on wide screens.
+      const gap = pr.left - cr.right;
+      if (gap > 120) issues.push(`checkout_side_gap_${Math.round(gap)}`);
+    }
+    if (beta) {
+      if (pricing) issues.push('beta_still_has_pricing_column');
+      if (!main.classList.contains('pro-view-hero-main--beta')) {
+        issues.push('missing_beta_main_class');
+      }
+      if (!copy.contains(beta)) issues.push('beta_note_not_in_copy');
+      if (sr && br.top < sr.bottom - 1) issues.push('beta_note_not_below_subhead');
+      // Side-by-side regression: beta note should share copy column width, not sit far right.
+      if (br.left > cr.left + 24) issues.push(`beta_note_inset_${Math.round(br.left - cr.left)}`);
+      if (br.width > cr.width + 2) issues.push('beta_note_wider_than_copy');
+      // Empty mid-gap heuristic from the old side-column layout.
+      const rightSlack = mr.right - br.right;
+      if (rightSlack > mr.width * 0.45 && br.width < mr.width * 0.4) {
+        issues.push(`beta_right_slack_${Math.round(rightSlack)}`);
+      }
+    }
+    const overflowPx = Math.max(
+      0,
+      Math.max(document.documentElement.scrollWidth, document.body.scrollWidth) -
+        document.documentElement.clientWidth,
+    );
+    if (overflowPx > 1) issues.push(`page_overflow_${overflowPx}`);
+    return {
+      ok: issues.length === 0,
+      issues,
+      main: { w: Math.round(mr.width), h: Math.round(mr.height) },
+      copy: { w: Math.round(cr.width), h: Math.round(cr.height) },
+      beta: br
+        ? { w: Math.round(br.width), h: Math.round(br.height), top: Math.round(br.top) }
+        : null,
+      pricing: pr ? { w: Math.round(pr.width), left: Math.round(pr.left) } : null,
+      overflowPx,
+    };
+  });
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const results = [];
+  try {
+    for (const vp of VIEWPORTS) {
+      const page = await browser.newPage({ viewport: { width: vp.width, height: vp.height } });
+      await page.goto(BASE, { waitUntil: 'domcontentloaded', timeout: 30000 });
+      await page.waitForFunction(
+        () => !document.documentElement.hasAttribute('data-boot-loading'),
+        null,
+        { timeout: 25000 },
+      );
+      await clickViewTab(page, 'pro');
+      await waitViewSettled(page, 'pro');
+      await page.waitForSelector('.pro-view-hero-main', { timeout: 10000 });
+      const m = await measureHero(page);
+      results.push({ viewport: vp.label, ...m });
+      await page.close();
+    }
+  } finally {
+    await browser.close();
+  }
+  fs.writeFileSync(OUT, `${JSON.stringify({ base: BASE, results }, null, 2)}\n`);
+  const failed = results.filter((r) => !r.ok);
+  for (const r of results) {
+    const mark = r.ok ? 'OK' : 'FAIL';
+    console.log(
+      `${mark} ${r.viewport}: copy=${r.copy?.w}px beta=${r.beta?.w ?? 'n/a'} overflow=${r.overflowPx}${
+        r.issues?.length ? ` issues=${r.issues.join(',')}` : ''
+      }`,
+    );
+  }
+  if (failed.length) {
+    console.error(`pro-view hero geometry FAIL (${failed.length}/${results.length})`);
+    process.exit(1);
+  }
+  console.log('pro-view hero geometry audit OK');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/pro-view.test.js
+++ b/tests/pro-view.test.js
@@ -88,6 +88,9 @@ describe('renderProView', () => {
     renderProView();
     const root = document.getElementById('proViewRoot');
     expect(root.querySelector('[data-pro-checkout]')).toBeNull();
+    expect(root.querySelector('.pro-view-pricing')).toBeNull();
+    expect(root.querySelector('.pro-view-hero-main--beta')).toBeTruthy();
+    expect(root.querySelector('.pro-view-hero-copy .pro-view-founder--hero-beta')).toBeTruthy();
     expect(root.innerHTML).toContain('Checkout is closed during beta');
   });
 


### PR DESCRIPTION
## Summary
- Stack the beta checkout-closed note under the Support tab pitch copy instead of a sparse side column
- Cap live-checkout side panel width; add Support hero viewport geometry audit

## Test plan
- [x] `npm test -- --run tests/pro-view.test.js`
- [x] `node scripts/pro-view-hero-geometry-audit.mjs` (1280/1024/768/390/360/844x390)
- [x] `node scripts/responsive-overflow-audit.mjs` (56/56)
- [ ] Hard-refresh Support tab with checkout closed; confirm single-column pitch + note