### PR TITLE
Fix close-worktree.ps1 PowerShell $Args collision

### DIFF
--- a/scripts/close-worktree.ps1
+++ b/scripts/close-worktree.ps1
@@ -33,18 +33,18 @@ if ($Branch -notmatch '^(feat|fix|chore)/[a-z0-9][a-z0-9._-]*$') {
 function Invoke-GitStep {
     param(
         [string]$Desc,
-        [string[]]$Args
+        [string[]]$GitArgs
     )
-    $cmd = "git $($Args -join ' ')"
+    $cmd = "git $($GitArgs -join ' ')"
     if ($DryRun) {
         Write-Host "[dry-run] $Desc" -ForegroundColor Yellow
         Write-Host "          $cmd" -ForegroundColor DarkGray
         return
     }
     Write-Host "--- $Desc ---" -ForegroundColor Cyan
-    & git @Args
+    & git @GitArgs
     if ($LASTEXITCODE -ne 0) {
-        throw "git $($Args[0]) failed (exit $LASTEXITCODE): $Desc"
+        throw "git $($GitArgs[0]) failed (exit $LASTEXITCODE): $Desc"
     }
 }
 


### PR DESCRIPTION
## Summary
- Rename `Invoke-GitStep` param `$Args` to `$GitArgs` so dry-run and live git steps no longer collide with PowerShell automatic `$Args`.

## Test plan
- [x] `.\scripts\close-worktree.ps1 feat/ads-polish -DryRun -SkipBackup` prints full `git branch|push|worktree|fetch` lines


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal script parameter naming without changing execution behavior, dry-run output, or failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->