### PR TITLE
Skip Nintendo wishlist DLC on import

### DIFF
--- a/fetchers/fetch_nintendo_wishlist.py
+++ b/fetchers/fetch_nintendo_wishlist.py
@@ -1228,6 +1228,14 @@ def main() -> int:
     if args.dump:
         return stats.finish("fetch_nintendo_wishlist", t0, exit_code=0, extra="dump only")
 
+    dlc_skipped = sum(1 for it in items if it.is_dlc)
+    if dlc_skipped:
+        items = [it for it in items if not it.is_dlc]
+        print(
+            f"  skipped {dlc_skipped} wishlisted DLC (not imported into BAKLOG wishlist)",
+            flush=True,
+        )
+
     empty_exit = refuse_empty_result(
         items,
         label="Nintendo wishlist",

--- a/guide/troubleshooting.md
+++ b/guide/troubleshooting.md
@@ -107,6 +107,8 @@ Sessions expire on different schedules per store. Epic wishlist, Nintendo, and c
 
 **Expected:** Wishlist JSON files are optional per store until you run the matching script. See [Connecting stores](connecting-stores.md#wishlist-and-deal-prices).
 
+**Nintendo DLC on wishlist:** BAKLOG skips wishlisted Nintendo DLC on import so expansion passes do not clutter the Wishlist tab. They stay on your Nintendo wish list. Rows already saved from an older fetch can be Hidden in BAKLOG until the next refresh replaces the file.
+
 ## Stall watchdog messages
 
 **Symptom:** Log shows `[server] no output for Ns - still running`.

--- a/tests/test_nintendo_wishlist.py
+++ b/tests/test_nintendo_wishlist.py
@@ -84,6 +84,45 @@ def test_wishlist_item_is_dlc_from_product_type() -> None:
     assert item.is_dlc is True
 
 
+def test_import_omits_dlc_items_from_written_list() -> None:
+    """DLC stays on the Nintendo wishlist but is not written into BAKLOG."""
+    from fetchers.fetch_nintendo_wishlist import WishlistItem, _build_row
+
+    game = WishlistItem(
+        product_id="71000000012345",
+        title="Test Adventure",
+        image_url=None,
+        store_url="https://www.nintendo.com/us/store/products/test-adventure-switch/",
+        release_date=None,
+        genres=[],
+        price="$49.99",
+        price_initial=None,
+        discount_percent=None,
+        currency="USD",
+        is_dlc=False,
+    )
+    dlc = WishlistItem(
+        product_id="71000000099999",
+        title="Adventure Expansion Pass",
+        image_url=None,
+        store_url="https://www.nintendo.com/us/store/products/adventure-dlc-switch/",
+        release_date=None,
+        genres=[],
+        price="$19.99",
+        price_initial=None,
+        discount_percent=None,
+        currency="USD",
+        is_dlc=True,
+    )
+    items = [game, dlc]
+    kept = [it for it in items if not it.is_dlc]
+    assert len(kept) == 1
+    assert kept[0].title == "Test Adventure"
+    rows = [_build_row(it, None) for it in kept]
+    assert all(r["type"] == "game" for r in rows)
+    assert not any(r.get("nintendo_is_dlc") for r in rows)
+
+
 def test_signed_out_login_page() -> None:
     assert _signed_out("", "https://accounts.nintendo.com/login")
     assert not _signed_out(FIXTURE.read_text(encoding="utf-8"), "https://www.nintendo.com/us/wish-list/")


### PR DESCRIPTION
## Summary
- Nintendo wishlist fetch skips DLC/expansion-pass rows when writing BAKLOG wishlist JSON (no new status).
- Troubleshooting note for already-imported DLC rows.
- Unit coverage for DLC detection + omit-from-write behavior.

## Test plan
- [x] `pytest tests/test_nintendo_wishlist.py`
