### PR TITLE
Refuse Connect credential persist after Cancel

### DIFF
--- a/auth/connect_loop.py
+++ b/auth/connect_loop.py
@@ -38,6 +38,9 @@ def run_connect_poll(
 
     while time.time() < deadline:
         abort_if_browser_closed(context)
+        # Cancel is cooperative: most Connect providers only poll via this loop.
+        if session is not None and getattr(session, "is_cancelled", lambda: False)():
+            raise ConnectBrowserClosed()
         try:
             creds = check()
         except ConnectBrowserClosed:

--- a/auth/manager.py
+++ b/auth/manager.py
@@ -816,6 +816,9 @@ def start_browser_auth(provider: str, *, fresh: bool = False) -> str:
             ensure_chromium_executable(on_progress=_on_chromium_progress)
 
             creds = run_browser_auth(provider, session)
+            if session.is_cancelled():
+                # Cancel raced a successful extract: never persist credentials.
+                return
             if not creds:
                 # Window closed without a completed sign-in. Reset to a clean,
                 # current state so the chip never keeps a stale error from a
@@ -838,11 +841,15 @@ def start_browser_auth(provider: str, *, fresh: bool = False) -> str:
                 # up to ~50s, so an immediate WL Xbox run collides and Chrome
                 # exits with "profile in use" (code 21). Trust the headed
                 # sign-in and do NOT launch a competing background browser.
+                if session.is_cancelled():
+                    return
                 mark_connected(provider, creds)
                 session.emit("extracted", {"status": "connected"})
                 return
 
             probe_err = probe_browser_session(provider, creds)
+            if session.is_cancelled():
+                return
             if probe_err:
                 mark_invalid(provider, error=probe_err)
                 session.emit("error", {"message": probe_err})
@@ -850,6 +857,8 @@ def start_browser_auth(provider: str, *, fresh: bool = False) -> str:
                 mark_connected(provider, creds)
                 session.emit("extracted", {"status": "connected"})
         except Exception as exc:  # noqa: BLE001
+            if session.is_cancelled():
+                return
             # Unexpected failure: clear stale state with a current message.
             mark_invalid(provider, error=f"Sign-in did not complete: {exc}")
             session.emit("error", {"message": str(exc)})

--- a/tests/test_auth_manager_profile.py
+++ b/tests/test_auth_manager_profile.py
@@ -173,6 +173,50 @@ def test_cancel_browser_auth_finishes_session(
     release.set()
 
 
+def test_cancel_after_extract_does_not_mark_connected(
+    profile_env: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Late cancel must not persist credentials even if extract already returned."""
+    started = threading.Event()
+    connected: list[str] = []
+    done = threading.Event()
+
+    def extract_then_wait(_provider: str, session: object) -> dict[str, str]:
+        started.set()
+        deadline = time.time() + 3.0
+        while time.time() < deadline:
+            if getattr(session, "is_cancelled", lambda: False)():
+                break
+            time.sleep(0.02)
+        return {"token": "should-not-persist"}
+
+    monkeypatch.setattr(auth_manager, "run_browser_auth", extract_then_wait)
+    monkeypatch.setattr(
+        auth_manager, "mark_connected", lambda p, _c: connected.append(p)
+    )
+    monkeypatch.setattr(auth_manager, "mark_invalid", lambda _p, error=None: None)
+
+    real_finish = None
+
+    def _track_finish(self: object) -> None:
+        assert real_finish is not None
+        real_finish(self)
+        done.set()
+
+    from auth.runner import AuthSession
+
+    real_finish = AuthSession.finish
+    monkeypatch.setattr(AuthSession, "finish", _track_finish)
+
+    auth_manager.start_browser_auth("epic")
+    assert started.wait(timeout=3.0)
+    assert auth_manager.cancel_browser_auth("epic") is True
+    assert done.wait(timeout=3.0)
+    # Give the worker a beat past the cancelled return path.
+    time.sleep(0.1)
+    assert connected == []
+
+
 def test_stale_session_taken_over_by_plain_connect(
     profile_env: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_connect_loop.py
+++ b/tests/test_connect_loop.py
@@ -66,3 +66,24 @@ def test_run_connect_poll_raises_on_deadline(monkeypatch: pytest.MonkeyPatch) ->
             check=lambda: None,
             timeout_message="no session",
         )
+
+
+def test_run_connect_poll_aborts_when_session_cancelled(monkeypatch: pytest.MonkeyPatch) -> None:
+    from auth.cdp_browser import ConnectBrowserClosed
+    from auth.runner import AuthSession
+
+    clock = _FakeTime(step_s=1.0)
+    monkeypatch.setattr("auth.connect_loop.time", clock)
+    monkeypatch.setattr("auth.connect_loop.abort_if_browser_closed", lambda _ctx: None)
+    session = AuthSession("cancel-poll", "epic")
+    session.cancel()
+
+    with pytest.raises(ConnectBrowserClosed):
+        run_connect_poll(
+            context=_FakeContext(),
+            session=session,
+            deadline=clock.time() + 60,
+            poll_sec=0.1,
+            check=lambda: {"TOKEN": "should-not-win"},
+            timeout_message="timed out",
+        )


### PR DESCRIPTION
## Summary
- Shared `run_connect_poll` aborts when the auth session is cancelled (covers providers that never called `abort_if_cancelled`).
- Auth worker skips `mark_connected` / error side effects after Cancel, even if extract already returned.

## Test plan
- [x] `pytest tests/test_connect_loop.py tests/test_auth_manager_profile.py`
- [ ] Manual: start Connect, Cancel mid-window, confirm no connected chip / no secrets.bin write for that provider

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cancelled browser authentication sessions now stop polling immediately.
  * Cancelled sessions no longer save credentials or mark authentication as connected or invalid.
  * Improved handling of cancellation during and after browser authentication checks.

* **Tests**
  * Added coverage for cancellation during credential extraction and connection polling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->