### PR TITLE
Close Epic Cloudflare detector test gaps

### DIFF
--- a/tests/fixtures/epic/store_home_signed_out.html
+++ b/tests/fixtures/epic/store_home_signed_out.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Epic Games Store</title>
+</head>
+<body>
+  <!-- Sanitized storefront home fixture for CF false-positive guard (signed-out / bounced home). -->
+  <header>
+    <a href="/login">Sign in</a>
+    <button type="button">Wishlist</button>
+  </header>
+  <main>
+    <h1>Epic Games Store</h1>
+    <p>Discover your next favorite game.</p>
+    <script>
+      // Bundles often reference cdn-cgi challenge-platform scripts without an active challenge page.
+      a.src = "/cdn-cgi/challenge-platform/scripts/jsd/main.js";
+    </script>
+  </main>
+</body>
+</html>

--- a/tests/test_epic_wishlist.py
+++ b/tests/test_epic_wishlist.py
@@ -2,12 +2,15 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
+from fetchers._progress import EXIT_CODE_AUTH
 from fetchers.fetch_epic_wishlist import (
     _build_row,
     parse_wishlist_sources,
 )
+from auth.epic_wishlist_session import storefront_auth_error_message
 
 FIXTURE = Path(__file__).resolve().parent / "fixtures" / "epic_wishlist_graphql.json"
 
@@ -45,3 +48,57 @@ def test_build_row_schema() -> None:
     assert row["epic_offer_id"] == "offer-aaa"
     assert "epicgames.com" in row["store_url"]
     assert row["price"] == "$19.99"
+
+
+def test_main_auth_abort_cf_page_exit_4(monkeypatch) -> None:
+    import fetchers.fetch_epic_wishlist as fetch_mod
+
+    cf_html = (
+        "<html><head><title>Just a moment...</title></head>"
+        "<body><div class='cf_challenge_container'>Checking your browser</div></body></html>"
+    )
+    wishlist_url = "https://store.epicgames.com/en-US/wishlist"
+    marked: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(
+        fetch_mod,
+        "run_with_heartbeat",
+        lambda fn, _label: (cf_html, wishlist_url, []),
+    )
+    monkeypatch.setattr(
+        fetch_mod,
+        "mark_invalid",
+        lambda provider, *, error="": marked.append((provider, error)),
+    )
+    monkeypatch.setattr(sys, "argv", ["fetch_epic_wishlist"])
+    assert fetch_mod.main() == EXIT_CODE_AUTH
+    assert marked and marked[0][0] == "epic_wishlist"
+    assert "Cloudflare" in marked[0][1]
+    assert "Cloudflare" in storefront_auth_error_message(cf_html, wishlist_url)
+
+
+def test_main_auth_abort_signed_out_exit_4(monkeypatch) -> None:
+    import fetchers.fetch_epic_wishlist as fetch_mod
+
+    html = (
+        "<html><body><a href='/login'>Sign in</a>"
+        "<button>Continue</button></body></html>"
+    )
+    home_url = "https://store.epicgames.com/?lang=en-US"
+    marked: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(
+        fetch_mod,
+        "run_with_heartbeat",
+        lambda fn, _label: (html, home_url, []),
+    )
+    monkeypatch.setattr(
+        fetch_mod,
+        "mark_invalid",
+        lambda provider, *, error="": marked.append((provider, error)),
+    )
+    monkeypatch.setattr(sys, "argv", ["fetch_epic_wishlist"])
+    assert fetch_mod.main() == EXIT_CODE_AUTH
+    assert marked and marked[0][0] == "epic_wishlist"
+    assert "Cloudflare" not in marked[0][1]
+    assert "session" in marked[0][1].lower() or "bounced" in marked[0][1].lower()

--- a/tests/test_epic_wishlist.py
+++ b/tests/test_epic_wishlist.py
@@ -5,12 +5,12 @@ import json
 import sys
 from pathlib import Path
 
+from auth.epic_wishlist_session import storefront_auth_error_message
 from fetchers._progress import EXIT_CODE_AUTH
 from fetchers.fetch_epic_wishlist import (
     _build_row,
     parse_wishlist_sources,
 )
-from auth.epic_wishlist_session import storefront_auth_error_message
 
 FIXTURE = Path(__file__).resolve().parent / "fixtures" / "epic_wishlist_graphql.json"
 

--- a/tests/test_epic_wishlist_session.py
+++ b/tests/test_epic_wishlist_session.py
@@ -19,7 +19,9 @@ from auth.epic_wishlist_session import (
     wishlist_graphql_ok,
 )
 
-DUMP_HTML = Path(__file__).resolve().parents[1] / "cache" / "epic" / "wishlist_dump.html"
+DUMP_HTML = (
+    Path(__file__).resolve().parent / "fixtures" / "epic" / "store_home_signed_out.html"
+)
 
 
 def test_wishlist_graphql_ok_ignores_toast_only_graphql() -> None:
@@ -120,6 +122,20 @@ def test_cloudflare_interstitial_not_normal_epic_login_html() -> None:
     assert not cloudflare_interstitial(login_html, "https://www.epicgames.com/id/login")
 
 
+def test_cloudflare_interstitial_not_login_with_embedded_cf_chl_opt() -> None:
+    """Login SPA can dump _cf_chl_opt into a form error without being a challenge page."""
+    login_html = (
+        "<html><head><title>Sign in to your Epic Games account</title></head>"
+        "<body><form><input name='email'/><button>Continue</button></form>"
+        "<div class='form-error'>Enable JavaScript and cookies to continue"
+        "<script>window._cf_chl_opt={cType: 'managed'};</script></div>"
+        "</body></html>"
+    )
+    login_url = "https://www.epicgames.com/id/login"
+    assert not cloudflare_interstitial(login_html, login_url)
+    assert cloudflare_embedded_challenge(login_html)
+
+
 def test_cloudflare_interstitial_not_store_home_js_bundle() -> None:
     snippet = (
         "<html><body><script>"
@@ -133,8 +149,7 @@ def test_cloudflare_interstitial_not_store_home_js_bundle() -> None:
 
 
 def test_store_home_dump_html_not_cloudflare_false_positive() -> None:
-    if not DUMP_HTML.exists():
-        return
+    assert DUMP_HTML.is_file(), f"missing committed fixture: {DUMP_HTML}"
     html = DUMP_HTML.read_text(encoding="utf-8", errors="replace")
     url = "https://store.epicgames.com/?lang=en-US"
     assert not cloudflare_interstitial(html, url)


### PR DESCRIPTION
## Summary
- Negative guard covers login HTML that embeds `_cf_chl_opt` without classifying as a challenge page.
- Committed sanitized store-home fixture so the false-positive dump test runs on CI.
- Fetcher-level tests pin exit code 4 + `mark_invalid` for CF page vs signed-out storefront.

## Test plan
- [x] `pytest tests/test_epic_wishlist_session.py tests/test_epic_wishlist.py`
