### PR TITLE
Reject JWT/service-role keys in frozen bundle .env smoke

### DIFF
--- a/scripts/frozen_bundle_smoke.py
+++ b/scripts/frozen_bundle_smoke.py
@@ -41,7 +41,17 @@ def _manifest_fetcher_count(bundle_dir):
     return 0
 
 
+_FORBIDDEN_BUNDLE_ENV_KEYS = frozenset(
+    {
+        "BAKLOG_SUPABASE_JWT_SECRET",
+        "BAKLOG_SUPABASE_SERVICE_ROLE_KEY",
+        "SUPABASE_SERVICE_ROLE_KEY",
+    }
+)
+
+
 def _env_has_auth_keys(env_path):
+    """Require anon auth keys and refuse JWT/service-role secrets in the bundle .env."""
     required = ("BAKLOG_SUPABASE_URL", "BAKLOG_SUPABASE_ANON_KEY")
     found = {}
     if env_path.is_file():
@@ -54,6 +64,9 @@ def _env_has_auth_keys(env_path):
             val = val.strip().strip('"').strip("'")
             if key and val:
                 found[key] = val
+    forbidden = sorted(k for k in _FORBIDDEN_BUNDLE_ENV_KEYS if found.get(k))
+    if forbidden:
+        return (False, [f"must not ship {k}" for k in forbidden])
     missing = [k for k in required if not found.get(k)]
     return (not missing, missing)
 
@@ -96,7 +109,7 @@ def run_smoke(bundle_dir, *, expected_version=None, port=BUNDLE_SMOKE_PORT):
         report["error"] = "fetchers/manifest.json missing or empty in bundle"
         return report
     if not env_ok:
-        report["error"] = f"bundled .env missing keys: {', '.join(env_missing)}"
+        report["error"] = f"bundled .env invalid: {', '.join(env_missing)}"
         return report
     config = None
     with tempfile.TemporaryDirectory(prefix="baklog-bundle-smoke-") as td:

--- a/tests/test_frozen_bundle_smoke.py
+++ b/tests/test_frozen_bundle_smoke.py
@@ -45,6 +45,31 @@ def test_env_has_auth_keys_detects_missing(tmp_path: Path) -> None:
     assert "BAKLOG_SUPABASE_ANON_KEY" in missing
 
 
+def test_env_has_auth_keys_rejects_jwt_secret(tmp_path: Path) -> None:
+    bundle = _stub_bundle(tmp_path, with_env=True)
+    env_path = bundle / ".env"
+    env_path.write_text(
+        env_path.read_text(encoding="utf-8") + "\nBAKLOG_SUPABASE_JWT_SECRET=must-not-ship\n",
+        encoding="utf-8",
+    )
+    ok, problems = smoke._env_has_auth_keys(env_path)
+    assert not ok
+    assert any("BAKLOG_SUPABASE_JWT_SECRET" in p for p in problems)
+
+
+def test_run_smoke_fails_with_jwt_secret_in_env(tmp_path: Path, monkeypatch) -> None:
+    bundle = _stub_bundle(tmp_path, with_env=True)
+    env_path = bundle / ".env"
+    env_path.write_text(
+        env_path.read_text(encoding="utf-8") + "\nBAKLOG_SUPABASE_JWT_SECRET=must-not-ship\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(smoke, "_read_expected_version", lambda: "0.8.20")
+    report = smoke.run_smoke(bundle, expected_version="0.8.20")
+    assert not report["ok"]
+    assert "must not ship BAKLOG_SUPABASE_JWT_SECRET" in (report.get("error") or "")
+
+
 def test_manifest_fetcher_count(tmp_path: Path) -> None:
     bundle = _stub_bundle(tmp_path)
     assert smoke._manifest_fetcher_count(bundle) == 2


### PR DESCRIPTION
## Summary
- Extend `_env_has_auth_keys` to fail closed on `BAKLOG_SUPABASE_JWT_SECRET` / service-role keys.
- Add unit coverage for the forbid path.

## Test plan
- [x] `pytest tests/test_frozen_bundle_smoke.py`

Made with [Cursor](https://cursor.com)