### PR TITLE
Name the blocking run when the fetcher queue is full

### DIFF
--- a/js/connections.js
+++ b/js/connections.js
@@ -2073,6 +2073,12 @@ async function enableLocalProvider(provider) {
   renderReconnectBanner();
 
   await refreshConnections();
+
+  if (log && provider === "amazon") {
+    log.classList.remove("hidden");
+    log.textContent =
+      "Amazon launcher connected. Refresh the Amazon chip manually - launcher sources do not auto-fetch.";
+  }
 }
 
 async function cancelBrowserConnect(provider) {

--- a/js/fetcher-health-log.js
+++ b/js/fetcher-health-log.js
@@ -15,7 +15,7 @@ export const LOG_PANEL_CHROME_HTML = `
           <span class="fh-log-title" data-role="title">Fetcher log</span>
           <span class="fh-log-status" data-role="status" aria-live="polite">idle</span>
         </div>
-        <button type="button" class="fh-log-btn fh-log-btn-cancel hidden" data-role="cancel" title="Stop all queued and running fetchers (Shift+click: force reset queue)">Cancel</button>
+        <button type="button" class="fh-log-btn fh-log-btn-cancel hidden" data-role="cancel" title="Stop all queued and running fetchers and enrichers (Shift+click: force-reset both lanes)">Cancel</button>
         <button type="button" class="fh-log-btn" data-role="clear" title="Clear log output (does not stop running fetchers)">Clear</button>
         <button type="button" class="fh-log-btn fh-log-toggle" data-role="close" aria-expanded="true" aria-label="Collapse log panel" title="Collapse log panel"><span class="fh-log-toggle-icon" aria-hidden="true">&#9662;</span></button>
       </div>

--- a/js/fetcher/render/dashboard.js
+++ b/js/fetcher/render/dashboard.js
@@ -207,7 +207,7 @@ export function renderDashboardFetcherHealth() {
         ].filter(Boolean);
     const queueFullElsewhere = fetcherRunner.isQueueFullForKey(src.key) && !runState;
     if (queueFullElsewhere) {
-      titleLines.push('Queue full - a fetch is already running. Wait for it to finish.');
+      titleLines.push(fetcherRunner.queueFullMessageForKey(src.key));
     }
     if (needsReconnect) {
       titleLines.push('Session expired - reconnect to refresh credentials, or dismiss to hide this hint.');

--- a/js/fetcher/runner/index.js
+++ b/js/fetcher/runner/index.js
@@ -96,6 +96,10 @@ export const fetcherRunner = (() => {
   let lastServerInFlight = false;
   let lastFetcherLaneInFlight = false;
   let lastEnrichLaneInFlight = false;
+  /** Active/queued owner key for the fetcher lane (server snap preferred). */
+  let lastFetcherLaneOwnerKey = null;
+  /** Active/queued owner key for the enrich lane (server snap preferred). */
+  let lastEnrichLaneOwnerKey = null;
   /** Signature (active run id + line count + queue depth) of the last in-flight snapshot. */
   let lastInFlightSig = '';
   /**
@@ -183,6 +187,12 @@ export const fetcherRunner = (() => {
     lastFetcherLaneInFlight = !!(blockingActive || blockingQueue.length);
     lastEnrichLaneInFlight = !!(enrichActive || enrichQueue.length);
     lastServerInFlight = lastFetcherLaneInFlight || lastEnrichLaneInFlight;
+    lastFetcherLaneOwnerKey = blockingActive?.key
+      || blockingQueue[0]?.key
+      || null;
+    lastEnrichLaneOwnerKey = enrichActive?.key
+      || enrichQueue[0]?.key
+      || null;
     const queueLen = blockingQueue.length + enrichQueue.length;
     const blockingRun = blockingActive || enrichActive;
     // line_count grows on every emitted line (heartbeats included), so the
@@ -774,6 +784,25 @@ export const fetcherRunner = (() => {
   function isEnrichKey(key) {
     return source(key)?.group === 'enrich';
   }
+
+  /** Label of the run holding this key's lane (server snap, else client chip state). */
+  function queueOwnerLabelForKey(key) {
+    const enrich = isEnrichKey(key);
+    const snapKey = enrich ? lastEnrichLaneOwnerKey : lastFetcherLaneOwnerKey;
+    if (snapKey) return labelForKey(snapKey);
+    for (const [k, st] of runStateByKey) {
+      if (!CANCELLABLE_CHIP_STATES.has(st)) continue;
+      if (isEnrichKey(k) === enrich) return labelForKey(k);
+    }
+    return null;
+  }
+
+  function queueFullMessageForKey(key) {
+    const owner = queueOwnerLabelForKey(key);
+    if (owner) return `Queue full - ${owner} is running. Wait for it to finish.`;
+    return 'Queue full - a fetch is already running. Wait for it to finish.';
+  }
+
   function isQueueFullForKey(key) {
     const enrich = isEnrichKey(key);
     const laneBusy = enrich ? lastEnrichLaneInFlight : lastFetcherLaneInFlight;
@@ -947,11 +976,11 @@ export const fetcherRunner = (() => {
     if (cancelInFlight) {
       btn.disabled = true;
       btn.textContent = 'Cancelling…';
-      btn.title = 'Stopping queued and running fetchers…';
+      btn.title = 'Stopping queued and running fetchers and enrichers…';
     } else {
       btn.disabled = !show;
       btn.textContent = 'Cancel';
-      btn.title = 'Stop all queued and running fetchers and enrichers (Shift+click: force reset queue)';
+      btn.title = 'Stop all queued and running fetchers and enrichers (Shift+click: force-reset both lanes)';
     }
   }
 
@@ -1461,7 +1490,7 @@ export const fetcherRunner = (() => {
         ensurePanel(src);
         logEvent(
           'info',
-          `[${src.label}: queue full - a fetch is already running]`,
+          `[${src.label}: ${queueFullMessageForKey(key)}]`,
         );
         scrollPopoverModule('console');
       }
@@ -1993,6 +2022,8 @@ export const fetcherRunner = (() => {
     cancellableCount,
     isQueueFull,
     isQueueFullForKey,
+    queueOwnerLabelForKey,
+    queueFullMessageForKey,
     waitForQueueSlot,
     run,
     runAllStale,

--- a/tests/fetcher-health.test.js
+++ b/tests/fetcher-health.test.js
@@ -957,6 +957,8 @@ describe('lane-aware queue slots', () => {
     expect(fetcherRunner.isQueueFullForKey('steam')).toBe(true);
     expect(fetcherRunner.isQueueFullForKey('hltb')).toBe(false);
     expect(fetcherRunner.getLastServerInFlight()).toBe(true);
+    expect(fetcherRunner.queueOwnerLabelForKey('amazon')).toMatch(/Steam/i);
+    expect(fetcherRunner.queueFullMessageForKey('amazon')).toMatch(/Steam/i);
   });
 
   it('enrich lane busy blocks enrich keys only', () => {
@@ -965,6 +967,8 @@ describe('lane-aware queue slots', () => {
     });
     expect(fetcherRunner.isQueueFullForKey('hltb')).toBe(true);
     expect(fetcherRunner.isQueueFullForKey('steam')).toBe(false);
+    expect(fetcherRunner.queueOwnerLabelForKey('hltb')).toBe('HLTB');
+    expect(fetcherRunner.queueFullMessageForKey('hltb')).toMatch(/HLTB is running/);
   });
 
   it('both lanes busy block both key types', () => {


### PR DESCRIPTION
## Summary
- Queue-full chip tooltips and console lines name the active lane owner (e.g. Steam Reviews is running).
- Cancel button copy clarifies force-reset clears both fetcher and enrich lanes.
- Amazon launcher Connect success notes that a manual Amazon chip refresh is required.

## Test plan
- [x] Vitest lane-aware queue slots (owner label assertions)
- [ ] Manual: start Steam fetch, click Amazon chip - tooltip names Steam
