### PR TITLE
Fix phone loading center, A-Z clamp, and right gutter stripe

### DIFF
--- a/app.css
+++ b/app.css
@@ -785,12 +785,18 @@ html[data-boot-loading] #bootLoadingOverlay {
   display: flex;
   position: fixed;
   inset: 0;
+  /* Prefer dvh so flex centering uses the visible viewport on mobile chrome. */
+  height: 100vh;
+  max-height: 100vh;
+  height: 100dvh;
+  max-height: 100dvh;
   z-index: var(--overlay-z-boot);
   align-items: center;
   justify-content: center;
   background: var(--bg);
   padding: 1.5rem;
   margin: 0;
+  box-sizing: border-box;
 }
 .boot-loading-card {
   display: flex;
@@ -3801,7 +3807,12 @@ body.bulk-bar-open {
   top: var(--view-overlay-top, 0);
   left: 0;
   right: 0;
-  bottom: 0;
+  bottom: auto;
+  /* Bound to dynamic viewport below the header so the card centers in view. */
+  height: calc(100vh - var(--view-overlay-top, 0px));
+  max-height: calc(100vh - var(--view-overlay-top, 0px));
+  height: calc(100dvh - var(--view-overlay-top, 0px));
+  max-height: calc(100dvh - var(--view-overlay-top, 0px));
   z-index: var(--overlay-z-view);
   display: flex;
   align-items: center;
@@ -3811,6 +3822,7 @@ body.bulk-bar-open {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.18s ease;
+  box-sizing: border-box;
 }
 #viewLoadingOverlay.app-view-overlay.show {
   opacity: 1;
@@ -3953,6 +3965,16 @@ html[data-boot-loading] .view-tab {
   }
 }
 @media (max-width: 639.98px), (max-height: 480px) and (hover: none) {
+  /* Stable gutter reserves an empty right strip on phone/DevTools. */
+  html {
+    scrollbar-gutter: auto;
+  }
+  .boot-loading-card {
+    padding: 1.5rem 1rem;
+  }
+  .app-view-overlay-card {
+    padding: 1rem 1.25rem;
+  }
   .alpha-nav-btn.enabled::before {
     width: max(100%, 36px);
     height: max(100%, 28px);
@@ -3968,7 +3990,9 @@ html[data-boot-loading] .view-tab {
     z-index: 40;
   }
   #alphaNav {
-    max-height: min(48vh, 320px);
+    /* Fit inside the visible viewport; scroll inside the rail if needed. */
+    max-height: min(48dvh, calc(100dvh - 120px));
+    overflow-y: auto;
   }
   #backToTop {
     /* Keep compact (match desktop rail control) - solid so it reads on cards */

--- a/scripts/phone-chrome-geometry-audit.mjs
+++ b/scripts/phone-chrome-geometry-audit.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Phone chrome light checks — 390x844 (iPhone 12 Pro-ish).
+ * Usage: node scripts/phone-chrome-geometry-audit.mjs [baseUrl]
+ * Prefer: BAKLOG_AUTH_DISABLED=1
+ */
+import { chromium } from 'playwright';
+import { clickViewTab, waitViewSettled } from './audit-view-click.mjs';
+
+const BASE = process.argv[2] || 'http://127.0.0.1:8765';
+const VP = { width: 390, height: 844 };
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({ viewport: VP });
+  const issues = [];
+  try {
+    await page.goto(BASE, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    await page.waitForFunction(
+      () => !document.documentElement.hasAttribute('data-boot-loading'),
+      null,
+      { timeout: 30000 },
+    );
+
+    const gutter = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).scrollbarGutter,
+    );
+    if (gutter && gutter !== 'auto' && gutter !== 'stable') {
+      // auto is expected on phone; stable would recreate the stripe
+    }
+    if (gutter === 'stable') issues.push(`scrollbar_gutter_stable`);
+
+    await clickViewTab(page, 'library');
+    await waitViewSettled(page, 'library');
+    await page.waitForSelector('#alphaNav', { timeout: 10000 });
+
+    const alpha = await page.evaluate(() => {
+      const nav = document.getElementById('alphaNav');
+      const wrap = document.getElementById('alphaNavWrap');
+      if (!nav || !wrap) return { ok: false, error: 'missing alpha' };
+      const nr = nav.getBoundingClientRect();
+      const wr = wrap.getBoundingClientRect();
+      const h = window.innerHeight;
+      const problems = [];
+      if (nr.bottom > h + 1) problems.push(`alpha_nav_bottom_${Math.round(nr.bottom)}_gt_${h}`);
+      if (wr.bottom > h + 1) problems.push(`alpha_wrap_bottom_${Math.round(wr.bottom)}_gt_${h}`);
+      return {
+        ok: problems.length === 0,
+        problems,
+        navBottom: Math.round(nr.bottom),
+        wrapBottom: Math.round(wr.bottom),
+        maxH: getComputedStyle(nav).maxHeight,
+        gutter: getComputedStyle(document.documentElement).scrollbarGutter,
+      };
+    });
+    if (!alpha.ok) issues.push(...(alpha.problems || [alpha.error]));
+
+    // Tab-switch overlay: center of card should sit mid content band.
+    await page.evaluate(() => {
+      const ov = document.getElementById('viewLoadingOverlay');
+      const header = document.querySelector('.app-header');
+      const top = header ? Math.ceil(header.getBoundingClientRect().bottom) : 0;
+      if (ov) {
+        ov.style.setProperty('--view-overlay-top', `${top}px`);
+        ov.classList.add('show');
+        ov.setAttribute('aria-hidden', 'false');
+      }
+    });
+    await page.waitForTimeout(50);
+    const load = await page.evaluate(() => {
+      const ov = document.getElementById('viewLoadingOverlay');
+      const card =
+        ov?.querySelector('.app-view-overlay-card') ||
+        ov?.querySelector('[class*="overlay-card"]');
+      if (!ov || !card) return { ok: false, error: 'missing overlay card' };
+      const or = ov.getBoundingClientRect();
+      const cr = card.getBoundingClientRect();
+      const mid = (cr.top + cr.bottom) / 2;
+      const bandTop = or.top;
+      const bandBot = or.bottom;
+      const pct = (mid - bandTop) / Math.max(1, bandBot - bandTop);
+      const problems = [];
+      if (or.height > window.innerHeight + 2) {
+        problems.push(`overlay_taller_than_vv_${Math.round(or.height)}`);
+      }
+      if (pct < 0.35 || pct > 0.65) {
+        problems.push(`card_center_pct_${pct.toFixed(2)}`);
+      }
+      return {
+        ok: problems.length === 0,
+        problems,
+        pct: Number(pct.toFixed(3)),
+        ovH: Math.round(or.height),
+        innerH: window.innerHeight,
+      };
+    });
+    await page.evaluate(() => {
+      document.getElementById('viewLoadingOverlay')?.classList.remove('show');
+    });
+    if (!load.ok) issues.push(...(load.problems || [load.error]));
+
+    console.log(JSON.stringify({ alpha, load, gutter }, null, 2));
+    if (issues.length) {
+      console.error('FAIL', issues.join(', '));
+      process.exit(1);
+    }
+    console.log('phone chrome geometry OK');
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Bound boot/view loading overlays to `dvh` so the card centers in the visible viewport
- Clamp the A-Z rail with `dvh` max-height on phone
- `scrollbar-gutter: auto` on phone to remove the reserved right stripe

## Test plan
- [x] `node scripts/phone-chrome-geometry-audit.mjs` (390x844): alpha in-bounds, card center 50%, gutter auto
- [ ] DevTools iPhone 12 Pro: cold load / tab switch / library rail / no right stripe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overlay and navigation sizing on mobile browsers with dynamic viewport heights.
  * Prevented loading and navigation elements from extending beyond the visible screen.
  * Adjusted spacing and scrolling behavior for short phone viewports.

* **Tests**
  * Added automated checks for mobile viewport sizing, scrolling, and loading overlay positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->