### PR TITLE
Fix CodeRabbit findings on cloud mirror P2

### DIFF
--- a/js/connections.js
+++ b/js/connections.js
@@ -772,7 +772,7 @@ async function handleCloudMirrorClear() {
   }
 }
 
-async function openCloudMirrorImportDialog(initialSnap) {
+export async function openCloudMirrorImportDialog(initialSnap) {
   const dialog = document.getElementById("cloudMirrorImportDialog");
   const listEl = document.getElementById("cloudMirrorImportArtifactList");
   const personalToggle = document.getElementById("cloudMirrorImportPersonal");
@@ -873,6 +873,17 @@ async function openCloudMirrorImportDialog(initialSnap) {
   }
 
   if (!importableCount && profiles.length <= 1) return null;
+
+  // Default mode is overwrite each open (canceling with Merge selected must not stick).
+  if (modeOverwrite) {
+    modeOverwrite.checked = true;
+    modeOverwrite.onchange = updateIntro;
+  }
+  if (modeMerge) {
+    modeMerge.checked = false;
+    modeMerge.onchange = updateIntro;
+  }
+  updateIntro();
 
   dialog.returnValue = "cancel";
   dialog.showModal();

--- a/shared/cloud_mirror.py
+++ b/shared/cloud_mirror.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -619,6 +620,15 @@ def _catalog_row_key(game: dict[str, Any]) -> str | None:
     return None
 
 
+def _stable_row_fingerprint(row: Any) -> str:
+    """Content hash for rows lacking store/id keys (stable across merge sides)."""
+    try:
+        payload = json.dumps(row, sort_keys=True, separators=(",", ":"), default=str)
+    except (TypeError, ValueError):
+        payload = repr(row)
+    return hashlib.sha1(payload.encode("utf-8")).hexdigest()[:16]
+
+
 def _merge_map_remote_wins(local: dict[str, Any], remote: dict[str, Any]) -> dict[str, Any]:
     """Union dict maps. Remote replaces overlapping keys; nested dicts merge field-wise."""
     out = dict(local)
@@ -656,7 +666,7 @@ def _merge_personal_docs(local: dict[str, Any], remote: dict[str, Any]) -> dict[
     manual_by_key: dict[str, Any] = {}
     manual_order: list[str] = []
 
-    def _manual_key(row: Any, *, fallback: str) -> str:
+    def _manual_key(row: Any) -> str:
         if isinstance(row, dict):
             mid = row.get("id")
             if mid is not None and str(mid).strip():
@@ -664,15 +674,16 @@ def _merge_personal_docs(local: dict[str, Any], remote: dict[str, Any]) -> dict[
             title = row.get("title") or row.get("name")
             if title is not None and str(title).strip():
                 return f"title:{str(title).strip().lower()}"
-        return fallback
+            return f"row:{_stable_row_fingerprint(row)}"
+        return f"row:{_stable_row_fingerprint(row)}"
 
-    for idx, row in enumerate(local_manual):
-        key = _manual_key(row, fallback=f"local:{idx}")
+    for row in local_manual:
+        key = _manual_key(row)
         if key not in manual_by_key:
             manual_order.append(key)
         manual_by_key[key] = row
-    for idx, row in enumerate(remote_manual):
-        key = _manual_key(row, fallback=f"remote:{idx}")
+    for row in remote_manual:
+        key = _manual_key(row)
         if key not in manual_by_key:
             manual_order.append(key)
         if isinstance(manual_by_key.get(key), dict) and isinstance(row, dict):
@@ -708,16 +719,19 @@ def _merge_catalog_docs(local: Any, remote: Any, *, filename: str) -> dict[str, 
     remote_games = remote.get("games") if isinstance(remote.get("games"), list) else []
     by_key: dict[str, dict[str, Any]] = {}
     order: list[str] = []
-    unkeyed: list[dict[str, Any]] = []
 
     def _ingest(rows: list[Any], *, remote_side: bool) -> None:
-        for idx, row in enumerate(rows):
+        for row in rows:
             if not isinstance(row, dict):
                 continue
             key = _catalog_row_key(row)
             if key is None:
-                unkeyed.append(dict(row))
-                continue
+                title = str(row.get("title") or row.get("name") or "").strip().lower()
+                store = str(row.get("store") or "steam").strip() or "steam"
+                if title:
+                    key = f"unkeyed:{store}:{title}"
+                else:
+                    key = f"unkeyed:{_stable_row_fingerprint(row)}"
             if key not in by_key:
                 order.append(key)
                 by_key[key] = dict(row)
@@ -729,7 +743,7 @@ def _merge_catalog_docs(local: Any, remote: Any, *, filename: str) -> dict[str, 
 
     _ingest(local_games, remote_side=False)
     _ingest(remote_games, remote_side=True)
-    out["games"] = [by_key[k] for k in order] + unkeyed
+    out["games"] = [by_key[k] for k in order]
     if "game_count" in out or "game_count" in remote or "game_count" in local_doc:
         out["game_count"] = len(out["games"])
     return out
@@ -824,6 +838,8 @@ def import_remote_mirror_to_profile(
                     doc = _merge_personal_docs(local_doc, doc)
                 else:
                     doc = _merge_catalog_docs(local_doc, doc, filename=rel)
+                # Refuse empty catalogs produced by merge when empty is not allowed.
+                _validate_mirror_staged_doc(rel, doc, allow_empty_catalogs=allow_empty_catalogs)
         staged[rel] = doc
     write_paths = [_mirror_artifact_write_path(rel, profile_id=pid) for rel in staged]
     backups: dict[Path, bytes | None] = {}

--- a/shared/supabase_mirror.py
+++ b/shared/supabase_mirror.py
@@ -143,7 +143,7 @@ def delete_mirror_objects(
     if not keys:
         return []
     url = f"{_base_url()}/storage/v1/object/{MIRROR_BUCKET}"
-    body = json.dumps(keys).encode("utf-8")
+    body = json.dumps({"prefixes": keys}).encode("utf-8")
     req = urllib.request.Request(
         url,
         data=body,

--- a/tests/connections-rail-render.test.js
+++ b/tests/connections-rail-render.test.js
@@ -43,6 +43,7 @@ vi.mock('../js/auth-gate.js', () => ({
   isAccountAuthMode: vi.fn(() => false),
   isPro: vi.fn(() => false),
   isAdminMode: vi.fn(() => false),
+  isLocalProfilesEnabled: vi.fn(() => true),
   proFeaturesUnlocked: vi.fn(() => false),
   getAccessToken: vi.fn(() => null),
   getAccountProfileId: vi.fn(() => null),
@@ -416,5 +417,76 @@ describe('cloud mirror prefs visibility', () => {
         (c) => c[0] === '/api/mirror/clear' && c[1]?.method === 'POST',
       ),
     ).toBe(true);
+  });
+
+  it('resets Import mode to overwrite when dialog reopens after Merge cancel', async () => {
+    document.body.innerHTML = `
+      <dialog id="cloudMirrorImportDialog">
+        <form method="dialog">
+          <p id="cloudMirrorImportIntro"></p>
+          <fieldset>
+            <input type="radio" name="cloudMirrorImportMode" id="cloudMirrorImportModeOverwrite" value="overwrite" checked />
+            <input type="radio" name="cloudMirrorImportMode" id="cloudMirrorImportModeMerge" value="merge" />
+          </fieldset>
+          <ul id="cloudMirrorImportArtifactList"></ul>
+          <input id="cloudMirrorImportPersonal" type="checkbox" />
+          <button type="submit" value="cancel" id="importCancel">Cancel</button>
+          <button type="submit" value="confirm" id="importConfirm">Import</button>
+        </form>
+      </dialog>
+    `;
+    // happy-dom may lack HTMLDialogElement.showModal
+    const dialog = document.getElementById('cloudMirrorImportDialog');
+    if (dialog && typeof dialog.showModal !== 'function') {
+      dialog.showModal = function showModal() {
+        this.open = true;
+      };
+      dialog.close = function close(returnValue) {
+        if (returnValue !== undefined) this.returnValue = returnValue;
+        this.open = false;
+        this.dispatchEvent(new Event('close'));
+      };
+    }
+
+    const auth = await import('../js/auth-gate.js');
+    vi.mocked(auth.getAccountProfileId).mockReturnValue(null);
+
+    const api = await import('../js/api-client.js');
+    vi.mocked(api.baklogFetch).mockImplementation(async (url) => {
+      if (String(url).startsWith('/api/mirror')) {
+        return new Response(
+          JSON.stringify({
+            artifacts: [{ path: 'games_steam.json' }],
+            profiles: ['default'],
+            profile: 'default',
+            localUploadState: { artifacts: {}, last_upload_at: null },
+          }),
+          { status: 200 },
+        );
+      }
+      return mockBaklogFetchDefault(url);
+    });
+
+    const { openCloudMirrorImportDialog } = await import('../js/connections.js');
+    const snap = {
+      artifacts: [{ path: 'games_steam.json' }],
+      profiles: ['default'],
+      profile: 'default',
+    };
+
+    const first = openCloudMirrorImportDialog(snap);
+    await Promise.resolve();
+    document.getElementById('cloudMirrorImportModeMerge').checked = true;
+    document.getElementById('cloudMirrorImportModeOverwrite').checked = false;
+    dialog.close('cancel');
+    const choice1 = await first;
+    expect(choice1.confirmed).toBe(false);
+
+    const second = openCloudMirrorImportDialog(snap);
+    await Promise.resolve();
+    expect(document.getElementById('cloudMirrorImportModeOverwrite')?.checked).toBe(true);
+    expect(document.getElementById('cloudMirrorImportModeMerge')?.checked).toBe(false);
+    dialog.close('cancel');
+    await second;
   });
 });

--- a/tests/test_cloud_mirror.py
+++ b/tests/test_cloud_mirror.py
@@ -344,6 +344,75 @@ def test_import_merge_unions_catalog_and_personal(
     assert personal_doc["prefs"]["dismissedClaims"] == {"a": True, "b": True}
 
 
+def test_merge_catalog_unkeyed_rows_dedupe_by_fingerprint() -> None:
+    local = {
+        "games": [{"title": "No Id Game", "store": "steam", "note": "local"}],
+        "game_count": 1,
+    }
+    remote = {
+        "games": [{"title": "No Id Game", "store": "steam", "note": "remote"}],
+        "game_count": 1,
+    }
+    once = cloud_mirror._merge_catalog_docs(local, remote, filename="games_steam.json")
+    twice = cloud_mirror._merge_catalog_docs(once, remote, filename="games_steam.json")
+    assert len(once["games"]) == 1
+    assert once["games"][0]["note"] == "remote"
+    assert len(twice["games"]) == 1
+
+
+def test_merge_manual_rows_dedupe_without_id() -> None:
+    local = {
+        "personal": {},
+        "prefs": {},
+        "manual": [{"title": "Homebrew", "platform": "pc"}],
+        "libraryFirstSeen": {},
+    }
+    remote = {
+        "personal": {},
+        "prefs": {},
+        "manual": [{"title": "Homebrew", "platform": "pc", "notes": "from cloud"}],
+        "libraryFirstSeen": {},
+    }
+    once = cloud_mirror._merge_personal_docs(local, remote)
+    twice = cloud_mirror._merge_personal_docs(once, remote)
+    assert len(once["manual"]) == 1
+    assert once["manual"][0]["notes"] == "from cloud"
+    assert len(twice["manual"]) == 1
+
+
+def test_merge_revalidates_empty_catalog_refusal(
+    profile_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    catalog = profile_home / "games_steam.json"
+    # Local games is not a list → merge treats it as empty; remote omits games.
+    catalog.write_text(
+        json.dumps({"games": "corrupt", "store": "steam"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "shared.supabase_auth.verify_bearer_user",
+        lambda *_a, **_k: {"id": "u", "email": "a@b.c"},
+    )
+    monkeypatch.setattr(
+        cloud_mirror,
+        "list_remote_mirror_artifacts",
+        lambda **_: [{"path": "games_steam.json"}],
+    )
+    monkeypatch.setattr(
+        cloud_mirror,
+        "download_remote_mirror_artifact",
+        lambda **_: json.dumps({"store": "steam"}).encode(),
+    )
+    with pytest.raises(ValueError, match="empty games"):
+        import_remote_mirror_to_profile(
+            authorization="Bearer x",
+            source_profile_id="default",
+            include_personal=False,
+            mode="merge",
+            allow_empty_catalogs=False,
+        )
+
+
 def test_clear_remote_mirror_profile_deletes_allowlisted(
     profile_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_supabase_mirror.py
+++ b/tests/test_supabase_mirror.py
@@ -103,10 +103,12 @@ def test_delete_mirror_objects_builds_keys(monkeypatch: pytest.MonkeyPatch) -> N
     )
     assert deleted == ["games_steam.json", "data/personal.json"]
     assert seen["method"] == "DELETE"
-    assert seen["body"] == [
-        "user-1/default/games_steam.json",
-        "user-1/default/data/personal.json",
-    ]
+    assert seen["body"] == {
+        "prefixes": [
+            "user-1/default/games_steam.json",
+            "user-1/default/data/personal.json",
+        ]
+    }
 
 
 def test_delete_mirror_snapshot_rows_scoped(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Storage `DELETE` sends `{ prefixes: [...] }` (Supabase REST shape).
- Soft-merge uses stable keys for id-less catalog/manual rows (no duplicate on re-merge).
- Revalidates merged catalogs so empty `games` still refuse when not allowed.
- Import dialog resets mode to Replace/overwrite after cancel with Merge selected.

## Test plan
- [x] pytest `tests/test_supabase_mirror.py` `tests/test_cloud_mirror.py`
- [x] vitest `tests/connections-rail-render.test.js`

Made with [Cursor](https://cursor.com)