### PR TITLE
Point CodeRabbit reviews at BAKLOG priorities

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,11 @@
 # CodeRabbit config for BAKLOG (public OSS - free PR reviews).
 # Docs: https://docs.coderabbit.ai/configuration/auto-review
 language: en-US
+tone_instructions: >
+  Prioritize security (auth, secrets, localhost binding), profile isolation,
+  fetcher exit-code contracts, and AGENTS.md sync-pair drift. Prefer concrete
+  regressions over style nits. Do not suggest committing personal data or
+  weakening X-BAKLOG-Local / credential handling.
 reviews:
   profile: chill
   request_changes_workflow: false


### PR DESCRIPTION
## Summary
- Add top-level `tone_instructions` so free OSS CodeRabbit reviews prioritize auth/secrets, profile isolation, fetcher exit codes, and AGENTS.md sync-pair drift over style nits
- Keep `reviews.profile: chill` and existing path instructions unchanged
- Local `main` was fast-forwarded to `origin/main` before branching

## Test plan
- [ ] Confirm PR triggers CodeRabbit and the walkthrough reflects the new priorities
- [ ] Spot-check that chill profile still avoids style-only noise

Made with [Cursor](https://cursor.com)