### PR TITLE
Scrub session errors inside bug report bundles

### DIFF
--- a/js/error-boundary.js
+++ b/js/error-boundary.js
@@ -510,8 +510,8 @@ export function buildBugBundle(extra = {}) {
     errors: {
       session_count: _errors.length,
       persisted_count: _persistedRing.length,
-      session: _errors.slice(),
-      persisted: _persistedRing.slice(),
+      session: _errors.map((e) => entryForStorage(e)),
+      persisted: _persistedRing.map((e) => entryForStorage(e)),
     },
     notice: 'This bundle was assembled locally. Nothing was sent anywhere. Paste it into a GitHub issue if you want to share it.',
   };

--- a/tests/error-boundary.test.js
+++ b/tests/error-boundary.test.js
@@ -344,6 +344,14 @@ describe("buildBugBundle shape", () => {
     expect(serialized).not.toMatch(/gamesBySource/);
   });
 
+  it("scrubs Bearer tokens from session errors in the bug bundle", () => {
+    reportError(new Error("upstream failed Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abc.def"));
+    const bundle = buildBugBundle();
+    const serialized = JSON.stringify(bundle.errors.session);
+    expect(serialized).toContain("Bearer [redacted]");
+    expect(serialized).not.toContain("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9");
+  });
+
   it("PARANOIA: bundle keys are exactly the documented whitelist", () => {
     const bundle = buildBugBundle();
     const topLevel = Object.keys(bundle).sort();


### PR DESCRIPTION
## Summary
- Run session and persisted error entries through `entryForStorage` inside `buildBugBundle` so Bearer/cookie-shaped text is redacted before copy/submit.
- Add a Vitest covering Bearer scrubbing in the session slice.

## Test plan
- [x] `npm test -- tests/error-boundary.test.js`

Made with [Cursor](https://cursor.com)