### PR TITLE
Unblock personal saves after failed profile switch

### DIFF
--- a/js/personal-store.js
+++ b/js/personal-store.js
@@ -418,12 +418,19 @@ export const personalStore = (() => {
     } catch (_) { /* ignore */ }
   }
 
+  /** Undo prepareForProfileSwitch when the active-profile POST fails (PIN / 409 / network). */
+  function abortProfileSwitchSaveBlock() {
+    profileSwitchSaveBlock = false;
+    initComplete = true;
+  }
+
   return {
     init,
     notify,
     flush,
     flushSync,
     prepareForProfileSwitch,
+    abortProfileSwitchSaveBlock,
     uploadLocalToServer,
     dismissMigration,
     isProfileSwitchSaveBlocked,

--- a/js/profiles.js
+++ b/js/profiles.js
@@ -418,9 +418,14 @@ async function switchProfile(id, pin) {
   closeMenu();
   const { personalStore } = await import('./personal-store.js');
   await personalStore.prepareForProfileSwitch();
-  const body = { id };
-  if (pin) body.pin = pin;
-  await api('POST', '/api/profiles/active', body);
+  try {
+    const body = { id };
+    if (pin) body.pin = pin;
+    await api('POST', '/api/profiles/active', body);
+  } catch (err) {
+    personalStore.abortProfileSwitchSaveBlock();
+    throw err;
+  }
   localStorage.setItem(ACTIVE_PROFILE_LS, id);
   resetTabMemoryForProfile(id);
   location.reload();

--- a/tests/scenario-matrix.test.js
+++ b/tests/scenario-matrix.test.js
@@ -216,6 +216,15 @@ describe('Scenario 5 — Profile switch mid-fetch', () => {
     const root = join(dirname(fileURLToPath(import.meta.url)), '..');
     const src = readFileSync(join(root, 'js', 'profiles.js'), 'utf8');
     expect(src).toMatch(/prepareForProfileSwitch\(\)[\s\S]*location\.reload\(\)/);
+    expect(src).toMatch(/abortProfileSwitchSaveBlock/);
+  });
+
+  it('abortProfileSwitchSaveBlock re-enables saves after a failed switch', async () => {
+    const { personalStore } = await import('../js/personal-store.js');
+    await personalStore.prepareForProfileSwitch();
+    expect(personalStore.isProfileSwitchSaveBlocked()).toBe(true);
+    personalStore.abortProfileSwitchSaveBlock();
+    expect(personalStore.isProfileSwitchSaveBlocked()).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `abortProfileSwitchSaveBlock` and call it when `POST /api/profiles/active` fails after prepare.
- Cover unblock + source wiring in scenario-matrix.

## Test plan
- [x] `npm test -- tests/scenario-matrix.test.js`

Made with [Cursor](https://cursor.com)