### PR TITLE
Restore outer request-profile pin after mirror import

### DIFF
--- a/shared/cloud_mirror.py
+++ b/shared/cloud_mirror.py
@@ -850,11 +850,12 @@ def import_remote_mirror_to_profile(
             backups[path] = None
     imported: list[str] = []
     personal_saved = False
-    from shared.profile_paths import clear_request_profile_id, set_request_profile_id
+    from shared.profile_paths import reset_request_profile_id, set_request_profile_id
 
     # Pin active profile for the write phase so a concurrent profile switch cannot
     # divert save_personal_doc() (no profile_id arg) into another profile root.
-    set_request_profile_id(pid)
+    # Reset the ContextVar token so any outer request pin is restored.
+    pin_token = set_request_profile_id(pid)
     try:
         catalogs: dict[str, Any] = {}
         for rel, doc in staged.items():
@@ -880,7 +881,7 @@ def import_remote_mirror_to_profile(
                 pass
         raise
     finally:
-        clear_request_profile_id()
+        reset_request_profile_id(pin_token)
     seen: set[str] = set()
     ordered: list[str] = []
     for name in imported:

--- a/shared/profile_paths.py
+++ b/shared/profile_paths.py
@@ -22,13 +22,22 @@ _request_profile_id: contextvars.ContextVar[str | None] = contextvars.ContextVar
 )
 
 
-def set_request_profile_id(profile_id: str | None) -> None:
-    """Pin active profile for the current HTTP request (Supabase auth)."""
-    _request_profile_id.set(profile_id)
+def set_request_profile_id(profile_id: str | None) -> contextvars.Token[str | None]:
+    """Pin active profile for the current HTTP request (Supabase auth).
+
+    Returns the ``ContextVar`` token so callers can ``token.reset()`` and restore
+    any prior pin instead of unconditionally clearing to ``None``.
+    """
+    return _request_profile_id.set(profile_id)
 
 
 def clear_request_profile_id() -> None:
     _request_profile_id.set(None)
+
+
+def reset_request_profile_id(token: contextvars.Token[str | None]) -> None:
+    """Restore the pin that was active before ``set_request_profile_id``."""
+    _request_profile_id.reset(token)
 
 
 # Bound at import; shared.install_paths.data_root() runs legacy migration on first call.

--- a/tests/test_cloud_mirror.py
+++ b/tests/test_cloud_mirror.py
@@ -572,5 +572,46 @@ def test_import_pins_request_profile_across_index_switch(
     assert default_personal["personal"]["steam:imported"]["status"] == "playing"
     assert "steam:imported" not in other_personal.get("personal", {})
     assert other_personal["personal"]["steam:keep"]["status"] == "backlog"
-    # Pin must be cleared after import.
+    # No outer pin: reset restores the ContextVar default (None).
     assert profile_paths._request_profile_id.get() is None
+
+
+def test_import_restores_outer_request_profile_pin(
+    profile_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Import must not wipe a caller-owned request profile pin on exit."""
+    monkeypatch.setattr(
+        "shared.supabase_auth.verify_bearer_user",
+        lambda *_a, **_k: {"id": "u", "email": "a@b.c"},
+    )
+    monkeypatch.setattr(
+        cloud_mirror,
+        "list_remote_mirror_artifacts",
+        lambda **_: [{"path": "data/personal.json"}],
+    )
+    monkeypatch.setattr(
+        cloud_mirror,
+        "download_remote_mirror_artifact",
+        lambda **_: json.dumps(
+            {
+                "personal": {"steam:imported": {"status": "playing"}},
+                "prefs": {},
+                "manual": [],
+                "libraryFirstSeen": {},
+                "schema_version": 1,
+            }
+        ).encode(),
+    )
+    monkeypatch.setattr("shared.server_personal._rebind_after_save", lambda: None)
+
+    outer = profile_paths.set_request_profile_id("outer-caller-pin")
+    try:
+        result = import_remote_mirror_to_profile(
+            authorization="Bearer x",
+            source_profile_id="default",
+            include_personal=True,
+        )
+        assert result.get("personal") is True
+        assert profile_paths._request_profile_id.get() == "outer-caller-pin"
+    finally:
+        profile_paths.reset_request_profile_id(outer)


### PR DESCRIPTION
## Summary
- Addresses CodeRabbit on #290: `import_remote_mirror_to_profile` now resets the `ContextVar` token so an outer request pin is restored instead of clearing to `None`.
- `set_request_profile_id` returns the token; add `reset_request_profile_id`.
- Extend regression coverage for an existing outer pin.

## Test plan
- [x] `pytest tests/test_cloud_mirror.py::test_import_pins_request_profile_across_index_switch`
- [x] `pytest tests/test_cloud_mirror.py::test_import_restores_outer_request_profile_pin`

Made with [Cursor](https://cursor.com)